### PR TITLE
fix(race): enforce 10-min advance interval

### DIFF
--- a/app/src/service/RaceService.js
+++ b/app/src/service/RaceService.js
@@ -183,7 +183,7 @@ exports.advanceRound = async function (raceId) {
       );
     }
 
-    await trx("race").where("id", raceId).update({ round: newRound });
+    await trx("race").where("id", raceId).update({ round: newRound, updated_at: new Date() });
 
     // Check for winner — tiebreak: stamina (desc) → lane (asc)
     const finishers = updates.filter(u => u.position >= raceConfig.trackLength);


### PR DESCRIPTION
## Summary
- `advanceRound` 只更新 `round` 沒有更新 `updated_at`，而 Knex 的 `timestamps()` 不會加 MySQL `ON UPDATE CURRENT_TIMESTAMP`
- 導致 `getNeedAdvance` 的時間檢查在比賽開始 10 分鐘後永遠為 true，每分鐘都推進一回合
- 修復：在 update 時一併寫入 `updated_at: new Date()`

## Test plan
- [ ] 開一場新賽跑，確認回合推進間隔恢復為 10 分鐘
- [ ] 確認比賽結束結算正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)