### PR TITLE
feat: 調整職業技能傷害倍率

### DIFF
--- a/app/src/model/application/RPGCharacter.js
+++ b/app/src/model/application/RPGCharacter.js
@@ -184,7 +184,7 @@ class Swordman extends Adventurer {
       name: "震地斬擊",
       description: "敵に1.5倍のダメージを与える",
       cost: 15,
-      rate: 1.5,
+      rate: 1.8,
     };
   }
 
@@ -209,8 +209,8 @@ class Mage extends Adventurer {
       name: "元素之力",
       description: "敵に1.1倍のダメージを与える。クリティカル時は2倍",
       cost: 8,
-      rate: 0.8,
-      criticalRate: 20,
+      rate: 0.85,
+      criticalRate: 25,
       criticalConfig: [
         makeCriticalConfig(1.5, 2, 70),
         makeCriticalConfig(2, 3, 20),
@@ -248,7 +248,12 @@ class Thief extends Adventurer {
       cost: 12,
       rate: 1.2,
       criticalRate: 40,
-      criticalConfig: [makeCriticalConfig(1.5, 2, 80), makeCriticalConfig(2, 3, 20)],
+      criticalConfig: [
+        makeCriticalConfig(0.8, 1.2, 5),
+        makeCriticalConfig(1.2, 1.5, 45),
+        makeCriticalConfig(1.5, 2, 40),
+        makeCriticalConfig(2, 3, 10),
+      ],
     };
   }
 


### PR DESCRIPTION
調整了劍士、法師和盜賊的技能傷害倍率，以提升遊戲平衡性和戰鬥體驗。

- 劍士的技能「震地斬擊」傷害倍率從 1.5 調整為 1.8。
- 法師的技能「元素之力」傷害倍率從 0.8 調整為 0.85，並將致命一擊倍率從 20% 調整為 25%。
- 盜賊的技能「暗殺」的致命一擊倍率調整如下：
  - 5% 的機率造成 1.2 倍傷害
  - 45% 的機率造成 1.5 倍傷害
  - 40% 的機率造成 2 倍傷害
  - 10% 的機率造成 3 倍傷害