### PR TITLE
fix(gacha): sanitize and validate headimage_url on save

### DIFF
--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -553,6 +553,22 @@ function trimParamter(rowData) {
   return objParam;
 }
 
+function sanitizeImageUrl(url) {
+  if (!url) return url;
+  const cleaned = url.trim().replace(/^['"]+|['"]+$/g, "").trim();
+  if (!cleaned.startsWith("https://")) {
+    throw new GachaException("headimage_url must start with https://", 4);
+  }
+  return cleaned;
+}
+
+function applyImageUrlSanitize(objParam) {
+  const urlKey = Object.keys(objParam).find(k => k.toLowerCase() === "headimage_url");
+  if (urlKey && objParam[urlKey]) {
+    objParam[urlKey] = sanitizeImageUrl(objParam[urlKey]);
+  }
+}
+
 async function updateCharacter(req, res) {
   const { id, data } = req.body;
   let result = {};
@@ -562,6 +578,7 @@ async function updateCharacter(req, res) {
     if (data === undefined) throw new GachaException("Parameter data missing", 2);
 
     let objParam = trimParamter(data);
+    applyImageUrlSanitize(objParam);
 
     await GachaModel.updateData(id, objParam);
   } catch (e) {
@@ -583,6 +600,8 @@ async function insertCharacter(req, res) {
     let objParam = trimParamter(data);
 
     if (Object.keys(objParam).length < 5) throw new GachaException("Parameter Leak", 3);
+
+    applyImageUrlSanitize(objParam);
 
     await GachaModel.insertNewData(objParam);
   } catch (e) {

--- a/frontend/src/pages/Admin/GachaPool/GachaPoolForm.jsx
+++ b/frontend/src/pages/Admin/GachaPool/GachaPoolForm.jsx
@@ -59,6 +59,7 @@ export default function GachaPoolForm() {
   const [loading, setLoading] = useState(isEdit);
   const [saving, setSaving] = useState(false);
   const [imgError, setImgError] = useState(false);
+  const [imageUrlError, setImageUrlError] = useState("");
 
   const [hintState, { handleOpen: showHint, handleClose: closeHint }] = useHintBar();
 
@@ -96,7 +97,25 @@ export default function GachaPoolForm() {
 
   const handleChange = (field) => (e) => {
     setFormData((prev) => ({ ...prev, [field]: e.target.value }));
-    if (field === "imageUrl") setImgError(false);
+    if (field === "imageUrl") {
+      setImgError(false);
+      setImageUrlError("");
+    }
+  };
+
+  const cleanUrl = (url) => url.trim().replace(/^['"]+|['"]+$/g, "").trim();
+
+  const handleImageUrlBlur = () => {
+    const cleaned = cleanUrl(formData.imageUrl);
+    if (cleaned !== formData.imageUrl) {
+      setFormData((prev) => ({ ...prev, imageUrl: cleaned }));
+    }
+  };
+
+  const validateImageUrl = (url) => {
+    if (!url) return "";
+    if (!url.startsWith("https://")) return "圖片網址必須以 https:// 開頭";
+    return "";
   };
 
   const handleSave = async () => {
@@ -105,9 +124,16 @@ export default function GachaPoolForm() {
       return;
     }
 
+    const cleanedImageUrl = cleanUrl(formData.imageUrl);
+    const urlErr = validateImageUrl(cleanedImageUrl);
+    if (urlErr) {
+      setImageUrlError(urlErr);
+      return;
+    }
+
     const payload = {
       name: formData.name,
-      headImage_url: formData.imageUrl,
+      headImage_url: cleanedImageUrl,
       star: formData.star,
       rate: formData.rate,
       is_princess: formData.isPrincess,
@@ -244,7 +270,10 @@ export default function GachaPoolForm() {
             label="圖片網址"
             value={formData.imageUrl}
             onChange={handleChange("imageUrl")}
+            onBlur={handleImageUrlBlur}
             placeholder="https://..."
+            error={Boolean(imageUrlError)}
+            helperText={imageUrlError}
           />
 
           {/* Section: Gacha Settings */}


### PR DESCRIPTION
## Summary

- 後端 `updateCharacter` / `insertCharacter` 在寫入前透過 `sanitizeImageUrl()` 去除前後空白與引號，並驗證必須為 `https://` 開頭，否則回 400
- 前端 `GachaPoolForm` 在 blur 時自動清理 URL，送出前驗證格式，不符合則顯示 inline error 並擋住送出

## Root Cause

`GachaPool` 中部分角色的 `headimage_url` 含有前後空格或被雙引號包住，導致 LINE API 驗證 Flex Message 時回傳 `invalid uri scheme`，GachaRecord 已寫入但訊息無法發送，用戶看不到每日一抽結果。

## Test plan

- [ ] 在管理頁面新增/編輯角色，輸入帶有前後空格或引號的 URL，blur 後應自動清理
- [ ] 輸入非 `https://` 開頭的 URL，點儲存應顯示 error 並擋住
- [ ] 直接呼叫 API 送帶引號的 URL，應回 400
- [ ] 正常 `https://` URL 仍可正常儲存

🤖 Generated with [Claude Code](https://claude.com/claude-code)