### PR TITLE
feat(analytics): integrate Umami analytics for command tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,7 @@ LANG=zh_TW.UTF-8
 
 ### Ngrok 連線配置 #########################################
 NGROK_AUTHTOKEN=
+
+### Umami Analytics ############################################
+UMAMI_URL=
+UMAMI_WEBSITE_ID=

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -7,6 +7,7 @@ const guildConfig = require("./controller/application/GroupConfig");
 const setProfile = require("./middleware/profile");
 const statistics = require("./middleware/statistics");
 const alias = require("./middleware/alias");
+const umamiTrack = require("./middleware/umamiTrack");
 const rateLimit = require("./middleware/rateLimit");
 const lineEvent = require("./controller/lineEvent");
 const welcome = require("./templates/common/welcome");
@@ -405,6 +406,7 @@ async function App(context) {
     HandlePostback, // 處理postback事件
     rateLimit, // 限制使用者指令速度
     alias,
+    umamiTrack, // Umami 事件追蹤
     GlobalOrderBase, // 全群指令分析
     OrderBased, // 指令分析
     CustomerOrderBased, // 自訂指令分析

--- a/app/src/controller/application/CustomerOrder.js
+++ b/app/src/controller/application/CustomerOrder.js
@@ -5,6 +5,7 @@ const random = require("math-random");
 const CustomerOrderTemplate = require("../../templates/application/CustomerOrder");
 const { send } = require("../../templates/application/Order");
 const { recordSign } = require("../../util/traffic");
+const umami = require("../../util/umami");
 const { get } = require("lodash");
 
 function CusOrderException(message, code = 0) {
@@ -190,6 +191,11 @@ exports.CustomerOrderDetect = async context => {
 
   if (chosenOrderKey === false) return false;
   recordSign("CustomerOrderDetect");
+  umami.track(
+    "customer_order_hit",
+    "/bot/application/customer_order",
+    umami.getSourceData(context)
+  );
   // 紀錄最近一次觸發時間，用於日後回收無用處之指令。
   CustomerOrderModel.touchOrder(context.event.message.text, sourceId);
 

--- a/app/src/controller/application/GlobalOrders.js
+++ b/app/src/controller/application/GlobalOrders.js
@@ -2,6 +2,7 @@ const OrderModel = require("../../model/application/GlobalOrders");
 const random = require("math-random");
 const { send } = require("../../templates/application/Order");
 const { recordSign } = require("../../util/traffic");
+const umami = require("../../util/umami");
 const allowParameter = ["orderKey", "replyDatas", "senderIcon", "senderName", "touchType"];
 
 function GlobalOrderException(message, code) {
@@ -27,6 +28,7 @@ exports.GlobalOrderBase = async (context, { next }) => {
 
   if (fullMatchResult.length !== 0) {
     recordSign("GlobalOrder");
+    umami.track("global_order_hit", "/bot/application/global_order", umami.getSourceData(context));
     objOrder = fullMatchResult[getRandom(fullMatchResult.length - 1)];
     send(context, objOrder.replyDatas, { name: objOrder.senderName, iconUrl: objOrder.senderIcon });
     return;
@@ -39,6 +41,7 @@ exports.GlobalOrderBase = async (context, { next }) => {
 
   if (matchResult.length !== 0) {
     recordSign("GlobalOrder");
+    umami.track("global_order_hit", "/bot/application/global_order", umami.getSourceData(context));
     objOrder = matchResult[getRandom(matchResult.length - 1)];
     send(context, objOrder.replyDatas, { name: objOrder.senderName, iconUrl: objOrder.senderIcon });
     return;

--- a/app/src/controller/application/OpenaiController.js
+++ b/app/src/controller/application/OpenaiController.js
@@ -1,5 +1,6 @@
 const { get, concat } = require("lodash");
 const redis = require("../../util/redis");
+const umami = require("../../util/umami");
 const { format } = require("util");
 const config = require("config");
 const groupSessionKeyTemplate = config.get("redis.keys.groupSession");
@@ -38,6 +39,7 @@ exports.naturalLanguageUnderstanding = async function (context, { next }) {
   if (!context.event.isText) {
     return next;
   }
+
   const { text, mention } = context.event.message;
   const mentionSelf = get(mention, "mentionees", []).find(mentionee => mentionee.isSelf === true);
 
@@ -45,6 +47,8 @@ exports.naturalLanguageUnderstanding = async function (context, { next }) {
   if (text.length > 200) {
     return next;
   }
+
+  umami.track("ai_conversation", "/bot/application/ai_conversation", umami.getSourceData(context));
 
   const replaceTarget = text.slice(mentionSelf.index, mentionSelf.index + mentionSelf.length);
   const replaceText = text.replace(replaceTarget, "").trim();

--- a/app/src/middleware/umamiTrack.js
+++ b/app/src/middleware/umamiTrack.js
@@ -1,0 +1,131 @@
+const umami = require("../util/umami");
+
+/**
+ * 指令 mapping 表
+ * 順序很重要：更精確的 pattern 要放前面
+ */
+const commandMap = [
+  // === princess ===
+  { pattern: /^[/#.]消耗抽/, name: "gacha_pickup", category: "princess" },
+  { pattern: /^[/#.]歐洲抽/, name: "gacha_europe", category: "princess" },
+  { pattern: /^[/#.]保證抽/, name: "gacha_ensure", category: "princess" },
+  { pattern: /^[/#.]抽/, name: "gacha_play", category: "princess" },
+  { pattern: /^[#.]我的包包$|^\/mybag$/i, name: "gacha_bag", category: "princess" },
+  { pattern: /^[#.](三刀出完|出完三刀|done)$/, name: "battle_done", category: "princess" },
+  { pattern: /^[#.](三刀重置|重置三刀|reset)$/, name: "battle_reset", category: "princess" },
+  { pattern: /^[#.](出完沒|趕快出|gblist)/, name: "battle_list", category: "princess" },
+  { pattern: /^[#.]刀軸轉換$|^[./]bt$/i, name: "battle_time", category: "princess" },
+  { pattern: /^[!#/]升滿星/, name: "character_full_rankup", category: "princess" },
+  { pattern: /^[!#/]升星/, name: "character_rankup", category: "princess" },
+  { pattern: /^[.#]轉蛋(兌換|商店)/, name: "godstone_shop", category: "princess" },
+
+  // === application: level & status ===
+  { pattern: /^(#我的狀態|\/me)$/, name: "level_status", category: "application" },
+  { pattern: /^[.#/](你的狀態|you)/, name: "level_friend_status", category: "application" },
+  { pattern: /^#狀態\s/, name: "level_friend_search", category: "application" },
+  { pattern: /^#等級排行$/, name: "level_rank", category: "application" },
+
+  // === application: orders ===
+  { pattern: /^[#.]?(指令列表|orderlist)$/, name: "order_list", category: "application" },
+  { pattern: /^[#.]?新增關鍵字指令/, name: "order_create_keyword", category: "application" },
+  { pattern: /^[#.]?新增指令/, name: "order_create", category: "application" },
+  { pattern: /^[#.]?[移刪]除指令/, name: "order_delete", category: "application" },
+
+  // === application: group ===
+  {
+    pattern: /^[#.]?(群組(設定|狀態|管理)|groupconfig)$/i,
+    name: "group_config",
+    category: "application",
+  },
+  { pattern: /^[#./]group$/, name: "group_panel", category: "application" },
+  { pattern: /^[.#]自訂頭像/, name: "set_sender", category: "application" },
+
+  // === application: world boss ===
+  { pattern: /^#冒險小卡$/, name: "worldboss_status", category: "application" },
+  { pattern: /^(\/worldboss|#世界王)$/, name: "worldboss_event", category: "application" },
+  { pattern: /^[.#/](攻擊|attack)$/, name: "worldboss_attack", category: "application" },
+  { pattern: /^[#]傷害[紀記]錄/, name: "worldboss_logs", category: "application" },
+  { pattern: /^[#＃]裝備$/, name: "worldboss_equipment", category: "application" },
+  { pattern: /^#夢幻回歸$/, name: "worldboss_revoke", category: "application" },
+  { pattern: /^\/worldrank$/, name: "worldboss_rank", category: "application" },
+
+  // === application: janken ===
+  { pattern: /^[.#/](猜拳段位|猜拳rank)/, name: "janken_rank", category: "application" },
+  {
+    pattern: /^[.#/](猜拳(擂台|(大|比)賽)|hold)/,
+    name: "janken_challenge",
+    category: "application",
+  },
+  { pattern: /^[.#/](決鬥|duel)/, name: "janken_duel", category: "application" },
+  { pattern: /^[.#/](猜拳)/, name: "janken_play", category: "application" },
+
+  // === application: race ===
+  { pattern: /^[.#/]賽跑下注\s*\d/, name: "race_bet", category: "application" },
+  { pattern: /^[.#/](賽跑紀錄)$/i, name: "race_history", category: "application" },
+  { pattern: /^[.#/](賽跑)$/i, name: "race_status", category: "application" },
+
+  // === application: market ===
+  { pattern: /^[./#](交易管理|trade-manage)$/i, name: "market_manage", category: "application" },
+  { pattern: /^[./#](快速轉帳|fastatm)/i, name: "market_fast_transfer", category: "application" },
+  { pattern: /^[./#](轉帳|atm)/i, name: "market_transfer", category: "application" },
+  { pattern: /^[./#](交易|trade)/i, name: "market_trade", category: "application" },
+
+  // === application: misc ===
+  { pattern: /^[.#/](成就|稱號|adv)$/, name: "advancement", category: "application" },
+  { pattern: /^[/.#]兌換\s/, name: "coupon_use", category: "application" },
+  { pattern: /^[./#]圖片上傳$/, name: "image_upload", category: "application" },
+  {
+    pattern: /^[.#/](my[-_]?money|我的錢錢|我的女神石)$/,
+    name: "status_godstone",
+    category: "application",
+  },
+  {
+    pattern: /^[.#/](my[-_]?character|我的角色|我的角色數量)$/,
+    name: "status_character",
+    category: "application",
+  },
+  { pattern: /^[.#/](訂閱兌換|sub-coupon)/, name: "subscribe_coupon", category: "application" },
+  { pattern: /^[.#/](訂閱|sub)$/, name: "subscribe_info", category: "application" },
+  { pattern: /^[.#/](轉職)$/, name: "job_change", category: "application" },
+  { pattern: /^[.#/](我要買月卡)/, name: "subscribe_buy", category: "application" },
+
+  // === general ===
+  { pattern: /^[/#.](使用說明|help)$/, name: "help", category: "general" },
+  { pattern: /^(\/link|#實用連結|#連結)$/, name: "link", category: "general" },
+];
+
+function trackPostback(context) {
+  if (!context.event.isPayload) return;
+
+  try {
+    const payload = JSON.parse(context.event.payload);
+    const { action } = payload;
+    if (!action) return;
+
+    umami.track(action, `/bot/postback/${action}`, umami.getSourceData(context));
+    // eslint-disable-next-line no-unused-vars
+  } catch (e) {
+    // payload 不是 JSON，跳過
+  }
+}
+
+function trackTextCommand(context) {
+  if (!context.event.isText) return;
+
+  const text = context.event.message.text;
+
+  for (const cmd of commandMap) {
+    if (cmd.pattern.test(text)) {
+      umami.track(cmd.name, `/bot/${cmd.category}/${cmd.name}`, umami.getSourceData(context));
+      return;
+    }
+  }
+}
+
+const umamiTrack = async (context, props) => {
+  trackPostback(context);
+  trackTextCommand(context);
+  return props.next;
+};
+
+module.exports = umamiTrack;

--- a/app/src/util/umami.js
+++ b/app/src/util/umami.js
@@ -1,0 +1,43 @@
+const axios = require("axios");
+
+const UMAMI_URL = process.env.UMAMI_URL;
+const UMAMI_WEBSITE_ID = process.env.UMAMI_WEBSITE_ID;
+const HOSTNAME = "linebot";
+
+function isEnabled() {
+  return Boolean(UMAMI_URL && UMAMI_WEBSITE_ID);
+}
+
+function send(payload) {
+  if (!isEnabled()) return;
+
+  axios
+    .post(`${UMAMI_URL}/api/send`, {
+      payload: {
+        hostname: HOSTNAME,
+        language: "zh-TW",
+        website: UMAMI_WEBSITE_ID,
+        ...payload,
+      },
+    })
+    .catch(err => {
+      console.error("[umami] send failed:", err.message);
+    });
+}
+
+/**
+ * 從 context 提取來源資訊
+ * @param {import("bottender").LineContext} context
+ */
+exports.getSourceData = function getSourceData(context) {
+  const { type, groupId } = context.event.source;
+  const data = { sourceType: type };
+  if (type === "group" && groupId) {
+    data.groupId = groupId;
+  }
+  return data;
+};
+
+exports.track = function track(name, url, data) {
+  send({ url, name, data });
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <script defer src="https://umami.hanshino.dev/script.js" data-website-id="99a6532d-7602-4e54-a72e-cf2b6ed96187"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- 整合 Umami 分析服務，追蹤 bot 指令使用頻率與來源（群組/私訊）
- 新增 `umamiTrack` middleware，透過 52 條 regex mapping 自動追蹤所有指令，動態指令（GlobalOrder、CustomerOrder、Gemini AI）由 controller 補埋
- Frontend admin dashboard 加入 Umami tracking script，與 bot 共用同一 website，靠 URL path 區分（`/bot/*` vs 前端路由）

## Changes
- `app/src/util/umami.js` — Umami Collect API 封裝（fire-and-forget，環境變數未設定時 no-op）
- `app/src/middleware/umamiTrack.js` — 指令 mapping 表 + middleware
- `app/src/app.js` — middleware chain 插入 umamiTrack（alias 之後）
- `app/src/controller/application/GlobalOrders.js` — 補埋 global_order_hit
- `app/src/controller/application/CustomerOrder.js` — 補埋 customer_order_hit
- `app/src/controller/application/OpenaiController.js` — 補埋 ai_conversation
- `frontend/index.html` — Umami tracking script
- `.env.example` — UMAMI_URL, UMAMI_WEBSITE_ID

## Test plan
- [x] ESLint 通過（新增/修改檔案 0 errors）
- [x] yarn test 通過（30 suites, 146 tests, 0 failures）
- [x] 模組載入驗證（umami.js, umamiTrack.js, app.js 皆正常）
- [ ] 部署後確認 Umami dashboard 收到事件

🤖 Generated with [Claude Code](https://claude.com/claude-code)