### PR TITLE
fix(race): prevent empty subtitle in Flex Message

### DIFF
--- a/app/src/templates/application/Race.js
+++ b/app/src/templates/application/Race.js
@@ -74,7 +74,7 @@ function generateTrackBubble(raceData, rankedRunners, odds) {
     subtitle = `截止時間: ${endTime}`;
   } else if (raceData.status === "running") {
     subtitle = `第 ${raceData.round} 回合`;
-  } else if (winner) {
+  } else {
     subtitle = `共 ${raceData.round} 回合`;
   }
 


### PR DESCRIPTION
## Summary
- LINE API 拒絕空字串的 text 欄位，當比賽結束但 `winner` 為 null 時，`subtitle` 為空字串導致 Flex Message 發送失敗
- 將 `else if (winner)` 改為 `else`，確保 finished 狀態下一律顯示「共 X 回合」

## Test plan
- [ ] 比賽結束後，`.賽跑` 指令正常顯示 Flex Message 無報錯

🤖 Generated with [Claude Code](https://claude.com/claude-code)