### PR TITLE
fix(umami): use browser-compatible payload format for Collect API

### DIFF
--- a/app/src/util/umami.js
+++ b/app/src/util/umami.js
@@ -2,7 +2,9 @@ const axios = require("axios");
 
 const UMAMI_URL = process.env.UMAMI_URL;
 const UMAMI_WEBSITE_ID = process.env.UMAMI_WEBSITE_ID;
-const HOSTNAME = "linebot";
+const UMAMI_HOSTNAME = process.env.APP_DOMAIN || "pudding.hanshino.dev";
+
+const USER_AGENT = "Mozilla/5.0 (Linux; x86_64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
 
 function isEnabled() {
   return Boolean(UMAMI_URL && UMAMI_WEBSITE_ID);
@@ -17,14 +19,20 @@ function send(payload) {
       {
         type: "event",
         payload: {
-          hostname: HOSTNAME,
+          hostname: UMAMI_HOSTNAME,
           language: "zh-TW",
+          screen: "1920x1080",
+          title: "RediveLineBot",
+          referrer: "",
           website: UMAMI_WEBSITE_ID,
           ...payload,
         },
       },
       {
-        headers: { "User-Agent": "RediveLineBot/1.0" },
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": USER_AGENT,
+        },
       }
     )
     .catch(err => {
@@ -46,5 +54,6 @@ exports.getSourceData = function getSourceData(context) {
 };
 
 exports.track = function track(name, url, data) {
-  send({ url, name, data });
+  const fullUrl = `https://${UMAMI_HOSTNAME}${url}`;
+  send({ url: fullUrl, name, data });
 };


### PR DESCRIPTION
## Summary
- Umami 收到 server-side 事件回 `200 { beep: 'boop' }` 但不寫入資料庫
- 原因：缺少 `hostname`、`screen`、`title`、`referrer` 等瀏覽器端欄位，且 `url` 需要完整 URL 格式
- 改用跟前端 tracking script 一致的 payload 格式，Umami 回應含 `sessionId` + `visitId` 確認寫入成功

## Test plan
- [x] ESLint 通過
- [x] yarn test 通過（146 tests）
- [x] 容器內手動測試確認 Umami 回應含 sessionId/visitId
- [ ] 部署後確認 Umami dashboard 顯示 bot 事件

🤖 Generated with [Claude Code](https://claude.com/claude-code)