### PR TITLE
fix(umami): add type field and User-Agent header to Collect API

### DIFF
--- a/app/src/util/umami.js
+++ b/app/src/util/umami.js
@@ -12,14 +12,21 @@ function send(payload) {
   if (!isEnabled()) return;
 
   axios
-    .post(`${UMAMI_URL}/api/send`, {
-      payload: {
-        hostname: HOSTNAME,
-        language: "zh-TW",
-        website: UMAMI_WEBSITE_ID,
-        ...payload,
+    .post(
+      `${UMAMI_URL}/api/send`,
+      {
+        type: "event",
+        payload: {
+          hostname: HOSTNAME,
+          language: "zh-TW",
+          website: UMAMI_WEBSITE_ID,
+          ...payload,
+        },
       },
-    })
+      {
+        headers: { "User-Agent": "RediveLineBot/1.0" },
+      }
+    )
     .catch(err => {
       console.error("[umami] send failed:", err.message);
     });


### PR DESCRIPTION
## Summary
- Umami `/api/send` 回 400，因為缺少 `type: "event"` 頂層欄位和 `User-Agent` header
- 加上這兩個欄位修復 server-side tracking

## Test plan
- [x] ESLint 通過
- [x] yarn test 通過（146 tests）
- [ ] 部署後確認 Umami dashboard 收到事件

🤖 Generated with [Claude Code](https://claude.com/claude-code)