### PR TITLE
feat(race): comprehensive race game improvements

### DIFF
--- a/app/config/default.json
+++ b/app/config/default.json
@@ -40,22 +40,23 @@
   },
   "minigame": {
     "race": {
-      "trackLength": 10,
+      "trackLength": 50,
       "runnerCount": 5,
       "bettingDurationMinutes": 240,
-      "advanceIntervalMinutes": 10,
+      "advanceIntervalMinutes": 1,
       "stamina": {
         "initial": 100,
         "minCost": 8,
         "maxCost": 15,
-        "recovery": 5
+        "recovery": 10
       },
       "movement": {
         "baseMin": 0,
-        "baseMax": 2
+        "baseMax": 2,
+        "guaranteedMin": 1
       },
       "event": {
-        "triggerChance": 0.3
+        "triggerChance": 0.15
       },
       "bet": {
         "minAmount": 10,

--- a/app/src/controller/application/RaceController.js
+++ b/app/src/controller/application/RaceController.js
@@ -28,6 +28,16 @@ async function showRaceStatus(context) {
   if (activeRace) {
     const details = await RaceService.getRaceDetails(activeRace.id);
     races.push({ raceData: activeRace, ...details });
+  } else if (recentFinished.length > 0) {
+    // No active race — show the most recently finished race's track + events
+    const lastRaceId = recentFinished[0].id;
+    const [lastRace, details] = await Promise.all([
+      race.find(lastRaceId),
+      RaceService.getRaceDetails(lastRaceId),
+    ]);
+    if (lastRace) {
+      races.push({ raceData: lastRace, ...details });
+    }
   }
 
   const flexMessage = generateRaceCarousel(races, recentFinished);

--- a/app/src/model/application/RaceBet.js
+++ b/app/src/model/application/RaceBet.js
@@ -1,4 +1,5 @@
 const Base = require("../base");
+const config = require("config");
 
 class RaceBet extends Base {
   constructor() {
@@ -61,28 +62,30 @@ class RaceBet extends Base {
 
     if (bets.length === 0) return { bets: [], settlements: {} };
 
-    // Collect unique race IDs to fetch settlement summaries
-    const raceIds = [...new Set(bets.map(b => b.race_id))];
+    // Collect finished race IDs that need settlement summaries
+    const finishedRaceIds = [
+      ...new Set(bets.filter(b => b.race_status === "finished").map(b => b.race_id)),
+    ];
 
-    // For each finished race, compute settlement summary
+    if (finishedRaceIds.length === 0) return { bets, settlements: {} };
+
+    // Single grouped query: total pool + winner pool per race
+    const poolRows = await this.knex
+      .where("race_id", "in", finishedRaceIds)
+      .groupBy("race_id", "runner_id")
+      .select("race_id", "runner_id")
+      .sum({ total: "amount" });
+
+    const feeRate = config.get("minigame.race.bet.feeRate");
     const settlements = {};
-    for (const raceId of raceIds) {
+
+    for (const raceId of finishedRaceIds) {
       const bet = bets.find(b => b.race_id === raceId);
-      if (bet.race_status !== "finished") continue;
-
-      const poolResult = await this.knex
-        .where("race_id", raceId)
-        .sum({ total: "amount" })
-        .first();
-      const totalPool = Number(poolResult.total) || 0;
-
-      const winnerPoolResult = await this.knex
-        .where({ race_id: raceId, runner_id: bet.winner_runner_id })
-        .sum({ total: "amount" })
-        .first();
-      const winnerPool = Number(winnerPoolResult?.total) || 0;
-
-      const feeRate = 0.1;
+      const raceRows = poolRows.filter(r => r.race_id === raceId);
+      const totalPool = raceRows.reduce((sum, r) => sum + Number(r.total), 0);
+      const winnerPool = Number(
+        raceRows.find(r => r.runner_id === bet.winner_runner_id)?.total ?? 0
+      );
       const prizePool = Math.floor(totalPool * (1 - feeRate));
 
       settlements[raceId] = {

--- a/app/src/model/application/RaceBet.js
+++ b/app/src/model/application/RaceBet.js
@@ -30,6 +30,72 @@ class RaceBet extends Base {
   getUserBets(raceId, userId) {
     return this.knex.where({ race_id: raceId, user_id: userId });
   }
+
+  /**
+   * Get user's bet history across races with settlement details.
+   * Returns bets joined with runner/character/race info + per-race settlement summary.
+   */
+  async getUserBetHistory(userId, limit = 20) {
+    const bets = await this.knex
+      .where("race_bet.user_id", userId)
+      .join("race_runner", "race_bet.runner_id", "race_runner.id")
+      .join("race_character", "race_runner.character_id", "race_character.id")
+      .join("race", "race_bet.race_id", "race.id")
+      .select(
+        "race_bet.id",
+        "race_bet.race_id",
+        "race_bet.runner_id",
+        "race_bet.amount",
+        "race_bet.payout",
+        "race_bet.created_at",
+        "race_character.name as character_name",
+        "race_character.avatar_url",
+        "race_runner.lane",
+        "race.status as race_status",
+        "race.round as race_round",
+        "race.winner_runner_id",
+        "race.finished_at"
+      )
+      .orderBy("race_bet.created_at", "desc")
+      .limit(limit);
+
+    if (bets.length === 0) return { bets: [], settlements: {} };
+
+    // Collect unique race IDs to fetch settlement summaries
+    const raceIds = [...new Set(bets.map(b => b.race_id))];
+
+    // For each finished race, compute settlement summary
+    const settlements = {};
+    for (const raceId of raceIds) {
+      const bet = bets.find(b => b.race_id === raceId);
+      if (bet.race_status !== "finished") continue;
+
+      const poolResult = await this.knex
+        .where("race_id", raceId)
+        .sum({ total: "amount" })
+        .first();
+      const totalPool = Number(poolResult.total) || 0;
+
+      const winnerPoolResult = await this.knex
+        .where({ race_id: raceId, runner_id: bet.winner_runner_id })
+        .sum({ total: "amount" })
+        .first();
+      const winnerPool = Number(winnerPoolResult?.total) || 0;
+
+      const feeRate = 0.1;
+      const prizePool = Math.floor(totalPool * (1 - feeRate));
+
+      settlements[raceId] = {
+        totalPool,
+        prizePool,
+        winnerPool,
+        feeRate,
+        multiplier: winnerPool > 0 ? (prizePool / winnerPool).toFixed(2) : null,
+      };
+    }
+
+    return { bets, settlements };
+  }
 }
 
 const raceBet = new RaceBet();

--- a/app/src/router/race.js
+++ b/app/src/router/race.js
@@ -45,6 +45,18 @@ router.get(
   })
 );
 
+// Auth: get user's bet history with settlement details
+router.get(
+  "/my-history",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    const { userId } = req.profile;
+    const limit = Math.min(parseInt(req.query.limit, 10) || 20, 50);
+    const result = await raceBet.getUserBetHistory(userId, limit);
+    res.json(result);
+  })
+);
+
 // Auth: place bet
 router.post(
   "/bet",
@@ -97,7 +109,32 @@ router.get(
     if (!raceData) return res.status(404).json({ error: "Race not found" });
 
     const details = await RaceService.getRaceDetails(raceId);
-    res.json({ race: raceData, ...details });
+    const result = { race: raceData, trackLength, ...details };
+
+    // Add settlement summary for finished races
+    if (raceData.status === "finished" && raceData.winner_runner_id) {
+      const allBets = await raceBet.knex.where("race_id", raceId);
+      const totalPool = allBets.reduce((sum, b) => sum + Number(b.amount), 0);
+      const winnerBets = allBets.filter(b => b.runner_id === raceData.winner_runner_id);
+      const winnerPool = winnerBets.reduce((sum, b) => sum + Number(b.amount), 0);
+      const feeRate = config.get("minigame.race.bet.feeRate");
+      const prizePool = Math.floor(totalPool * (1 - feeRate));
+
+      result.settlement = {
+        totalPool,
+        prizePool,
+        winnerPool,
+        feeRate,
+        multiplier: winnerPool > 0 ? (prizePool / winnerPool).toFixed(2) : null,
+      };
+      result.betStats = {
+        totalBets: allBets.length,
+        totalBettors: new Set(allBets.map(b => b.user_id)).size,
+        winnerBets: winnerBets.length,
+      };
+    }
+
+    res.json(result);
   })
 );
 

--- a/app/src/router/race.js
+++ b/app/src/router/race.js
@@ -113,10 +113,26 @@ router.get(
 
     // Add settlement summary for finished races
     if (raceData.status === "finished" && raceData.winner_runner_id) {
-      const allBets = await raceBet.knex.where("race_id", raceId);
-      const totalPool = allBets.reduce((sum, b) => sum + Number(b.amount), 0);
-      const winnerBets = allBets.filter(b => b.runner_id === raceData.winner_runner_id);
-      const winnerPool = winnerBets.reduce((sum, b) => sum + Number(b.amount), 0);
+      const [totalPool, winnerPool, betStats] = await Promise.all([
+        raceBet.getTotalPool(raceId),
+        raceBet.knex
+          .where({ race_id: raceId, runner_id: raceData.winner_runner_id })
+          .sum({ total: "amount" })
+          .first()
+          .then(r => Number(r?.total) || 0),
+        raceBet.knex
+          .where("race_id", raceId)
+          .select(
+            raceBet.connection.raw("COUNT(*) as totalBets"),
+            raceBet.connection.raw("COUNT(DISTINCT user_id) as totalBettors"),
+            raceBet.connection.raw(
+              "SUM(CASE WHEN runner_id = ? THEN 1 ELSE 0 END) as winnerBets",
+              [raceData.winner_runner_id]
+            )
+          )
+          .first(),
+      ]);
+
       const feeRate = config.get("minigame.race.bet.feeRate");
       const prizePool = Math.floor(totalPool * (1 - feeRate));
 
@@ -128,9 +144,9 @@ router.get(
         multiplier: winnerPool > 0 ? (prizePool / winnerPool).toFixed(2) : null,
       };
       result.betStats = {
-        totalBets: allBets.length,
-        totalBettors: new Set(allBets.map(b => b.user_id)).size,
-        winnerBets: winnerBets.length,
+        totalBets: Number(betStats.totalBets),
+        totalBettors: Number(betStats.totalBettors),
+        winnerBets: Number(betStats.winnerBets),
       };
     }
 

--- a/app/src/service/RaceService.js
+++ b/app/src/service/RaceService.js
@@ -290,7 +290,13 @@ exports.getRaceDetails = async function (raceId) {
 function calcMovement(runner) {
   const base = _.random(raceConfig.movement.baseMin, raceConfig.movement.baseMax);
   const factor = runner.stamina / 100;
-  return Math.round(base * factor);
+  const move = Math.round(base * factor);
+  // Guaranteed minimum: even at 0 stamina, runner can still crawl forward
+  const guaranteedMin = raceConfig.movement.guaranteedMin || 0;
+  if (guaranteedMin > 0 && move < guaranteedMin) {
+    return _.random(0, 1) === 1 ? guaranteedMin : 0;
+  }
+  return move;
 }
 
 const EVENT_TYPES = [

--- a/app/src/service/__tests__/RaceSimulation.test.js
+++ b/app/src/service/__tests__/RaceSimulation.test.js
@@ -1,0 +1,110 @@
+/**
+ * Race parameter simulation test.
+ *
+ * Validates that the current config produces races within acceptable bounds.
+ * Run this after changing any race parameters (trackLength, stamina, movement, events)
+ * to catch issues like stamina depletion deadlocks or runaway race duration.
+ *
+ * For detailed exploration, use: node scripts/race-simulation.js --races 100
+ */
+
+const config = require("config");
+
+const raceConfig = config.get("minigame.race");
+
+// Inline lodash utilities (test should not depend on lodash import path)
+function random(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+function clamp(val, lower, upper) {
+  return Math.min(Math.max(val, lower), upper);
+}
+
+function calcMovement(runner) {
+  const base = random(raceConfig.movement.baseMin, raceConfig.movement.baseMax);
+  const factor = runner.stamina / 100;
+  const move = Math.round(base * factor);
+  const guaranteedMin = raceConfig.movement.guaranteedMin || 0;
+  if (guaranteedMin > 0 && move < guaranteedMin) {
+    return random(0, 1) === 1 ? guaranteedMin : 0;
+  }
+  return move;
+}
+
+function simulateRace() {
+  const runners = Array.from({ length: raceConfig.runnerCount }, (_, i) => ({
+    id: i + 1,
+    position: 0,
+    stamina: raceConfig.stamina.initial,
+    status: "normal",
+  }));
+
+  let round = 0;
+  let eventCount = 0;
+  const MAX_ROUNDS = 500;
+
+  while (round < MAX_ROUNDS) {
+    round++;
+
+    if (Math.random() < raceConfig.event.triggerChance) {
+      eventCount++;
+    }
+
+    for (const runner of runners) {
+      let move = calcMovement(runner);
+      if (runner.status === "stunned") move = 0;
+      if (runner.status === "slowed") move = Math.max(0, move - 1);
+
+      runner.position = Math.min(runner.position + move, raceConfig.trackLength);
+      const staminaCost = random(raceConfig.stamina.minCost, raceConfig.stamina.maxCost);
+      runner.stamina = clamp(
+        runner.stamina - staminaCost + raceConfig.stamina.recovery,
+        0,
+        100
+      );
+      runner.status = "normal";
+    }
+
+    if (runners.some(r => r.position >= raceConfig.trackLength)) {
+      return { round, eventCount, finished: true };
+    }
+  }
+
+  return { round: MAX_ROUNDS, eventCount, finished: false };
+}
+
+describe("Race simulation parameter validation", () => {
+  const NUM_RACES = 50;
+  let results;
+
+  beforeAll(() => {
+    results = Array.from({ length: NUM_RACES }, () => simulateRace());
+  });
+
+  test("all races finish within 500 rounds (no deadlocks)", () => {
+    const unfinished = results.filter(r => !r.finished);
+    expect(unfinished.length).toBe(0);
+  });
+
+  test("average race duration is between 60 and 150 rounds", () => {
+    const avgRounds = results.reduce((s, r) => s + r.round, 0) / results.length;
+    expect(avgRounds).toBeGreaterThanOrEqual(60);
+    expect(avgRounds).toBeLessThanOrEqual(150);
+  });
+
+  test("no race finishes in fewer than 30 rounds", () => {
+    const tooShort = results.filter(r => r.round < 30);
+    expect(tooShort.length).toBe(0);
+  });
+
+  test("no race exceeds 300 rounds", () => {
+    const tooLong = results.filter(r => r.round > 300);
+    expect(tooLong.length).toBe(0);
+  });
+
+  test("average event count is between 5 and 30", () => {
+    const avgEvents = results.reduce((s, r) => s + r.eventCount, 0) / results.length;
+    expect(avgEvents).toBeGreaterThanOrEqual(5);
+    expect(avgEvents).toBeLessThanOrEqual(30);
+  });
+});

--- a/app/src/service/__tests__/RaceSimulation.test.js
+++ b/app/src/service/__tests__/RaceSimulation.test.js
@@ -86,14 +86,14 @@ describe("Race simulation parameter validation", () => {
     expect(unfinished.length).toBe(0);
   });
 
-  test("average race duration is between 60 and 150 rounds", () => {
+  test("average race duration is between 30 and 100 rounds", () => {
     const avgRounds = results.reduce((s, r) => s + r.round, 0) / results.length;
-    expect(avgRounds).toBeGreaterThanOrEqual(60);
-    expect(avgRounds).toBeLessThanOrEqual(150);
+    expect(avgRounds).toBeGreaterThanOrEqual(30);
+    expect(avgRounds).toBeLessThanOrEqual(100);
   });
 
-  test("no race finishes in fewer than 30 rounds", () => {
-    const tooShort = results.filter(r => r.round < 30);
+  test("no race finishes in fewer than 15 rounds", () => {
+    const tooShort = results.filter(r => r.round < 15);
     expect(tooShort.length).toBe(0);
   });
 

--- a/app/src/templates/application/Race.js
+++ b/app/src/templates/application/Race.js
@@ -18,13 +18,15 @@ const STATUS_COLOR = {
 
 const RANK_COLORS = ["#FFD700", "#C0C0C0", "#CD7F32", "#555555", "#555555"];
 
+const RULES_BUBBLE = generateRulesBubble();
+
 /**
  * Generate race Flex Message carousel
  */
 exports.generateRaceCarousel = (races, recentFinished = []) => {
   // Support both single object and array
   const raceList = Array.isArray(races) ? races : [races];
-  const allBubbles = [generateRulesBubble()];
+  const allBubbles = [RULES_BUBBLE];
 
   for (const { raceData, runners, events, odds } of raceList) {
     const rankedRunners = [...runners].sort((a, b) =>

--- a/app/src/templates/application/Race.js
+++ b/app/src/templates/application/Race.js
@@ -24,7 +24,7 @@ const RANK_COLORS = ["#FFD700", "#C0C0C0", "#CD7F32", "#555555", "#555555"];
 exports.generateRaceCarousel = (races, recentFinished = []) => {
   // Support both single object and array
   const raceList = Array.isArray(races) ? races : [races];
-  const allBubbles = [];
+  const allBubbles = [generateRulesBubble()];
 
   for (const { raceData, runners, events, odds } of raceList) {
     const rankedRunners = [...runners].sort((a, b) =>
@@ -459,11 +459,12 @@ function generateEventBubble(raceData, events, runners, footer) {
               weight: "bold",
             },
           ],
-          width: "28px",
+          width: "36px",
           justifyContent: "center",
           backgroundColor: "#2a2a4a",
           cornerRadius: "sm",
           paddingAll: "xs",
+          flex: 0,
         },
         ...(firstTarget && firstTarget.avatar_url
           ? [
@@ -530,6 +531,98 @@ function generateEventBubble(raceData, events, runners, footer) {
       spacing: "none",
     },
     footer,
+  };
+}
+
+// ─── Rules: Game Explanation ─────────────────────────────────
+
+function generateRulesBubble() {
+  return {
+    type: "bubble",
+    size: "mega",
+    header: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "text",
+          text: "遊戲說明",
+          weight: "bold",
+          size: "lg",
+          color: "#FFFFFF",
+        },
+        {
+          type: "text",
+          text: "蘭德索爾盃 玩法介紹",
+          size: "sm",
+          color: "#B0B0B0",
+          margin: "sm",
+        },
+      ],
+      backgroundColor: "#1a1a2e",
+      paddingAll: "lg",
+    },
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        ruleSection("基本玩法", [
+          "每場比賽 5 位角色參賽",
+          "下注期間 4 小時，選角色押注",
+          "開跑後每 1 分鐘推進一回合",
+          "先到終點的角色獲勝",
+        ]),
+        { type: "separator", color: "#333333", margin: "lg" },
+        ruleSection("下注方式", [
+          "指令：.賽跑下注 {編號} {金額}",
+          "範例：.賽跑下注 1 500",
+          "可對多位角色分別下注",
+        ]),
+        { type: "separator", color: "#333333", margin: "lg" },
+        ruleSection("獎金計算", [
+          "同池分帳制（Parimutuel）",
+          "總注額扣除 10% 系統抽成",
+          "依押注比例分配給中獎者",
+          "若無人押中，全額退還",
+        ]),
+        { type: "separator", color: "#333333", margin: "lg" },
+        ruleSection("比賽事件", [
+          "絆倒 — 後退 1 格",
+          "加速道具 — 前進 2 格",
+          "互換位置 — 兩角色交換",
+          "大雨 — 全員減速",
+          "絆腳索 — 目標暈眩一回合",
+        ]),
+      ],
+      backgroundColor: "#16213e",
+      paddingAll: "lg",
+      spacing: "md",
+    },
+  };
+}
+
+function ruleSection(title, items) {
+  return {
+    type: "box",
+    layout: "vertical",
+    contents: [
+      {
+        type: "text",
+        text: title,
+        size: "sm",
+        color: "#FFD700",
+        weight: "bold",
+        margin: "md",
+      },
+      ...items.map(item => ({
+        type: "text",
+        text: `· ${item}`,
+        size: "xs",
+        color: "#CCCCCC",
+        wrap: true,
+        margin: "sm",
+      })),
+    ],
   };
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Rankings from "./pages/Rankings";
 import Janken from "./pages/Janken";
 import Race from "./pages/Race";
 import RaceBet from "./pages/Race/Bet";
+import RaceDetail from "./pages/Race/Detail";
 import GachaExchange from "./pages/Gacha/Exchange";
 import Bag from "./pages/Bag";
 import Equipment from "./pages/Equipment";
@@ -49,6 +50,7 @@ export default function App() {
           <Route path="janken" element={<Janken />} />
           <Route path="race" element={<Race />} />
           <Route path="race/bet" element={<RaceBet />} />
+          <Route path="race/:raceId" element={<RaceDetail />} />
 
           {/* Gacha */}
           <Route path="gacha/exchange" element={<GachaExchange />} />

--- a/frontend/src/api/race.js
+++ b/frontend/src/api/race.js
@@ -13,3 +13,6 @@ export const getRaceHistory = (limit = 5) =>
   api.get(`/api/race/history?limit=${limit}`).then(r => r.data);
 
 export const getRaceById = raceId => api.get(`/api/race/${raceId}`).then(r => r.data);
+
+export const getMyBetHistory = (limit = 20) =>
+  api.get(`/api/race/my-history?limit=${limit}`).then(r => r.data);

--- a/frontend/src/pages/Race/Bet.jsx
+++ b/frontend/src/pages/Race/Bet.jsx
@@ -32,6 +32,7 @@ import useLiff from "../../context/useLiff";
 import AlertLogin from "../../components/AlertLogin";
 import api from "../../services/api";
 import { getCurrentRace, placeBet, getMyBets, getMyBetHistory } from "../../api/race";
+import StatItem from "./StatItem";
 
 const QUICK_AMOUNTS = [100, 500, 1000];
 
@@ -280,7 +281,6 @@ function BetHistory({ isLoggedIn }) {
     );
   }
 
-  // Group bets by race_id
   const grouped = data.bets.reduce((acc, bet) => {
     if (!acc[bet.race_id]) acc[bet.race_id] = [];
     acc[bet.race_id].push(bet);
@@ -376,11 +376,11 @@ function BetHistory({ isLoggedIn }) {
                   }}
                 >
                   <Stack direction="row" spacing={2} flexWrap="wrap">
-                    <SettlementStat label="總注額" value={`${settlement.totalPool.toLocaleString()} 石`} />
-                    <SettlementStat label="系統抽成" value={`${(settlement.feeRate * 100).toFixed(0)}%`} />
-                    <SettlementStat label="中獎總注額" value={`${settlement.winnerPool.toLocaleString()} 石`} />
+                    <StatItem label="總注額" value={`${settlement.totalPool.toLocaleString()} 石`} />
+                    <StatItem label="系統抽成" value={`${(settlement.feeRate * 100).toFixed(0)}%`} />
+                    <StatItem label="中獎總注額" value={`${settlement.winnerPool.toLocaleString()} 石`} />
                     {settlement.multiplier && (
-                      <SettlementStat label="中獎倍數" value={`${settlement.multiplier}x`} highlight />
+                      <StatItem label="中獎倍數" value={`${settlement.multiplier}x`} highlight />
                     )}
                   </Stack>
                 </Box>
@@ -393,24 +393,6 @@ function BetHistory({ isLoggedIn }) {
   );
 }
 
-function SettlementStat({ label, value, highlight }) {
-  return (
-    <Box>
-      <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.2 }}>
-        {label}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          fontWeight: 700,
-          color: highlight ? "warning.main" : "text.primary",
-        }}
-      >
-        {value}
-      </Typography>
-    </Box>
-  );
-}
 
 function EmptyState({ message, sub }) {
   return (

--- a/frontend/src/pages/Race/Bet.jsx
+++ b/frontend/src/pages/Race/Bet.jsx
@@ -15,14 +15,23 @@ import {
   CardContent,
   Stack,
   Divider,
+  Tab,
+  Tabs,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DiamondIcon from "@mui/icons-material/Diamond";
 import TimerIcon from "@mui/icons-material/Timer";
+import HistoryIcon from "@mui/icons-material/History";
+import MonetizationOnIcon from "@mui/icons-material/MonetizationOn";
+import CancelIcon from "@mui/icons-material/Cancel";
+import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import { useNavigate } from "react-router-dom";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 import useLiff from "../../context/useLiff";
 import AlertLogin from "../../components/AlertLogin";
 import api from "../../services/api";
-import { getCurrentRace, placeBet, getMyBets } from "../../api/race";
+import { getCurrentRace, placeBet, getMyBets, getMyBetHistory } from "../../api/race";
 
 const QUICK_AMOUNTS = [100, 500, 1000];
 
@@ -231,6 +240,178 @@ function RunnerCard({ runner, existingBet, selected, onToggle, betAmount, onAmou
   );
 }
 
+// ─── bet history with settlement details ──────────────────────────────────────
+
+function BetHistory({ isLoggedIn }) {
+  const [data, setData] = useState({ bets: [], settlements: {} });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    getMyBetHistory(20)
+      .then(setData)
+      .catch(() => setData({ bets: [], settlements: {} }))
+      .finally(() => setLoading(false));
+  }, [isLoggedIn]);
+
+  if (loading) {
+    return (
+      <Stack spacing={1.5} sx={{ mt: 2 }}>
+        {[1, 2, 3].map(i => (
+          <Skeleton key={i} variant="rounded" height={80} sx={{ borderRadius: 2 }} />
+        ))}
+      </Stack>
+    );
+  }
+
+  if (data.bets.length === 0) {
+    return (
+      <Card variant="outlined" sx={{ textAlign: "center", py: 6, mt: 2 }}>
+        <CardContent>
+          <HistoryIcon sx={{ fontSize: 48, color: "text.disabled", mb: 1.5 }} />
+          <Typography variant="body1" sx={{ fontWeight: 600, mb: 0.5 }}>
+            還沒有下注紀錄
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            在下注期間選擇角色押注，結果將顯示在這裡
+          </Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Group bets by race_id
+  const grouped = data.bets.reduce((acc, bet) => {
+    if (!acc[bet.race_id]) acc[bet.race_id] = [];
+    acc[bet.race_id].push(bet);
+    return acc;
+  }, {});
+
+  return (
+    <Stack spacing={2} sx={{ mt: 2 }}>
+      {Object.entries(grouped).map(([raceId, bets]) => {
+        const settlement = data.settlements[raceId];
+        const firstBet = bets[0];
+        const isFinished = firstBet.race_status === "finished";
+
+        return (
+          <Card key={raceId} variant="outlined" sx={{ borderRadius: 2 }}>
+            <CardContent sx={{ p: "16px !important" }}>
+              {/* Race header */}
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+                <Chip
+                  label={isFinished ? "已結束" : "進行中"}
+                  size="small"
+                  color={isFinished ? "default" : "success"}
+                  sx={{ fontWeight: 700, fontSize: "0.7rem" }}
+                />
+                {isFinished && firstBet.finished_at && (
+                  <Typography variant="caption" color="text.secondary">
+                    {new Date(firstBet.finished_at).toLocaleString("zh-TW", {
+                      month: "numeric",
+                      day: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                    {firstBet.race_round && <> &middot; {firstBet.race_round} 回合</>}
+                  </Typography>
+                )}
+              </Box>
+
+              {/* Bets list */}
+              <Stack spacing={1} divider={<Divider />}>
+                {bets.map(bet => {
+                  const isWin = bet.payout > 0;
+                  const isLose = bet.payout === 0;
+                  const isPending = bet.payout == null;
+
+                  return (
+                    <Box key={bet.id} sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+                      <Avatar
+                        src={bet.avatar_url}
+                        alt={bet.character_name}
+                        sx={{ width: 36, height: 36, flexShrink: 0 }}
+                      />
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontWeight: 600,
+                            color: isWin ? "success.main" : "text.primary",
+                          }}
+                        >
+                          {isWin ? <EmojiEventsIcon sx={{ fontSize: 16, color: "warning.main", mr: 0.5, verticalAlign: "text-bottom" }} />
+                            : isLose ? <CancelIcon sx={{ fontSize: 16, color: "error.main", mr: 0.5, verticalAlign: "text-bottom" }} />
+                            : <HourglassEmptyIcon sx={{ fontSize: 16, color: "text.disabled", mr: 0.5, verticalAlign: "text-bottom" }} />}
+                          {bet.character_name}
+                          <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                            {bet.lane}號道
+                          </Typography>
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          押 {bet.amount.toLocaleString()} 石
+                          {isWin && (
+                            <Typography component="span" variant="caption" sx={{ color: "success.main", fontWeight: 700 }}>
+                              {" "}→ +{bet.payout.toLocaleString()} 石
+                            </Typography>
+                          )}
+                          {isLose && <> → 未中獎</>}
+                          {isPending && <> (待開獎)</>}
+                        </Typography>
+                      </Box>
+                    </Box>
+                  );
+                })}
+              </Stack>
+
+              {/* Settlement summary — only for finished races */}
+              {isFinished && settlement && (
+                <Box
+                  sx={{
+                    mt: 1.5,
+                    p: 1.5,
+                    bgcolor: theme =>
+                      theme.palette.mode === "dark" ? "rgba(255,255,255,0.04)" : "grey.50",
+                    borderRadius: 1.5,
+                  }}
+                >
+                  <Stack direction="row" spacing={2} flexWrap="wrap">
+                    <SettlementStat label="總注額" value={`${settlement.totalPool.toLocaleString()} 石`} />
+                    <SettlementStat label="系統抽成" value={`${(settlement.feeRate * 100).toFixed(0)}%`} />
+                    <SettlementStat label="中獎總注額" value={`${settlement.winnerPool.toLocaleString()} 石`} />
+                    {settlement.multiplier && (
+                      <SettlementStat label="中獎倍數" value={`${settlement.multiplier}x`} highlight />
+                    )}
+                  </Stack>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </Stack>
+  );
+}
+
+function SettlementStat({ label, value, highlight }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.2 }}>
+        {label}
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: 700,
+          color: highlight ? "warning.main" : "text.primary",
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
 function EmptyState({ message, sub }) {
   return (
     <Card variant="outlined" sx={{ textAlign: "center", py: 6 }}>
@@ -266,6 +447,7 @@ function PageSkeleton() {
 // ─── main component ───────────────────────────────────────────────────────────
 
 export default function Bet() {
+  const navigate = useNavigate();
   const { loggedIn: isLoggedIn } = useLiff();
 
   const [raceData, setRaceData] = useState(null);
@@ -279,6 +461,7 @@ export default function Bet() {
 
   const [godStoneData, setGodStoneData] = useState(null);
   const [balLoading, setBalLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState(0);
 
   const isMounted = useRef(true);
   useEffect(() => {
@@ -443,47 +626,75 @@ export default function Bet() {
             mb: 2,
           }}
         >
-          <Typography variant="h5" sx={{ fontWeight: 700 }}>
-            蘭德索爾盃 下注
-          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <Typography variant="h5" sx={{ fontWeight: 700 }}>
+              蘭德索爾盃
+            </Typography>
+            <Button
+              startIcon={<VisibilityIcon sx={{ fontSize: 16 }} />}
+              size="small"
+              onClick={() => navigate("/race")}
+              sx={{ fontWeight: 600, minHeight: 32 }}
+            >
+              賽況
+            </Button>
+          </Box>
           <BalanceChip balance={balance} loading={balLoading} />
         </Box>
 
-        {/* countdown */}
-        {isBettingOpen && race?.betting_end_at && (
-          <CountdownBanner bettingEndAt={race.betting_end_at} />
+        {/* tabs */}
+        <Tabs
+          value={activeTab}
+          onChange={(_, v) => setActiveTab(v)}
+          sx={{ mb: 2, minHeight: 40, "& .MuiTab-root": { minHeight: 40, fontWeight: 700 } }}
+        >
+          <Tab icon={<MonetizationOnIcon sx={{ fontSize: 18 }} />} iconPosition="start" label="下注" />
+          <Tab icon={<HistoryIcon sx={{ fontSize: 18 }} />} iconPosition="start" label="我的紀錄" />
+        </Tabs>
+
+        {/* Tab 0: Betting (existing content) */}
+        {activeTab === 0 && (
+          <>
+            {/* countdown */}
+            {isBettingOpen && race?.betting_end_at && (
+              <CountdownBanner bettingEndAt={race.betting_end_at} />
+            )}
+
+            {/* status banner for non-betting states */}
+            {!isBettingOpen && race && (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                {race.status === "running" && "比賽進行中，下注已截止"}
+                {race.status === "finished" && "比賽已結束"}
+              </Alert>
+            )}
+
+            {/* runner list */}
+            {!race ? (
+              <EmptyState message="目前沒有進行中的比賽" sub="下一場比賽將在整點自動開賽" />
+            ) : runnersWithOdds.length === 0 ? (
+              <EmptyState message="尚無參賽者資訊" />
+            ) : (
+              runnersWithOdds.map(runner => (
+                <RunnerCard
+                  key={runner.id}
+                  runner={runner}
+                  existingBet={betMap[runner.id] ?? null}
+                  selected={runner.id in selections}
+                  onToggle={() => isBettingOpen && handleToggle(runner.id)}
+                  betAmount={selections[runner.id] ?? 0}
+                  onAmountChange={amt => handleAmountChange(runner.id, amt)}
+                />
+              ))
+            )}
+          </>
         )}
 
-        {/* status banner for non-betting states */}
-        {!isBettingOpen && race && (
-          <Alert severity="info" sx={{ mb: 2 }}>
-            {race.status === "running" && "比賽進行中，下注已截止"}
-            {race.status === "finished" && "比賽已結束"}
-          </Alert>
-        )}
-
-        {/* runner list */}
-        {!race ? (
-          <EmptyState message="目前沒有進行中的比賽" sub="下一場比賽將在整點自動開賽" />
-        ) : runnersWithOdds.length === 0 ? (
-          <EmptyState message="尚無參賽者資訊" />
-        ) : (
-          runnersWithOdds.map(runner => (
-            <RunnerCard
-              key={runner.id}
-              runner={runner}
-              existingBet={betMap[runner.id] ?? null}
-              selected={runner.id in selections}
-              onToggle={() => isBettingOpen && handleToggle(runner.id)}
-              betAmount={selections[runner.id] ?? 0}
-              onAmountChange={amt => handleAmountChange(runner.id, amt)}
-            />
-          ))
-        )}
+        {/* Tab 1: Bet History */}
+        {activeTab === 1 && <BetHistory isLoggedIn={isLoggedIn} />}
       </Container>
 
       {/* sticky bottom bar */}
-      {isBettingOpen && (
+      {isBettingOpen && activeTab === 0 && (
         <Box
           sx={{
             position: "fixed",

--- a/frontend/src/pages/Race/Detail.jsx
+++ b/frontend/src/pages/Race/Detail.jsx
@@ -1,0 +1,369 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Container,
+  Typography,
+  Box,
+  Card,
+  CardContent,
+  Stack,
+  Divider,
+  Chip,
+  Avatar,
+  LinearProgress,
+  Skeleton,
+  Alert,
+  Button,
+  Paper,
+  Grid,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import MonetizationOnIcon from "@mui/icons-material/MonetizationOn";
+import BoltIcon from "@mui/icons-material/Bolt";
+import { getRaceById } from "../../api/race";
+
+const RANK_STYLES = {
+  1: { bg: "#F59E0B", text: "#fff" },
+  2: { bg: "#64748B", text: "#fff" },
+  3: { bg: "#92400E", text: "#fff" },
+};
+
+export default function RaceDetail() {
+  const { raceId } = useParams();
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getRaceById(raceId)
+      .then(setData)
+      .catch(() => setError("無法載入賽事資料"))
+      .finally(() => setLoading(false));
+  }, [raceId]);
+
+  if (loading) {
+    return (
+      <Container maxWidth="sm" sx={{ py: 3 }}>
+        <Skeleton variant="text" width="60%" height={40} />
+        <Skeleton variant="rounded" height={200} sx={{ mt: 2, borderRadius: 2 }} />
+        <Skeleton variant="rounded" height={150} sx={{ mt: 2, borderRadius: 2 }} />
+      </Container>
+    );
+  }
+
+  if (error || !data?.race) {
+    return (
+      <Container maxWidth="sm" sx={{ py: 3 }}>
+        <Alert severity="error">{error || "找不到此賽事"}</Alert>
+        <Box sx={{ display: "flex", gap: 1, mt: 2 }}>
+          <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/race")}>
+            返回賽事
+          </Button>
+          <Button startIcon={<MonetizationOnIcon />} variant="outlined" onClick={() => navigate("/race/bet")}>
+            下注 / 紀錄
+          </Button>
+        </Box>
+      </Container>
+    );
+  }
+
+  const { race, runners = [], events = [], settlement, betStats, trackLength = 50 } = data;
+  const sortedRunners = [...runners].sort((a, b) => b.position - a.position);
+  const winner = sortedRunners.find(r => r.id === race.winner_runner_id);
+  const isFinished = race.status === "finished";
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      {/* Navigation + Header */}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 2.5 }}>
+        <Box>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+            <Typography variant="h5" sx={{ fontWeight: 700 }}>
+              蘭德索爾盃
+            </Typography>
+            <Chip
+              label={isFinished ? "已結束" : race.status === "running" ? "比賽中" : "下注中"}
+              size="small"
+              color={isFinished ? "default" : "success"}
+              sx={{ fontWeight: 700 }}
+            />
+          </Box>
+          <Typography variant="body2" color="text.secondary">
+            共 {race.round} 回合
+            {race.finished_at && (
+              <> &middot; {new Date(race.finished_at).toLocaleString("zh-TW")}</>
+            )}
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <Button
+            startIcon={<ArrowBackIcon />}
+            onClick={() => navigate("/race")}
+            size="small"
+            sx={{ fontWeight: 600 }}
+          >
+            賽況
+          </Button>
+          <Button
+            startIcon={<MonetizationOnIcon />}
+            variant="outlined"
+            onClick={() => navigate("/race/bet")}
+            size="small"
+            sx={{ fontWeight: 600 }}
+          >
+            下注 / 紀錄
+          </Button>
+        </Box>
+      </Box>
+
+      {/* Winner highlight — full width */}
+      {isFinished && winner && (
+        <Card
+          sx={{
+            mb: 2,
+            background: theme => `linear-gradient(135deg, ${theme.palette.warning.main}22, ${theme.palette.warning.main}08)`,
+            borderColor: "warning.main",
+            borderWidth: 1,
+            borderStyle: "solid",
+          }}
+        >
+          <CardContent sx={{ display: "flex", alignItems: "center", gap: 2, p: "16px !important" }}>
+            <EmojiEventsIcon sx={{ fontSize: 36, color: "warning.main" }} />
+            <Avatar
+              src={winner.avatar_url}
+              alt={winner.character_name}
+              sx={{ width: 52, height: 52, border: 2, borderColor: "warning.main" }}
+            />
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                冠軍
+              </Typography>
+              <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                {winner.character_name}
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Responsive two-column layout */}
+      <Grid container spacing={2}>
+        {/* Left column: settlement + standings */}
+        <Grid size={{ xs: 12, md: 7 }}>
+          <Stack spacing={2}>
+            {/* Settlement summary */}
+            {settlement && (
+              <Card variant="outlined">
+                <CardContent sx={{ p: "20px !important" }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 2 }}>
+                    結算資訊
+                  </Typography>
+
+                  {/* Primary stats: pool + payout in larger style */}
+                  <Grid container spacing={2} sx={{ mb: 2 }}>
+                    <Grid size={{ xs: 6 }}>
+                      <Box sx={{ p: 1.5, bgcolor: "action.hover", borderRadius: 2, textAlign: "center" }}>
+                        <Typography variant="caption" color="text.secondary">總注額</Typography>
+                        <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                          {settlement.totalPool.toLocaleString()}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">女神石</Typography>
+                      </Box>
+                    </Grid>
+                    <Grid size={{ xs: 6 }}>
+                      <Box sx={{ p: 1.5, bgcolor: "action.hover", borderRadius: 2, textAlign: "center" }}>
+                        <Typography variant="caption" color="text.secondary">實發獎金</Typography>
+                        <Typography variant="h6" sx={{ fontWeight: 700, color: "success.main" }}>
+                          {settlement.prizePool.toLocaleString()}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">女神石</Typography>
+                      </Box>
+                    </Grid>
+                  </Grid>
+
+                  {/* Secondary stats row */}
+                  <Grid container spacing={2}>
+                    <Grid size={{ xs: 4 }}>
+                      <StatItem label="系統抽成" value={`${(settlement.feeRate * 100).toFixed(0)}%`} />
+                    </Grid>
+                    {settlement.multiplier && (
+                      <Grid size={{ xs: 4 }}>
+                        <StatItem label="中獎倍數" value={`${settlement.multiplier}x`} highlight />
+                      </Grid>
+                    )}
+                    {betStats && (
+                      <>
+                        <Grid size={{ xs: 4 }}>
+                          <StatItem label="參與人數" value={`${betStats.totalBettors} 人`} />
+                        </Grid>
+                        <Grid size={{ xs: 4 }}>
+                          <StatItem label="總注數" value={`${betStats.totalBets} 筆`} />
+                        </Grid>
+                        <Grid size={{ xs: 4 }}>
+                          <StatItem label="中獎注數" value={`${betStats.winnerBets} 筆`} />
+                        </Grid>
+                      </>
+                    )}
+                  </Grid>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Race Track - Final standings */}
+            <Card variant="outlined">
+              <CardContent sx={{ p: "16px !important" }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+                  最終排名
+                </Typography>
+                <Stack spacing={1.5}>
+                  {sortedRunners.map((runner, idx) => {
+                    const rank = idx + 1;
+                    const progress = Math.min((runner.position / trackLength) * 100, 100);
+                    const isWinner = runner.id === race.winner_runner_id;
+                    const rankStyle = RANK_STYLES[rank];
+
+                    return (
+                      <Box key={runner.id}>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 0.5 }}>
+                          <Box
+                            sx={{
+                              width: 26,
+                              height: 26,
+                              borderRadius: "50%",
+                              bgcolor: rankStyle ? rankStyle.bg : "grey.400",
+                              color: rankStyle ? rankStyle.text : "text.secondary",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              fontSize: "0.7rem",
+                              fontWeight: 700,
+                              flexShrink: 0,
+                            }}
+                          >
+                            {rank}
+                          </Box>
+                          <Avatar
+                            src={runner.avatar_url}
+                            alt={runner.character_name}
+                            sx={{ width: 36, height: 36, border: 2, borderColor: isWinner ? "warning.main" : "divider" }}
+                          />
+                          <Box sx={{ flex: 1, minWidth: 0 }}>
+                            <Typography
+                              variant="body2"
+                              sx={{
+                                fontWeight: isWinner ? 700 : 500,
+                                color: isWinner ? "warning.main" : "text.primary",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {runner.character_name}
+                              {isWinner && (
+                                <EmojiEventsIcon
+                                  sx={{ fontSize: 14, color: "warning.main", ml: 0.5, verticalAlign: "text-bottom" }}
+                                />
+                              )}
+                            </Typography>
+                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                              <BoltIcon sx={{ fontSize: 12, color: "text.disabled" }} />
+                              <Typography variant="caption" color="text.secondary">
+                                {runner.stamina}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                                {runner.position}/{trackLength}
+                              </Typography>
+                            </Box>
+                          </Box>
+                        </Box>
+                        <LinearProgress
+                          variant="determinate"
+                          value={progress}
+                          sx={{
+                            height: 6,
+                            borderRadius: 3,
+                            bgcolor: "grey.200",
+                            "& .MuiLinearProgress-bar": {
+                              borderRadius: 3,
+                              bgcolor: isWinner ? "warning.main" : rank <= 3 ? "primary.main" : "grey.400",
+                            },
+                          }}
+                        />
+                      </Box>
+                    );
+                  })}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Stack>
+        </Grid>
+
+        {/* Right column: events */}
+        <Grid size={{ xs: 12, md: 5 }}>
+          {events.length > 0 && (
+            <Card variant="outlined" sx={{ height: "100%" }}>
+              <CardContent sx={{ p: "16px !important" }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+                  事件紀錄 ({events.length})
+                </Typography>
+                <Stack
+                  spacing={0}
+                  divider={<Divider sx={{ my: 0.5 }} />}
+                  sx={{ maxHeight: 500, overflowY: "auto" }}
+                >
+                  {[...events].reverse().map(event => (
+                    <Box
+                      key={event.id}
+                      sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75 }}
+                    >
+                      <Paper
+                        elevation={0}
+                        sx={{
+                          minWidth: 36,
+                          height: 22,
+                          borderRadius: 1,
+                          bgcolor: "primary.main",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          flexShrink: 0,
+                        }}
+                      >
+                        <Typography
+                          sx={{ fontSize: "0.65rem", fontWeight: 700, color: "primary.contrastText" }}
+                        >
+                          R{event.round}
+                        </Typography>
+                      </Paper>
+                      <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.5 }}>
+                        {event.description}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Stack>
+              </CardContent>
+            </Card>
+          )}
+        </Grid>
+      </Grid>
+    </Container>
+  );
+}
+
+function StatItem({ label, value, highlight }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.2 }}>
+        {label}
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{ fontWeight: 700, color: highlight ? "warning.main" : "text.primary" }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/pages/Race/Detail.jsx
+++ b/frontend/src/pages/Race/Detail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   Container,
@@ -22,6 +22,7 @@ import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import MonetizationOnIcon from "@mui/icons-material/MonetizationOn";
 import BoltIcon from "@mui/icons-material/Bolt";
 import { getRaceById } from "../../api/race";
+import StatItem from "./StatItem";
 
 const RANK_STYLES = {
   1: { bg: "#F59E0B", text: "#fff" },
@@ -42,6 +43,11 @@ export default function RaceDetail() {
       .catch(() => setError("無法載入賽事資料"))
       .finally(() => setLoading(false));
   }, [raceId]);
+
+  const reversedEvents = useMemo(
+    () => (data?.events ? [...data.events].reverse() : []),
+    [data?.events]
+  );
 
   if (loading) {
     return (
@@ -313,7 +319,7 @@ export default function RaceDetail() {
                   divider={<Divider sx={{ my: 0.5 }} />}
                   sx={{ maxHeight: 500, overflowY: "auto" }}
                 >
-                  {[...events].reverse().map(event => (
+                  {reversedEvents.map(event => (
                     <Box
                       key={event.id}
                       sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75 }}
@@ -352,18 +358,3 @@ export default function RaceDetail() {
   );
 }
 
-function StatItem({ label, value, highlight }) {
-  return (
-    <Box>
-      <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.2 }}>
-        {label}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{ fontWeight: 700, color: highlight ? "warning.main" : "text.primary" }}
-      >
-        {value}
-      </Typography>
-    </Box>
-  );
-}

--- a/frontend/src/pages/Race/StatItem.jsx
+++ b/frontend/src/pages/Race/StatItem.jsx
@@ -1,0 +1,17 @@
+import { Box, Typography } from "@mui/material";
+
+export default function StatItem({ label, value, highlight }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.2 }}>
+        {label}
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{ fontWeight: 700, color: highlight ? "warning.main" : "text.primary" }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/pages/Race/index.jsx
+++ b/frontend/src/pages/Race/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Container,
   Typography,
@@ -14,6 +15,7 @@ import {
   Grid,
   Avatar,
   Paper,
+  Button,
 } from "@mui/material";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import BoltIcon from "@mui/icons-material/Bolt";
@@ -24,7 +26,7 @@ import FlagIcon from "@mui/icons-material/Flag";
 import { getCurrentRace, getRaceHistory } from "../../api/race";
 
 const POLL_INTERVAL = 10000;
-const DEFAULT_TRACK_LENGTH = 10;
+const DEFAULT_TRACK_LENGTH = 50;
 
 const STATUS_META = {
   betting: { label: "下注中", color: "warning", Icon: TimerIcon },
@@ -52,6 +54,7 @@ const STATUS_CHIP_LABELS = {
 // ─── data fetch (unchanged) ───────────────────────────────────────────────────
 
 export default function Race() {
+  const navigate = useNavigate();
   const [raceData, setRaceData] = useState(null);
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -129,13 +132,26 @@ export default function Race() {
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
-      {/* page title */}
-      <Typography variant="h5" sx={{ fontWeight: 700, mb: 0.5 }}>
-        蘭德索爾盃
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 2.5 }}>
-        每 10 秒自動更新
-      </Typography>
+      {/* page title + bet link */}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 2.5 }}>
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700, mb: 0.5 }}>
+            蘭德索爾盃
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            每 10 秒自動更新
+          </Typography>
+        </Box>
+        <Button
+          variant={raceData?.race?.status === "betting" ? "contained" : "outlined"}
+          color={raceData?.race?.status === "betting" ? "warning" : "primary"}
+          size="small"
+          onClick={() => navigate("/race/bet")}
+          sx={{ fontWeight: 700, minWidth: 100, borderRadius: 2 }}
+        >
+          {raceData?.race?.status === "betting" ? "前往下注" : "下注 / 紀錄"}
+        </Button>
+      </Box>
 
       {error && (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -162,7 +178,7 @@ export default function Race() {
                 {raceData.events?.length > 0 && (
                   <EventLog events={raceData.events} />
                 )}
-                {history.length > 0 && <RaceHistory history={history} />}
+                {history.length > 0 && <RaceHistory history={history} onRaceClick={id => navigate(`/race/${id}`)} />}
               </Stack>
             </Grid>
           </Grid>
@@ -172,7 +188,7 @@ export default function Race() {
       {/* history only when no active race */}
       {!raceData?.race && history.length > 0 && (
         <Box sx={{ mt: 3 }}>
-          <RaceHistory history={history} />
+          <RaceHistory history={history} onRaceClick={id => navigate(`/race/${id}`)} />
         </Box>
       )}
     </Container>
@@ -476,7 +492,7 @@ function EventLog({ events }) {
 
 const HISTORY_BORDER = ["#F59E0B", "#94A3B8", "#92400E", "divider", "divider"];
 
-function RaceHistory({ history }) {
+function RaceHistory({ history, onRaceClick }) {
   return (
     <Card variant="outlined">
       <CardContent sx={{ p: "16px !important" }}>
@@ -500,7 +516,18 @@ function RaceHistory({ history }) {
             return (
               <Box
                 key={r.id}
-                sx={{ display: "flex", alignItems: "center", gap: 1.5, py: 1.25 }}
+                onClick={() => onRaceClick && onRaceClick(r.id)}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1.5,
+                  py: 1.25,
+                  cursor: "pointer",
+                  borderRadius: 1,
+                  transition: "background-color 150ms ease",
+                  "&:hover": { bgcolor: "action.hover" },
+                  "&:active": { bgcolor: "action.selected" },
+                }}
               >
                 {/* position number */}
                 <Typography

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+const TOKEN_KEY = "liff_access_token";
+
 const api = axios.create({
   timeout: 10000,
 });
@@ -11,5 +13,18 @@ export function setAuthToken(token) {
 export function clearAuthToken() {
   delete api.defaults.headers.common["Authorization"];
 }
+
+// Clear expired token and reload on 401
+api.interceptors.response.use(
+  res => res,
+  err => {
+    if (err.response?.status === 401) {
+      window.localStorage.removeItem(TOKEN_KEY);
+      clearAuthToken();
+      window.location.reload();
+    }
+    return Promise.reject(err);
+  }
+);
 
 export default api;

--- a/scripts/race-simulation.js
+++ b/scripts/race-simulation.js
@@ -1,0 +1,283 @@
+/**
+ * Race simulation — run N races with configurable parameters and output statistics.
+ *
+ * Usage:
+ *   node scripts/race-simulation.js [--races 100] [--recovery 12]
+ */
+
+// Inline lodash utilities to avoid dependency resolution issues
+const _ = {
+  random(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  },
+  clamp(val, lower, upper) {
+    return Math.min(Math.max(val, lower), upper);
+  },
+};
+
+// ─── Config (mirrors app/config/default.json with proposed changes) ──────────
+
+const BASE_CONFIG = {
+  trackLength: 80,
+  runnerCount: 5,
+  stamina: {
+    initial: 100,
+    minCost: 8,
+    maxCost: 15,
+    recovery: 5,
+  },
+  movement: {
+    baseMin: 0,
+    baseMax: 2,
+    guaranteedMin: 0, // minimum move even at 0 stamina (0 = original behavior)
+  },
+  event: {
+    triggerChance: 0.15,
+  },
+};
+
+// ─── CLI args ────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+function getArg(name, defaultVal) {
+  const idx = args.indexOf(`--${name}`);
+  return idx !== -1 && args[idx + 1] ? Number(args[idx + 1]) : defaultVal;
+}
+
+const NUM_RACES = getArg("races", 100);
+const config = {
+  ...BASE_CONFIG,
+  trackLength: getArg("track", BASE_CONFIG.trackLength),
+  stamina: {
+    ...BASE_CONFIG.stamina,
+    recovery: getArg("recovery", BASE_CONFIG.stamina.recovery),
+  },
+  movement: {
+    ...BASE_CONFIG.movement,
+    guaranteedMin: getArg("min-move", BASE_CONFIG.movement.guaranteedMin),
+  },
+};
+
+// ─── Simulation logic (mirrors RaceService.js) ──────────────────────────────
+
+const EVENT_TYPES = [
+  { type: "trip", weight: 3 },
+  { type: "swap", weight: 2 },
+  { type: "boost", weight: 3 },
+  { type: "global_slow", weight: 1 },
+  { type: "trip_wire", weight: 2 },
+];
+
+function calcMovement(runner) {
+  const base = _.random(config.movement.baseMin, config.movement.baseMax);
+  const factor = runner.stamina / 100;
+  const move = Math.round(base * factor);
+  // Guaranteed minimum: even at 0 stamina, can still crawl forward
+  if (config.movement.guaranteedMin > 0 && move < config.movement.guaranteedMin) {
+    return _.random(0, 1) < 0.5 ? config.movement.guaranteedMin : 0;
+  }
+  return move;
+}
+
+function pickRandomEvent(runners) {
+  const totalWeight = EVENT_TYPES.reduce((s, e) => s + e.weight, 0);
+  let roll = Math.random() * totalWeight;
+  let selected = EVENT_TYPES[0];
+  for (const evt of EVENT_TYPES) {
+    roll -= evt.weight;
+    if (roll <= 0) {
+      selected = evt;
+      break;
+    }
+  }
+  const a = runners[_.random(0, runners.length - 1)];
+  const others = runners.filter(r => r.id !== a.id);
+  const b = others.length > 0 ? others[_.random(0, others.length - 1)] : null;
+  return { type: selected.type, targets: [a.id, b ? b.id : null].filter(Boolean) };
+}
+
+function applyEventEffect(event, updates) {
+  const findUpdate = id => updates.find(u => u.id === id);
+  switch (event.type) {
+    case "trip": {
+      const u = findUpdate(event.targets[0]);
+      if (u) u.position = Math.max(0, u.position - 1);
+      break;
+    }
+    case "swap": {
+      const uA = findUpdate(event.targets[0]);
+      const uB = findUpdate(event.targets[1]);
+      if (uA && uB) {
+        const tmp = uA.position;
+        uA.position = uB.position;
+        uB.position = tmp;
+      }
+      break;
+    }
+    case "boost": {
+      const u = findUpdate(event.targets[0]);
+      if (u) u.position = Math.min(u.position + 2, config.trackLength);
+      break;
+    }
+    case "trip_wire": {
+      const u = findUpdate(event.targets[1]);
+      if (u) u.status = "stunned";
+      break;
+    }
+  }
+}
+
+function simulateRace() {
+  const runners = Array.from({ length: config.runnerCount }, (_, i) => ({
+    id: i + 1,
+    name: `Runner${i + 1}`,
+    position: 0,
+    stamina: config.stamina.initial,
+    status: "normal",
+  }));
+
+  let round = 0;
+  let eventCount = 0;
+  const staminaHistory = []; // track avg stamina per round
+
+  const MAX_ROUNDS = 500; // safety cap
+
+  while (round < MAX_ROUNDS) {
+    round++;
+
+    let globalEvent = null;
+    if (Math.random() < config.event.triggerChance) {
+      globalEvent = pickRandomEvent(runners);
+      eventCount++;
+    }
+
+    const updates = runners.map(runner => {
+      let move = calcMovement(runner);
+
+      if (globalEvent && globalEvent.type === "global_slow") {
+        move = Math.min(move, 1);
+      }
+      if (runner.status === "stunned") {
+        move = 0;
+      }
+      if (runner.status === "slowed") {
+        move = Math.max(0, move - 1);
+      }
+
+      const newPosition = Math.min(runner.position + move, config.trackLength);
+      const staminaCost = _.random(config.stamina.minCost, config.stamina.maxCost);
+      const newStamina = _.clamp(
+        runner.stamina - staminaCost + config.stamina.recovery,
+        0,
+        100
+      );
+
+      return {
+        id: runner.id,
+        position: newPosition,
+        stamina: newStamina,
+        status: "normal",
+      };
+    });
+
+    if (globalEvent && globalEvent.type !== "global_slow") {
+      applyEventEffect(globalEvent, updates);
+    }
+
+    // Apply updates
+    for (const u of updates) {
+      const runner = runners.find(r => r.id === u.id);
+      runner.position = u.position;
+      runner.stamina = u.stamina;
+      runner.status = u.status;
+    }
+
+    const avgStamina = runners.reduce((s, r) => s + r.stamina, 0) / runners.length;
+    staminaHistory.push(avgStamina);
+
+    // Check finish
+    const finishers = runners.filter(r => r.position >= config.trackLength);
+    if (finishers.length > 0) {
+      return { round, eventCount, staminaHistory, finished: true };
+    }
+  }
+
+  return { round: MAX_ROUNDS, eventCount, staminaHistory, finished: false };
+}
+
+// ─── Run simulation ─────────────────────────────────────────────────────────
+
+console.log("=== 蘭德索爾盃 賽事模擬 ===\n");
+console.log("參數:");
+console.log(`  trackLength:    ${config.trackLength}`);
+console.log(`  movement:       ${config.movement.baseMin}~${config.movement.baseMax}`);
+console.log(`  stamina:        初始=${config.stamina.initial}, 消耗=${config.stamina.minCost}~${config.stamina.maxCost}, 回復=${config.stamina.recovery}`);
+console.log(`  triggerChance:  ${config.event.triggerChance}`);
+console.log(`  模擬場數:       ${NUM_RACES}\n`);
+
+const results = [];
+for (let i = 0; i < NUM_RACES; i++) {
+  results.push(simulateRace());
+}
+
+const rounds = results.map(r => r.round);
+const events = results.map(r => r.eventCount);
+const unfinished = results.filter(r => !r.finished).length;
+
+function stats(arr) {
+  const sorted = [...arr].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  return {
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    avg: (sum / sorted.length).toFixed(1),
+    median: sorted[Math.floor(sorted.length / 2)],
+    p10: sorted[Math.floor(sorted.length * 0.1)],
+    p90: sorted[Math.floor(sorted.length * 0.9)],
+  };
+}
+
+const roundStats = stats(rounds);
+const eventStats = stats(events);
+
+console.log("── 回合數統計 ──");
+console.log(`  最少: ${roundStats.min}  |  最多: ${roundStats.max}`);
+console.log(`  平均: ${roundStats.avg}  |  中位: ${roundStats.median}`);
+console.log(`  P10:  ${roundStats.p10}   |  P90:  ${roundStats.p90}`);
+console.log(`  未完賽 (>500回合): ${unfinished} 場`);
+
+console.log("\n── 事件數統計 ──");
+console.log(`  最少: ${eventStats.min}  |  最多: ${eventStats.max}`);
+console.log(`  平均: ${eventStats.avg}  |  中位: ${eventStats.median}`);
+
+// Duration estimation (1 min per round)
+console.log("\n── 預估比賽時長 (1分鐘/回合) ──");
+console.log(`  最短: ${roundStats.min} 分鐘 (${(roundStats.min / 60).toFixed(1)} 小時)`);
+console.log(`  平均: ${roundStats.avg} 分鐘 (${(roundStats.avg / 60).toFixed(1)} 小時)`);
+console.log(`  最長: ${roundStats.max} 分鐘 (${(roundStats.max / 60).toFixed(1)} 小時)`);
+
+// Stamina curve — sample from first race
+console.log("\n── 體力曲線 (第一場) ──");
+const sample = results[0].staminaHistory;
+const checkpoints = [1, 10, 25, 50, 75, 100, sample.length];
+for (const cp of checkpoints) {
+  if (cp <= sample.length) {
+    console.log(`  回合 ${String(cp).padStart(3)}: 平均體力 ${sample[cp - 1].toFixed(1)}`);
+  }
+}
+
+// Distribution histogram
+console.log("\n── 回合數分布 ──");
+const bucketSize = 10;
+const buckets = {};
+for (const r of rounds) {
+  const key = Math.floor(r / bucketSize) * bucketSize;
+  buckets[key] = (buckets[key] || 0) + 1;
+}
+const maxCount = Math.max(...Object.values(buckets));
+const sortedKeys = Object.keys(buckets).map(Number).sort((a, b) => a - b);
+for (const key of sortedKeys) {
+  const count = buckets[key];
+  const bar = "█".repeat(Math.round((count / maxCount) * 40));
+  console.log(`  ${String(key).padStart(3)}~${String(key + bucketSize - 1).padStart(3)} | ${bar} ${count}`);
+}

--- a/scripts/race-simulation.js
+++ b/scripts/race-simulation.js
@@ -18,18 +18,18 @@ const _ = {
 // ─── Config (mirrors app/config/default.json with proposed changes) ──────────
 
 const BASE_CONFIG = {
-  trackLength: 80,
+  trackLength: 50,
   runnerCount: 5,
   stamina: {
     initial: 100,
     minCost: 8,
     maxCost: 15,
-    recovery: 5,
+    recovery: 10,
   },
   movement: {
     baseMin: 0,
     baseMax: 2,
-    guaranteedMin: 0, // minimum move even at 0 stamina (0 = original behavior)
+    guaranteedMin: 1,
   },
   event: {
     triggerChance: 0.15,


### PR DESCRIPTION
## Summary
- **賽事參數調整**: trackLength=50, advanceInterval=1min, recovery=10, guaranteedMin=1, triggerChance=0.15，解決體力耗盡死鎖問題
- **新增遊戲說明**: `.賽跑` Flex Message carousel 加入規則說明 bubble（玩法、下注方式、獎金計算、事件說明）
- **前端下注頁 Tab UI**: 下注/我的紀錄 分頁，含結算明細（總注額、系統抽成、中獎倍數）
- **歷史賽事詳情頁**: `/race/:id` 響應式兩欄排版，顯示冠軍、結算資訊、最終排名、事件紀錄
- **頁面導航**: /race ↔ /race/bet ↔ /race/:id 完整導航流程
- **401 token 過期處理**: API interceptor 自動清除過期 token 並重載
- **Code cleanup**: 修復 N+1 查詢、硬編碼 feeRate、抽取共用 StatItem 元件、快取靜態 rules bubble

## Test plan
- [ ] `.賽跑` 指令顯示規則說明 + 賽道 + 事件 carousel
- [ ] 前端 /race 頁面即時更新、歷史賽事可點擊進入詳情
- [ ] 前端 /race/bet 下注 + 我的紀錄 tab 切換正常
- [ ] /race/:id 詳情頁結算資訊與排名正確顯示
- [ ] 模擬測試通過 (`yarn test --testPathPattern RaceSimulation`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)