### PR TITLE
feat: gacha banner system with auth guard and admin UX improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,6 @@ DB_USER=
 DB_USER_PASSWORD=
 REDIS_PASSWORD=
 
-#管理員信箱，用於簽訂SSL證書使用
-ADMIN_EMAIL=
-
 ###########################################################
 ######################### 選 填 ###########################
 ##########################################################
@@ -25,14 +22,17 @@ ADMIN_EMAIL=
 ### Line Front-end Framwork Id 用於 Line 網頁應用程式 #######
 
 #LINE_LIFF_ID=
+#LINE_LIFF_COMPACT_ID=
+#LINE_LIFF_TALL_ID=
+#LINE_LIFF_FULL_ID=
 
-### 用於發送排程執行結果 https://notify-bot.line.me/ #########
+### Google Gemini AI API Key ################################
 
-#LINE_NOTIFY_TOKEN=
+#GEMINI_API_KEY=
 
-### 異常Log發送 ############################################
+### Imgur 圖片上傳 ##########################################
 
-#SENTRY_DSN=
+#IMGUR_CLIENT_ID=
 
 ###########################################################
 ################## 不 會 設 定 請 勿 動 #####################
@@ -40,13 +40,9 @@ ADMIN_EMAIL=
 
 PROJECT_NAME=redive
 APP_DOMAIN=redivebot.local
-APP_PORT=80
 
 ### 使用資料庫名稱 #########################################
 DB_DATABASE=Princess
-
-### docker 資料庫儲存位置 ##################################
-DB_STOREPATH=./data
 
 ### 資料庫連線配置 #########################################
 DB_HOST=mysql
@@ -56,17 +52,8 @@ DB_PORT=3306
 REDIS_PORT=6379
 REDIS_HOST=redis
 
-### 圖形辨識連線配置 ######################################
-OPENCV_HOST=python
-
-### 公主遊戲資料庫連線配置 ################################
-PRINCESS_DB_PATH=assets
-
 TZ=Asia/Taipei
 LANG=zh_TW.UTF-8
-
-### Ngrok 連線配置 #########################################
-NGROK_AUTHTOKEN=
 
 ### Umami Analytics ############################################
 UMAMI_URL=

--- a/app/migrations/20260406120000_create_gacha_banner.js
+++ b/app/migrations/20260406120000_create_gacha_banner.js
@@ -1,0 +1,27 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("gacha_banner", function (table) {
+    table.increments("id").primary();
+    table.string("name", 100).notNullable().comment("Banner 名稱");
+    table.enum("type", ["rate_up", "europe"]).notNullable().comment("活動類型");
+    table.integer("rate_boost").unsigned().defaultTo(0).comment("機率加成百分比，僅 rate_up 用，如 150 表示 1.5 倍");
+    table.integer("cost").unsigned().defaultTo(0).comment("花費女神石，僅 europe 用，0 表示用 config 預設");
+    table.timestamp("start_at").notNullable().comment("活動開始時間");
+    table.timestamp("end_at").notNullable().comment("活動結束時間");
+    table.boolean("is_active").notNullable().defaultTo(true).comment("是否啟用");
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("gacha_banner");
+};

--- a/app/migrations/20260406120001_create_gacha_banner_characters.js
+++ b/app/migrations/20260406120001_create_gacha_banner_characters.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("gacha_banner_characters", function (table) {
+    table.increments("id").primary();
+    table.integer("banner_id").unsigned().notNullable().comment("對應 gacha_banner.id");
+    table.integer("character_id").unsigned().notNullable().comment("對應 GachaPool.id");
+
+    table.foreign("banner_id").references("gacha_banner.id").onDelete("CASCADE");
+    table.unique(["banner_id", "character_id"]);
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("gacha_banner_characters");
+};

--- a/app/server.js
+++ b/app/server.js
@@ -30,7 +30,7 @@ const app = bottender({
   dev: process.env.NODE_ENV !== "production",
 });
 
-const port = Number(process.env.PORT) || 5000;
+const port = Number(process.env.PORT) || 9527;
 
 // the request handler of the bottender app
 const handle = app.getRequestHandler();

--- a/app/src/controller/princess/GachaBannerController.js
+++ b/app/src/controller/princess/GachaBannerController.js
@@ -1,0 +1,100 @@
+const GachaBanner = require("../../model/princess/GachaBanner");
+
+/**
+ * 取得所有 banner 列表
+ */
+async function listBanners(req, res) {
+  try {
+    const banners = await GachaBanner.all({
+      order: [{ column: "start_at", direction: "desc" }],
+    });
+    res.json(banners);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "取得 banner 列表失敗" });
+  }
+}
+
+/**
+ * 取得單一 banner 詳情（含角色）
+ */
+async function getBanner(req, res) {
+  try {
+    const { id } = req.params;
+    const banner = await GachaBanner.findWithCharacters(parseInt(id));
+    if (!banner) {
+      return res.status(404).json({ message: "Banner 不存在" });
+    }
+    res.json(banner);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "取得 banner 失敗" });
+  }
+}
+
+/**
+ * 新增 banner
+ * body: { name, type, rate_boost, cost, start_at, end_at, is_active, characterIds }
+ */
+async function createBanner(req, res) {
+  try {
+    const { characterIds = [], ...bannerData } = req.body;
+    const id = await GachaBanner.create(bannerData);
+
+    if (bannerData.type === "rate_up" && characterIds.length > 0) {
+      await GachaBanner.setBannerCharacters(id, characterIds);
+    }
+
+    res.json({ id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "新增 banner 失敗" });
+  }
+}
+
+/**
+ * 更新 banner
+ * body: { name, type, rate_boost, cost, start_at, end_at, is_active, characterIds }
+ */
+async function updateBanner(req, res) {
+  try {
+    const { id } = req.params;
+    const { characterIds, ...bannerData } = req.body;
+
+    await GachaBanner.update(parseInt(id), {
+      ...bannerData,
+      updated_at: new Date(),
+    });
+
+    if (characterIds !== undefined) {
+      await GachaBanner.setBannerCharacters(parseInt(id), characterIds);
+    }
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "更新 banner 失敗" });
+  }
+}
+
+/**
+ * 刪除 banner（cascade 會自動刪除關聯角色）
+ */
+async function deleteBanner(req, res) {
+  try {
+    const { id } = req.params;
+    await GachaBanner.delete(parseInt(id));
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "刪除 banner 失敗" });
+  }
+}
+
+module.exports = {
+  listBanners,
+  getBanner,
+  createBanner,
+  updateBanner,
+  deleteBanner,
+};

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -147,34 +147,29 @@ async function userCooldown(userId) {
 }
 
 /**
- * 將轉蛋池3*機率調升
- * @param {Array} pool
+ * 對符合條件的角色套用機率加成
+ * @param {Array} pool 轉蛋池
+ * @param {Function} shouldBoost 判斷是否加成的 predicate
+ * @param {Number} boost 加成百分比，如 150 → (100+150)/100 = 2.5 倍
+ * @returns {Array}
  */
-function makePickup(pool, rate = 100) {
+function boostRate(pool, shouldBoost, boost) {
   return pool.map(data => {
-    if (data.star !== "3") return data;
+    if (!shouldBoost(data)) return data;
     return {
       ...data,
-      rate: `${(parseFloat(data.rate) * (100 + rate)) / 100}%`,
+      rate: `${(parseFloat(data.rate) * (100 + boost)) / 100}%`,
     };
   });
 }
 
-/**
- * 對 banner 指定的角色套用機率加成
- * @param {Array} pool 轉蛋池
- * @param {Array<Number>} characterIds banner 指定角色 ID
- * @param {Number} rateBoost 加成百分比，如 150 = 1.5 倍
- * @returns {Array}
- */
+function makePickup(pool, rate = 100) {
+  return boostRate(pool, data => data.star === "3", rate);
+}
+
 function applyBannerRateUp(pool, characterIds, rateBoost) {
-  return pool.map(data => {
-    if (!characterIds.includes(data.id)) return data;
-    return {
-      ...data,
-      rate: `${(parseFloat(data.rate) * (100 + rateBoost)) / 100}%`,
-    };
-  });
+  const idSet = new Set(characterIds);
+  return boostRate(pool, data => idSet.has(data.id), rateBoost);
 }
 
 /**
@@ -200,10 +195,13 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
   let { tag, times = 10 } = match.groups;
   const { userId, type, groupId } = context.event.source;
 
-  // 歐洲抽：查詢是否有進行中的 europe banner
+  // 一次查詢所有進行中的 banner（避免多次 DB round-trip）
+  const allActiveBanners = await GachaBanner.getActiveBannersWithCharacters();
+  const europeBanners = allActiveBanners.filter(b => b.type === "europe");
+  const rateUpBanners = allActiveBanners.filter(b => b.type === "rate_up");
+
   let activeEuropeBanner = null;
   if (europe) {
-    const europeBanners = await GachaBanner.getActiveBanners({ type: "europe" });
     if (europeBanners.length === 0) {
       return context.replyText(i18n.__("message.gacha.cross_year_only"));
     }
@@ -284,21 +282,15 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     newCharacters: [],
     repeatReward: 0,
   };
-  // 查詢當前有效的 rate_up banner
-  const rateUpBanners = await GachaBanner.getActiveBanners({ type: "rate_up" });
-
-  const dailyPool = await (async () => {
+  const dailyPool = (() => {
     let pool = filteredPool;
 
-    // 先套用 banner rate_up（管理員設定，自動生效）
     for (const banner of rateUpBanners) {
-      const bannerCharIds = await GachaBanner.getBannerCharacterIds(banner.id);
-      if (bannerCharIds.length > 0) {
-        pool = applyBannerRateUp(pool, bannerCharIds, banner.rate_boost);
+      if (banner.characterIds.length > 0) {
+        pool = applyBannerRateUp(pool, banner.characterIds, banner.rate_boost);
       }
     }
 
-    // 再套用玩家指令效果
     if (pickup) {
       return makePickup(pool, 200);
     } else if (ensure) {

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -13,6 +13,7 @@ const EventCenterService = require("../../service/EventCenterService");
 const signModel = require("../../model/application/SigninDays");
 const { isNull, get, countBy, shuffle, uniqBy, difference, sum, uniq, pullAt } = require("lodash");
 const GachaRecord = require("../../model/princess/GachaRecord");
+const GachaBanner = require("../../model/princess/GachaBanner");
 const SubscribeUser = require("../../model/application/SubscribeUser");
 const SubscribeCard = require("../../model/application/SubscribeCard");
 const config = require("config");
@@ -160,6 +161,23 @@ function makePickup(pool, rate = 100) {
 }
 
 /**
+ * 對 banner 指定的角色套用機率加成
+ * @param {Array} pool 轉蛋池
+ * @param {Array<Number>} characterIds banner 指定角色 ID
+ * @param {Number} rateBoost 加成百分比，如 150 = 1.5 倍
+ * @returns {Array}
+ */
+function applyBannerRateUp(pool, characterIds, rateBoost) {
+  return pool.map(data => {
+    if (!characterIds.includes(data.id)) return data;
+    return {
+      ...data,
+      rate: `${(parseFloat(data.rate) * (100 + rateBoost)) / 100}%`,
+    };
+  });
+}
+
+/**
  * 檢視自己的轉蛋包包
  * @param {import("bottender").LineContext} context
  */
@@ -182,13 +200,15 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
   let { tag, times = 10 } = match.groups;
   const { userId, type, groupId } = context.event.source;
   const now = moment();
-  const month = now.month() + 1;
-  const date = now.date();
-  const isEventTime = month === 1 && date >= 27 && date <= 31;
 
-  // 只有 12/31~1/1 這兩天才會開放歐洲轉蛋池
-  if (europe && !isEventTime) {
-    return context.replyText(i18n.__("message.gacha.cross_year_only"));
+  // 歐洲抽：查詢是否有進行中的 europe banner
+  let activeEuropeBanner = null;
+  if (europe) {
+    const europeBanners = await GachaBanner.getActiveBanners({ type: "europe" });
+    if (europeBanners.length === 0) {
+      return context.replyText(i18n.__("message.gacha.cross_year_only"));
+    }
+    activeEuropeBanner = europeBanners[0];
   }
 
   if (type === "group" && context.state.guildConfig.Gacha === "N") {
@@ -243,7 +263,9 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
   const userOwnStone = parseInt(await GachaModel.getUserGodStoneCount(userId));
   const pickupCost = config.get("gacha.pick_up_cost");
   const ensureCost = config.get("gacha.ensure_cost");
-  const europeCost = config.get("gacha.europe_cost");
+  const europeCost = (activeEuropeBanner && activeEuropeBanner.cost > 0)
+    ? activeEuropeBanner.cost
+    : config.get("gacha.europe_cost");
 
   // 檢查是否有足夠的女神石
   if (pickup && userOwnStone < pickupCost) {
@@ -262,16 +284,29 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     newCharacters: [],
     repeatReward: 0,
   };
-  // const dailyPool = pickup ? makePickup(filteredPool, 200) : filteredPool;
-  const dailyPool = (() => {
-    if (pickup) {
-      return makePickup(filteredPool, 200);
-    } else if (ensure) {
-      return filteredPool;
-    } else if (europe) {
-      return filteredPool.filter(data => data.star == "3");
+  // 查詢當前有效的 rate_up banner
+  const rateUpBanners = await GachaBanner.getActiveBanners({ type: "rate_up" });
+
+  const dailyPool = await (async () => {
+    let pool = filteredPool;
+
+    // 先套用 banner rate_up（管理員設定，自動生效）
+    for (const banner of rateUpBanners) {
+      const bannerCharIds = await GachaBanner.getBannerCharacterIds(banner.id);
+      if (bannerCharIds.length > 0) {
+        pool = applyBannerRateUp(pool, bannerCharIds, banner.rate_boost);
+      }
     }
-    return filteredPool;
+
+    // 再套用玩家指令效果
+    if (pickup) {
+      return makePickup(pool, 200);
+    } else if (ensure) {
+      return pool;
+    } else if (europe) {
+      return pool.filter(data => data.star == "3");
+    }
+    return pool;
   })();
 
   // 進行特殊費用扣除

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -199,7 +199,6 @@ async function showGachaBag(context) {
 async function gacha(context, { match, pickup, ensure = false, europe = false }) {
   let { tag, times = 10 } = match.groups;
   const { userId, type, groupId } = context.event.source;
-  const now = moment();
 
   // 歐洲抽：查詢是否有進行中的 europe banner
   let activeEuropeBanner = null;
@@ -263,9 +262,10 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
   const userOwnStone = parseInt(await GachaModel.getUserGodStoneCount(userId));
   const pickupCost = config.get("gacha.pick_up_cost");
   const ensureCost = config.get("gacha.ensure_cost");
-  const europeCost = (activeEuropeBanner && activeEuropeBanner.cost > 0)
-    ? activeEuropeBanner.cost
-    : config.get("gacha.europe_cost");
+  const europeCost =
+    activeEuropeBanner && activeEuropeBanner.cost > 0
+      ? activeEuropeBanner.cost
+      : config.get("gacha.europe_cost");
 
   // 檢查是否有足夠的女神石
   if (pickup && userOwnStone < pickupCost) {

--- a/app/src/middleware/validation.js
+++ b/app/src/middleware/validation.js
@@ -72,7 +72,7 @@ exports.verifyAdmin = async (req, res, next) => {
 
   const adminList = await AdminModel.getList();
   var adminData = adminList.find(data => data.userId === userId);
-  if (adminData === undefined) return Unauthorized(res);
+  if (adminData === undefined) return Forbidden(res);
 
   req.profile = {
     ...req.profile,
@@ -88,7 +88,7 @@ exports.verifyPrivilege = (allow = 9) => {
     privilege = parseInt(privilege);
 
     if (privilege < allow) {
-      return Unauthorized(res);
+      return Forbidden(res);
     }
 
     next();
@@ -140,4 +140,8 @@ exports.socketVerifyAdmin = async (socket, next) => {
 
 function Unauthorized(res) {
   res.status(401).json({ message: "invalid token." });
+}
+
+function Forbidden(res) {
+  res.status(403).json({ message: "forbidden" });
 }

--- a/app/src/model/princess/GachaBanner.js
+++ b/app/src/model/princess/GachaBanner.js
@@ -1,0 +1,85 @@
+const Base = require("../base");
+
+class GachaBanner extends Base {
+  constructor() {
+    super({
+      table: "gacha_banner",
+      fillable: [
+        "name",
+        "type",
+        "rate_boost",
+        "cost",
+        "start_at",
+        "end_at",
+        "is_active",
+      ],
+    });
+  }
+
+  /**
+   * 查詢當前有效的 banner（時間內且啟用中）
+   * @param {Object} options
+   * @param {String} options.type 活動類型 rate_up | europe
+   * @returns {Promise<Array>}
+   */
+  async getActiveBanners(options = {}) {
+    const now = new Date();
+    let query = this.knex
+      .where("is_active", true)
+      .where("start_at", "<=", now)
+      .where("end_at", ">=", now);
+
+    if (options.type) {
+      query = query.where("type", options.type);
+    }
+
+    return query.orderBy("start_at", "desc");
+  }
+
+  /**
+   * 取得 banner 的關聯角色 ID 列表
+   * @param {Number} bannerId
+   * @returns {Promise<Array<Number>>}
+   */
+  async getBannerCharacterIds(bannerId) {
+    const rows = await this.connection("gacha_banner_characters")
+      .where("banner_id", bannerId)
+      .select("character_id");
+    return rows.map(r => r.character_id);
+  }
+
+  /**
+   * 設定 banner 的關聯角色（先刪後插）
+   * @param {Number} bannerId
+   * @param {Array<Number>} characterIds
+   */
+  async setBannerCharacters(bannerId, characterIds) {
+    await this.connection("gacha_banner_characters")
+      .where("banner_id", bannerId)
+      .del();
+
+    if (characterIds.length > 0) {
+      await this.connection("gacha_banner_characters").insert(
+        characterIds.map(characterId => ({
+          banner_id: bannerId,
+          character_id: characterId,
+        }))
+      );
+    }
+  }
+
+  /**
+   * 取得 banner 詳情（含關聯角色）
+   * @param {Number} id
+   * @returns {Promise<Object|null>}
+   */
+  async findWithCharacters(id) {
+    const banner = await this.find(id);
+    if (!banner) return null;
+
+    const characterIds = await this.getBannerCharacterIds(id);
+    return { ...banner, characterIds };
+  }
+}
+
+module.exports = new GachaBanner();

--- a/app/src/model/princess/GachaBanner.js
+++ b/app/src/model/princess/GachaBanner.js
@@ -4,15 +4,7 @@ class GachaBanner extends Base {
   constructor() {
     super({
       table: "gacha_banner",
-      fillable: [
-        "name",
-        "type",
-        "rate_boost",
-        "cost",
-        "start_at",
-        "end_at",
-        "is_active",
-      ],
+      fillable: ["name", "type", "rate_boost", "cost", "start_at", "end_at", "is_active"],
     });
   }
 
@@ -54,9 +46,7 @@ class GachaBanner extends Base {
    * @param {Array<Number>} characterIds
    */
   async setBannerCharacters(bannerId, characterIds) {
-    await this.connection("gacha_banner_characters")
-      .where("banner_id", bannerId)
-      .del();
+    await this.connection("gacha_banner_characters").where("banner_id", bannerId).del();
 
     if (characterIds.length > 0) {
       await this.connection("gacha_banner_characters").insert(

--- a/app/src/model/princess/GachaBanner.js
+++ b/app/src/model/princess/GachaBanner.js
@@ -41,20 +41,48 @@ class GachaBanner extends Base {
   }
 
   /**
-   * 設定 banner 的關聯角色（先刪後插）
+   * 查詢有效 banner 並一次載入所有關聯角色（避免 N+1）
+   * @param {Object} options
+   * @param {String} options.type 活動類型 rate_up | europe
+   * @returns {Promise<Array>} banners with characterIds attached
+   */
+  async getActiveBannersWithCharacters(options = {}) {
+    const banners = await this.getActiveBanners(options);
+    if (banners.length === 0) return [];
+
+    const ids = banners.map(b => b.id);
+    const chars = await this.connection("gacha_banner_characters")
+      .whereIn("banner_id", ids)
+      .select("banner_id", "character_id");
+
+    const charMap = {};
+    for (const c of chars) {
+      (charMap[c.banner_id] ||= []).push(c.character_id);
+    }
+    return banners.map(b => ({ ...b, characterIds: charMap[b.id] || [] }));
+  }
+
+  /**
+   * 設定 banner 的關聯角色（先刪後插，包在 transaction 中）
    * @param {Number} bannerId
    * @param {Array<Number>} characterIds
    */
   async setBannerCharacters(bannerId, characterIds) {
-    await this.connection("gacha_banner_characters").where("banner_id", bannerId).del();
-
-    if (characterIds.length > 0) {
-      await this.connection("gacha_banner_characters").insert(
-        characterIds.map(characterId => ({
-          banner_id: bannerId,
-          character_id: characterId,
-        }))
-      );
+    const trx = await this.connection.transaction();
+    try {
+      await trx("gacha_banner_characters").where("banner_id", bannerId).del();
+      if (characterIds.length > 0) {
+        await trx("gacha_banner_characters").insert(
+          characterIds.map(characterId => ({
+            banner_id: bannerId,
+            character_id: characterId,
+          }))
+        );
+      }
+      await trx.commit();
+    } catch (err) {
+      await trx.rollback();
+      throw err;
     }
   }
 

--- a/app/src/router/api.js
+++ b/app/src/router/api.js
@@ -16,6 +16,7 @@ const {
   verifyLineGroupId,
 } = require("../middleware/validation");
 const gacha = require("../controller/princess/gacha");
+const GachaBannerController = require("../controller/princess/GachaBannerController");
 const { webhook } = require("../util/discord");
 const { showStatistics, showUserStatistics } = require("../controller/application/Statistics");
 const ChatLevelController = require("../controller/application/ChatLevelController");
@@ -203,6 +204,15 @@ router.post("/admin/gacha-pool", verifyPrivilege(9), gacha.api.insertCharacter);
  * 刪除管理員轉蛋資料
  */
 router.delete("/admin/gacha-pool/:id", verifyPrivilege(9), gacha.api.deleteCharacter);
+
+/**
+ * 轉蛋 Banner 管理
+ */
+router.get("/admin/gacha-banners", verifyPrivilege(1), GachaBannerController.listBanners);
+router.get("/admin/gacha-banners/:id", verifyPrivilege(1), GachaBannerController.getBanner);
+router.post("/admin/gacha-banners", verifyPrivilege(9), GachaBannerController.createBanner);
+router.put("/admin/gacha-banners/:id", verifyPrivilege(9), GachaBannerController.updateBanner);
+router.delete("/admin/gacha-banners/:id", verifyPrivilege(9), GachaBannerController.deleteBanner);
 
 /**
  * 取得管理員全群指令

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -18,7 +18,7 @@ services:
     env_file: ./.env
     restart: always
     expose:
-      - 5000
+      - 9527
     networks:
       - infra
       - traefik
@@ -31,7 +31,7 @@ services:
       - "traefik.http.routers.${PROJECT_NAME}_bot-secure.tls=true"
       - "traefik.http.routers.${PROJECT_NAME}_bot-secure.tls.certresolver=leresolver"
       - "traefik.http.routers.${PROJECT_NAME}_bot-secure.priority=100"
-      - "traefik.http.services.${PROJECT_NAME}_bot.loadbalancer.server.port=5000"
+      - "traefik.http.services.${PROJECT_NAME}_bot.loadbalancer.server.port=9527"
       - "traefik.docker.network=traefik"
     logging:
       driver: "json-file"

--- a/docs/superpowers/plans/2026-04-06-gacha-banner-system.md
+++ b/docs/superpowers/plans/2026-04-06-gacha-banner-system.md
@@ -1,0 +1,1281 @@
+# Gacha Banner 系統 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 建立管理員可設定的轉蛋 Banner 系統，支援「期間限定機率提升（rate_up）」與「歐洲抽（europe）」兩種活動類型，前端提供管理介面，後端自動在抽卡時套用當前有效的 banner。
+
+**Architecture:** 新增 `gacha_banner` + `gacha_banner_characters` 兩張資料表。後端新增 GachaBanner model + CRUD API。Controller 抽卡時查詢當前有效 banner，對指定角色套用倍率（rate_up）或開放歐洲抽（europe）。前端新增 `/admin/gacha-banner` 管理頁面。現有 pickup 指令邏輯完全不動。
+
+**Tech Stack:** Knex migrations, CommonJS model (extends Base), Express routes, React + MUI frontend
+
+---
+
+## File Structure
+
+### 新建檔案
+
+| 檔案 | 職責 |
+|------|------|
+| `app/migrations/20260406120000_create_gacha_banner.js` | 建立 `gacha_banner` 表 |
+| `app/migrations/20260406120001_create_gacha_banner_characters.js` | 建立 `gacha_banner_characters` 關聯表 |
+| `app/src/model/princess/GachaBanner.js` | GachaBanner model (extends Base) |
+| `app/src/controller/princess/GachaBannerController.js` | Banner CRUD API controller |
+| `frontend/src/services/gachaBanner.js` | 前端 API service |
+| `frontend/src/pages/Admin/GachaBanner/index.jsx` | Banner 列表管理頁 |
+| `frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx` | Banner 新增/編輯表單頁 |
+
+### 修改檔案
+
+| 檔案 | 修改內容 |
+|------|----------|
+| `app/src/router/api.js` | 新增 `/api/admin/gacha-banners` CRUD routes |
+| `app/src/controller/princess/gacha.js` | 抽卡時查詢 active banner 並套用倍率；歐洲抽改查 banner 表 |
+| `frontend/src/App.jsx` | 新增 banner 管理路由 |
+| `frontend/src/components/NavDrawer.jsx` | admin menu 新增「活動 Banner」項目 |
+
+---
+
+## Task 1: 建立 gacha_banner 資料表 migration
+
+**Files:**
+- Create: `app/migrations/20260406120000_create_gacha_banner.js`
+
+- [ ] **Step 1: 建立 migration 檔案**
+
+```javascript
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("gacha_banner", function (table) {
+    table.increments("id").primary();
+    table.string("name", 100).notNullable().comment("Banner 名稱");
+    table.enum("type", ["rate_up", "europe"]).notNullable().comment("活動類型");
+    table.integer("rate_boost").unsigned().defaultTo(0).comment("機率加成百分比，僅 rate_up 用，如 150 表示 1.5 倍");
+    table.integer("cost").unsigned().defaultTo(0).comment("花費女神石，僅 europe 用，0 表示用 config 預設");
+    table.timestamp("start_at").notNullable().comment("活動開始時間");
+    table.timestamp("end_at").notNullable().comment("活動結束時間");
+    table.boolean("is_active").notNullable().defaultTo(true).comment("是否啟用");
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("gacha_banner");
+};
+```
+
+- [ ] **Step 2: 驗證 migration 可執行**
+
+Run: `cd /home/hanshino/workspace/redive_linebot/app && npx knex migrate:latest --dry-run 2>&1 || echo "dry-run not supported, check syntax only"`
+
+---
+
+## Task 2: 建立 gacha_banner_characters 關聯表 migration
+
+**Files:**
+- Create: `app/migrations/20260406120001_create_gacha_banner_characters.js`
+
+- [ ] **Step 1: 建立 migration 檔案**
+
+```javascript
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("gacha_banner_characters", function (table) {
+    table.increments("id").primary();
+    table.integer("banner_id").unsigned().notNullable().comment("對應 gacha_banner.id");
+    table.integer("character_id").unsigned().notNullable().comment("對應 GachaPool.id");
+
+    table.foreign("banner_id").references("gacha_banner.id").onDelete("CASCADE");
+    table.unique(["banner_id", "character_id"]);
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("gacha_banner_characters");
+};
+```
+
+- [ ] **Step 2: Commit migrations**
+
+```bash
+git add app/migrations/20260406120000_create_gacha_banner.js app/migrations/20260406120001_create_gacha_banner_characters.js
+git commit -m "feat(db): add gacha_banner and gacha_banner_characters migrations"
+```
+
+---
+
+## Task 3: 建立 GachaBanner Model
+
+**Files:**
+- Create: `app/src/model/princess/GachaBanner.js`
+
+- [ ] **Step 1: 建立 model 檔案**
+
+```javascript
+const Base = require("../base");
+
+class GachaBanner extends Base {
+  constructor() {
+    super({
+      table: "gacha_banner",
+      fillable: [
+        "name",
+        "type",
+        "rate_boost",
+        "cost",
+        "start_at",
+        "end_at",
+        "is_active",
+      ],
+    });
+  }
+
+  /**
+   * 查詢當前有效的 banner（時間內且啟用中）
+   * @param {Object} options
+   * @param {String} options.type 活動類型 rate_up | europe
+   * @returns {Promise<Array>}
+   */
+  async getActiveBanners(options = {}) {
+    const now = new Date();
+    let query = this.knex
+      .where("is_active", true)
+      .where("start_at", "<=", now)
+      .where("end_at", ">=", now);
+
+    if (options.type) {
+      query = query.where("type", options.type);
+    }
+
+    return query.orderBy("start_at", "desc");
+  }
+
+  /**
+   * 取得 banner 的關聯角色 ID 列表
+   * @param {Number} bannerId
+   * @returns {Promise<Array<Number>>}
+   */
+  async getBannerCharacterIds(bannerId) {
+    const rows = await this.connection("gacha_banner_characters")
+      .where("banner_id", bannerId)
+      .select("character_id");
+    return rows.map(r => r.character_id);
+  }
+
+  /**
+   * 設定 banner 的關聯角色（先刪後插）
+   * @param {Number} bannerId
+   * @param {Array<Number>} characterIds
+   */
+  async setBannerCharacters(bannerId, characterIds) {
+    await this.connection("gacha_banner_characters")
+      .where("banner_id", bannerId)
+      .del();
+
+    if (characterIds.length > 0) {
+      await this.connection("gacha_banner_characters").insert(
+        characterIds.map(characterId => ({
+          banner_id: bannerId,
+          character_id: characterId,
+        }))
+      );
+    }
+  }
+
+  /**
+   * 取得 banner 詳情（含關聯角色）
+   * @param {Number} id
+   * @returns {Promise<Object|null>}
+   */
+  async findWithCharacters(id) {
+    const banner = await this.find(id);
+    if (!banner) return null;
+
+    const characterIds = await this.getBannerCharacterIds(id);
+    return { ...banner, characterIds };
+  }
+}
+
+module.exports = new GachaBanner();
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/model/princess/GachaBanner.js
+git commit -m "feat(model): add GachaBanner model with active banner query"
+```
+
+---
+
+## Task 4: 建立 GachaBanner CRUD Controller
+
+**Files:**
+- Create: `app/src/controller/princess/GachaBannerController.js`
+
+- [ ] **Step 1: 建立 controller 檔案**
+
+```javascript
+const GachaBanner = require("../../model/princess/GachaBanner");
+
+/**
+ * 取得所有 banner 列表
+ */
+async function listBanners(req, res) {
+  try {
+    const banners = await GachaBanner.all({
+      order: [{ column: "start_at", direction: "desc" }],
+    });
+    res.json(banners);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "取得 banner 列表失敗" });
+  }
+}
+
+/**
+ * 取得單一 banner 詳情（含角色）
+ */
+async function getBanner(req, res) {
+  try {
+    const { id } = req.params;
+    const banner = await GachaBanner.findWithCharacters(parseInt(id));
+    if (!banner) {
+      return res.status(404).json({ message: "Banner 不存在" });
+    }
+    res.json(banner);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "取得 banner 失敗" });
+  }
+}
+
+/**
+ * 新增 banner
+ * body: { name, type, rate_boost, cost, start_at, end_at, is_active, characterIds }
+ */
+async function createBanner(req, res) {
+  try {
+    const { characterIds = [], ...bannerData } = req.body;
+    const id = await GachaBanner.create(bannerData);
+
+    if (bannerData.type === "rate_up" && characterIds.length > 0) {
+      await GachaBanner.setBannerCharacters(id, characterIds);
+    }
+
+    res.json({ id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "新增 banner 失敗" });
+  }
+}
+
+/**
+ * 更新 banner
+ * body: { name, type, rate_boost, cost, start_at, end_at, is_active, characterIds }
+ */
+async function updateBanner(req, res) {
+  try {
+    const { id } = req.params;
+    const { characterIds, ...bannerData } = req.body;
+
+    await GachaBanner.update(parseInt(id), {
+      ...bannerData,
+      updated_at: new Date(),
+    });
+
+    if (characterIds !== undefined) {
+      await GachaBanner.setBannerCharacters(parseInt(id), characterIds);
+    }
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "更新 banner 失敗" });
+  }
+}
+
+/**
+ * 刪除 banner（cascade 會自動刪除關聯角色）
+ */
+async function deleteBanner(req, res) {
+  try {
+    const { id } = req.params;
+    await GachaBanner.delete(parseInt(id));
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "刪除 banner 失敗" });
+  }
+}
+
+module.exports = {
+  listBanners,
+  getBanner,
+  createBanner,
+  updateBanner,
+  deleteBanner,
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/controller/princess/GachaBannerController.js
+git commit -m "feat(controller): add GachaBanner CRUD API controller"
+```
+
+---
+
+## Task 5: 註冊 Banner API Routes
+
+**Files:**
+- Modify: `app/src/router/api.js`
+
+- [ ] **Step 1: 在 api.js 新增 routes**
+
+在 `api.js` 頂部 require 區塊（約 line 18 附近）加入：
+
+```javascript
+const GachaBannerController = require("../controller/princess/GachaBannerController");
+```
+
+在 line 205（`router.delete("/admin/gacha-pool/:id"...` 下方）加入：
+
+```javascript
+/**
+ * 轉蛋 Banner 管理
+ */
+router.get("/admin/gacha-banners", verifyPrivilege(1), GachaBannerController.listBanners);
+router.get("/admin/gacha-banners/:id", verifyPrivilege(1), GachaBannerController.getBanner);
+router.post("/admin/gacha-banners", verifyPrivilege(9), GachaBannerController.createBanner);
+router.put("/admin/gacha-banners/:id", verifyPrivilege(9), GachaBannerController.updateBanner);
+router.delete("/admin/gacha-banners/:id", verifyPrivilege(9), GachaBannerController.deleteBanner);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/router/api.js
+git commit -m "feat(router): register gacha banner admin API routes"
+```
+
+---
+
+## Task 6: 修改 gacha controller — 套用 banner 機率加成
+
+**Files:**
+- Modify: `app/src/controller/princess/gacha.js`
+
+這是核心改動。需要在抽卡流程中查詢當前有效 banner 並套用。
+
+- [ ] **Step 1: 在 gacha.js 頂部加入 require**
+
+在 line 15（`const GachaRecord = require(...)` 附近）加入：
+
+```javascript
+const GachaBanner = require("../../model/princess/GachaBanner");
+```
+
+- [ ] **Step 2: 新增 applyBannerRateUp 函式**
+
+在 `makePickup` 函式（line 152-160）後面加入：
+
+```javascript
+/**
+ * 對 banner 指定的角色套用機率加成
+ * @param {Array} pool 轉蛋池
+ * @param {Array<Number>} characterIds banner 指定角色 ID
+ * @param {Number} rateBoost 加成百分比，如 150 = 1.5 倍
+ * @returns {Array}
+ */
+function applyBannerRateUp(pool, characterIds, rateBoost) {
+  return pool.map(data => {
+    if (!characterIds.includes(data.id)) return data;
+    return {
+      ...data,
+      rate: `${(parseFloat(data.rate) * (100 + rateBoost)) / 100}%`,
+    };
+  });
+}
+```
+
+- [ ] **Step 3: 修改 gacha 函式中的歐洲抽時間判斷與池子組裝**
+
+將 line 184-191 的硬寫時間判斷：
+
+```javascript
+  const now = moment();
+  const month = now.month() + 1;
+  const date = now.date();
+  const isEventTime = month === 1 && date >= 27 && date <= 31;
+
+  // 只有 12/31~1/1 這兩天才會開放歐洲轉蛋池
+  if (europe && !isEventTime) {
+    return context.replyText(i18n.__("message.gacha.cross_year_only"));
+  }
+```
+
+改為：
+
+```javascript
+  const now = moment();
+
+  // 歐洲抽：查詢是否有進行中的 europe banner
+  if (europe) {
+    const europeBanners = await GachaBanner.getActiveBanners({ type: "europe" });
+    if (europeBanners.length === 0) {
+      return context.replyText(i18n.__("message.gacha.cross_year_only"));
+    }
+  }
+```
+
+- [ ] **Step 4: 修改池子組裝邏輯，加入 banner rate_up**
+
+將 line 266-275 的 dailyPool 組裝：
+
+```javascript
+  const dailyPool = (() => {
+    if (pickup) {
+      return makePickup(filteredPool, 200);
+    } else if (ensure) {
+      return filteredPool;
+    } else if (europe) {
+      return filteredPool.filter(data => data.star == "3");
+    }
+    return filteredPool;
+  })();
+```
+
+改為：
+
+```javascript
+  // 查詢當前有效的 rate_up banner
+  const rateUpBanners = await GachaBanner.getActiveBanners({ type: "rate_up" });
+
+  const dailyPool = await (async () => {
+    let pool = filteredPool;
+
+    // 先套用 banner rate_up（管理員設定，自動生效）
+    for (const banner of rateUpBanners) {
+      const bannerCharIds = await GachaBanner.getBannerCharacterIds(banner.id);
+      if (bannerCharIds.length > 0) {
+        pool = applyBannerRateUp(pool, bannerCharIds, banner.rate_boost);
+      }
+    }
+
+    // 再套用玩家指令效果
+    if (pickup) {
+      return makePickup(pool, 200);
+    } else if (ensure) {
+      return pool;
+    } else if (europe) {
+      return pool.filter(data => data.star == "3");
+    }
+    return pool;
+  })();
+```
+
+- [ ] **Step 5: 驗證程式碼無語法錯誤**
+
+Run: `cd /home/hanshino/workspace/redive_linebot/app && node -e "require('./src/controller/princess/gacha')"`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/controller/princess/gacha.js
+git commit -m "feat(gacha): integrate banner system for rate-up and europe scheduling"
+```
+
+---
+
+## Task 7: 建立前端 API Service
+
+**Files:**
+- Create: `frontend/src/services/gachaBanner.js`
+
+- [ ] **Step 1: 建立 service 檔案**
+
+```javascript
+import api from "./api";
+
+export const fetchBanners = () =>
+  api.get("/api/admin/gacha-banners").then(r => r.data);
+
+export const fetchBanner = (id) =>
+  api.get(`/api/admin/gacha-banners/${id}`).then(r => r.data);
+
+export const createBanner = (data) =>
+  api.post("/api/admin/gacha-banners", data).then(r => r.data);
+
+export const updateBanner = (id, data) =>
+  api.put(`/api/admin/gacha-banners/${id}`, data).then(r => r.data);
+
+export const deleteBanner = (id) =>
+  api.delete(`/api/admin/gacha-banners/${id}`).then(r => r.data);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/services/gachaBanner.js
+git commit -m "feat(frontend): add gachaBanner API service"
+```
+
+---
+
+## Task 8: 建立前端 Banner 列表管理頁
+
+**Files:**
+- Create: `frontend/src/pages/Admin/GachaBanner/index.jsx`
+
+- [ ] **Step 1: 建立列表頁面**
+
+```jsx
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Button,
+  Typography,
+  Chip,
+  IconButton,
+  Stack,
+  Paper,
+  Tooltip,
+  Divider,
+  useTheme,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import CelebrationIcon from "@mui/icons-material/Celebration";
+import { FullPageLoading } from "../../../components/Loading";
+import HintSnackBar from "../../../components/HintSnackBar";
+import AlertDialog from "../../../components/AlertDialog";
+import useHintBar from "../../../hooks/useHintBar";
+import useAlertDialog from "../../../hooks/useAlertDialog";
+import * as gachaBannerService from "../../../services/gachaBanner";
+
+const TYPE_CONFIG = {
+  rate_up: { label: "機率提升", color: "warning" },
+  europe: { label: "歐洲抽", color: "info" },
+};
+
+function formatDateTime(value) {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("zh-TW");
+}
+
+function isActive(banner) {
+  if (!banner.is_active) return false;
+  const now = new Date();
+  return new Date(banner.start_at) <= now && new Date(banner.end_at) >= now;
+}
+
+export default function AdminGachaBanner() {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [hintState, { handleOpen: showHint, handleClose: closeHint }] = useHintBar();
+  const [alertState, { handleOpen: showAlert, handleClose: closeAlert }] = useAlertDialog();
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await gachaBannerService.fetchBanners();
+      setRows(data);
+    } catch {
+      showHint("載入資料失敗", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showHint]);
+
+  useEffect(() => {
+    document.title = "活動 Banner 管理";
+    fetchData();
+  }, [fetchData]);
+
+  const handleDeleteClick = (row) => {
+    showAlert({
+      title: "確認刪除",
+      description: `確定要刪除 Banner「${row.name}」嗎？`,
+      onSubmit: async () => {
+        try {
+          await gachaBannerService.deleteBanner(row.id);
+          showHint("刪除成功", "success");
+          fetchData();
+        } catch {
+          showHint("刪除失敗", "error");
+        } finally {
+          closeAlert();
+        }
+      },
+    });
+  };
+
+  if (loading && rows.length === 0) {
+    return <FullPageLoading />;
+  }
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      {/* Header */}
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 2, sm: 3 },
+          mb: 3,
+          borderRadius: 3,
+          border: 1,
+          borderColor: "divider",
+          background: isDark
+            ? "linear-gradient(135deg, rgba(251,191,36,0.08) 0%, rgba(168,85,247,0.06) 100%)"
+            : "linear-gradient(135deg, rgba(245,158,11,0.06) 0%, rgba(168,85,247,0.04) 100%)",
+        }}
+      >
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            <Typography variant="h5" sx={{ fontWeight: 700 }}>
+              活動 Banner 管理
+            </Typography>
+            <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+              共 {rows.length} 個 Banner
+            </Typography>
+          </Box>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => navigate("/admin/gacha-banner/new")}
+            sx={{ borderRadius: 2, px: 2.5, boxShadow: 2 }}
+          >
+            新增 Banner
+          </Button>
+        </Stack>
+      </Paper>
+
+      {/* Banner List */}
+      <Paper elevation={0} sx={{ borderRadius: 3, border: 1, borderColor: "divider" }}>
+        {rows.length === 0 && (
+          <Box sx={{ p: 3 }}>
+            <Typography variant="body2" color="text.secondary">
+              尚無 Banner 資料
+            </Typography>
+          </Box>
+        )}
+        {rows.map((banner, index) => (
+          <Box key={banner.id}>
+            {index > 0 && <Divider />}
+            <Box
+              sx={{
+                px: { xs: 2.5, sm: 3 },
+                py: { xs: 2, sm: 2.5 },
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+              }}
+            >
+              <CelebrationIcon
+                sx={{
+                  fontSize: 32,
+                  color: isActive(banner) ? "warning.main" : "text.disabled",
+                }}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    {banner.name}
+                  </Typography>
+                  <Chip
+                    label={TYPE_CONFIG[banner.type]?.label || banner.type}
+                    color={TYPE_CONFIG[banner.type]?.color || "default"}
+                    size="small"
+                  />
+                  {isActive(banner) ? (
+                    <Chip label="進行中" color="success" size="small" variant="outlined" />
+                  ) : (
+                    <Chip label="未啟用" size="small" variant="outlined" />
+                  )}
+                </Stack>
+                <Typography variant="caption" color="text.secondary">
+                  {formatDateTime(banner.start_at)} ～ {formatDateTime(banner.end_at)}
+                </Typography>
+                {banner.type === "rate_up" && (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                    機率加成: {banner.rate_boost}%
+                  </Typography>
+                )}
+                {banner.type === "europe" && banner.cost > 0 && (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                    花費: {banner.cost} 女神石
+                  </Typography>
+                )}
+              </Box>
+              <Stack direction="row" spacing={0.5}>
+                <Tooltip title="編輯" arrow>
+                  <IconButton
+                    size="small"
+                    onClick={() => navigate(`/admin/gacha-banner/${banner.id}/edit`)}
+                    sx={{ color: "primary.main" }}
+                  >
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="刪除" arrow>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleDeleteClick(banner)}
+                    sx={{ color: "error.main" }}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+            </Box>
+          </Box>
+        ))}
+      </Paper>
+
+      <AlertDialog
+        open={alertState.open}
+        onClose={closeAlert}
+        onSubmit={alertState.onSubmit}
+        onCancel={closeAlert}
+        title={alertState.title}
+        description={alertState.description}
+      />
+      <HintSnackBar
+        open={hintState.open}
+        message={hintState.message}
+        severity={hintState.severity}
+        onClose={closeHint}
+      />
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/pages/Admin/GachaBanner/index.jsx
+git commit -m "feat(frontend): add gacha banner list admin page"
+```
+
+---
+
+## Task 9: 建立前端 Banner 表單頁
+
+**Files:**
+- Create: `frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx`
+
+- [ ] **Step 1: 建立表單頁面**
+
+```jsx
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Button,
+  TextField,
+  MenuItem,
+  Typography,
+  Stack,
+  Paper,
+  IconButton,
+  Chip,
+  Autocomplete,
+  Switch,
+  FormControlLabel,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import SaveIcon from "@mui/icons-material/Save";
+import HintSnackBar from "../../../components/HintSnackBar";
+import { FullPageLoading } from "../../../components/Loading";
+import useHintBar from "../../../hooks/useHintBar";
+import * as gachaBannerService from "../../../services/gachaBanner";
+import * as gachaPoolService from "../../../services/gachaPool";
+
+const TYPE_OPTIONS = [
+  { value: "rate_up", label: "機率提升" },
+  { value: "europe", label: "歐洲抽" },
+];
+
+const EMPTY_FORM = {
+  name: "",
+  type: "rate_up",
+  rate_boost: 150,
+  cost: 0,
+  start_at: "",
+  end_at: "",
+  is_active: true,
+  characterIds: [],
+};
+
+function toLocalDateTimeString(dateStr) {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  const offset = d.getTimezoneOffset();
+  const local = new Date(d.getTime() - offset * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
+export default function GachaBannerForm() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isDark = theme.palette.mode === "dark";
+  const isEdit = Boolean(id);
+
+  const [formData, setFormData] = useState(EMPTY_FORM);
+  const [characters, setCharacters] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [hintState, { handleOpen: showHint, handleClose: closeHint }] = useHintBar();
+
+  const fetchInitialData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const poolData = await gachaPoolService.fetchData();
+      const ssrCharacters = poolData
+        .filter((c) => parseInt(c.star, 10) === 3)
+        .map((c) => ({ id: c.id, name: c.name, imageUrl: c.imageUrl }));
+      setCharacters(ssrCharacters);
+
+      if (isEdit) {
+        const banner = await gachaBannerService.fetchBanner(id);
+        setFormData({
+          name: banner.name || "",
+          type: banner.type || "rate_up",
+          rate_boost: banner.rate_boost || 0,
+          cost: banner.cost || 0,
+          start_at: toLocalDateTimeString(banner.start_at),
+          end_at: toLocalDateTimeString(banner.end_at),
+          is_active: Boolean(banner.is_active),
+          characterIds: banner.characterIds || [],
+        });
+      }
+    } catch {
+      showHint("載入資料失敗", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [id, isEdit, showHint]);
+
+  useEffect(() => {
+    document.title = isEdit ? "編輯 Banner" : "新增 Banner";
+    fetchInitialData();
+  }, [isEdit, fetchInitialData]);
+
+  const handleChange = (field) => (e) => {
+    setFormData((prev) => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleSave = async () => {
+    if (!formData.name.trim()) {
+      showHint("請輸入 Banner 名稱", "warning");
+      return;
+    }
+    if (!formData.start_at || !formData.end_at) {
+      showHint("請設定活動時間", "warning");
+      return;
+    }
+    if (new Date(formData.start_at) >= new Date(formData.end_at)) {
+      showHint("結束時間必須晚於開始時間", "warning");
+      return;
+    }
+
+    const payload = {
+      name: formData.name,
+      type: formData.type,
+      rate_boost: formData.type === "rate_up" ? parseInt(formData.rate_boost, 10) : 0,
+      cost: formData.type === "europe" ? parseInt(formData.cost, 10) : 0,
+      start_at: new Date(formData.start_at).toISOString(),
+      end_at: new Date(formData.end_at).toISOString(),
+      is_active: formData.is_active,
+      characterIds: formData.type === "rate_up" ? formData.characterIds : [],
+    };
+
+    try {
+      setSaving(true);
+      if (isEdit) {
+        await gachaBannerService.updateBanner(Number(id), payload);
+      } else {
+        await gachaBannerService.createBanner(payload);
+      }
+      showHint(isEdit ? "更新成功" : "新增成功", "success");
+      setTimeout(() => navigate("/admin/gacha-banner"), 800);
+    } catch {
+      showHint(isEdit ? "更新失敗" : "新增失敗", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <FullPageLoading />;
+  }
+
+  const selectedCharacters = characters.filter((c) =>
+    formData.characterIds.includes(c.id)
+  );
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: 640, mx: "auto", pb: 10 }}>
+      {/* Header */}
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 3 }}>
+        <IconButton
+          onClick={() => navigate("/admin/gacha-banner")}
+          sx={{
+            bgcolor: isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.04)",
+            "&:hover": { bgcolor: isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.08)" },
+          }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          {isEdit ? "編輯 Banner" : "新增 Banner"}
+        </Typography>
+      </Stack>
+
+      {/* Form */}
+      <Paper
+        elevation={0}
+        sx={{ p: { xs: 2.5, sm: 3 }, borderRadius: 3, border: 1, borderColor: "divider" }}
+      >
+        <Stack spacing={2.5}>
+          <Typography variant="overline" sx={{ color: "text.secondary", fontWeight: 700 }}>
+            基本設定
+          </Typography>
+
+          <TextField
+            fullWidth
+            label="Banner 名稱"
+            value={formData.name}
+            onChange={handleChange("name")}
+            required
+          />
+
+          <TextField
+            fullWidth
+            select
+            label="活動類型"
+            value={formData.type}
+            onChange={handleChange("type")}
+          >
+            {TYPE_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={formData.is_active}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, is_active: e.target.checked }))
+                }
+              />
+            }
+            label="啟用"
+          />
+
+          {/* 時間設定 */}
+          <Typography variant="overline" sx={{ color: "text.secondary", fontWeight: 700, mt: 1 }}>
+            活動時間
+          </Typography>
+
+          <Stack direction={isMobile ? "column" : "row"} spacing={2}>
+            <TextField
+              fullWidth
+              label="開始時間"
+              type="datetime-local"
+              value={formData.start_at}
+              onChange={handleChange("start_at")}
+              required
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+            <TextField
+              fullWidth
+              label="結束時間"
+              type="datetime-local"
+              value={formData.end_at}
+              onChange={handleChange("end_at")}
+              required
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+          </Stack>
+
+          {/* rate_up 專用欄位 */}
+          {formData.type === "rate_up" && (
+            <>
+              <Typography
+                variant="overline"
+                sx={{ color: "text.secondary", fontWeight: 700, mt: 1 }}
+              >
+                機率提升設定
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="機率加成 (%)"
+                value={formData.rate_boost}
+                onChange={handleChange("rate_boost")}
+                type="number"
+                helperText="例如 150 表示指定角色機率變為 (100+150)/100 = 2.5 倍"
+                slotProps={{ htmlInput: { min: 0, step: 10 } }}
+              />
+
+              <Autocomplete
+                multiple
+                options={characters}
+                getOptionLabel={(option) => option.name}
+                value={selectedCharacters}
+                onChange={(_, newValue) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    characterIds: newValue.map((c) => c.id),
+                  }))
+                }
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                renderTags={(value, getTagProps) =>
+                  value.map((option, index) => (
+                    <Chip
+                      label={option.name}
+                      size="small"
+                      {...getTagProps({ index })}
+                      key={option.id}
+                    />
+                  ))
+                }
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="選擇加成角色（僅 SSR）"
+                    placeholder="搜尋角色名稱..."
+                  />
+                )}
+              />
+            </>
+          )}
+
+          {/* europe 專用欄位 */}
+          {formData.type === "europe" && (
+            <>
+              <Typography
+                variant="overline"
+                sx={{ color: "text.secondary", fontWeight: 700, mt: 1 }}
+              >
+                歐洲抽設定
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="花費女神石"
+                value={formData.cost}
+                onChange={handleChange("cost")}
+                type="number"
+                helperText="設為 0 則使用系統預設值 (10,000)"
+                slotProps={{ htmlInput: { min: 0, step: 100 } }}
+              />
+            </>
+          )}
+        </Stack>
+      </Paper>
+
+      {/* Sticky Save Button */}
+      <Box
+        sx={{
+          position: "fixed",
+          bottom: 0,
+          left: { xs: 0, md: 260 },
+          right: 0,
+          p: 2,
+          bgcolor: "background.paper",
+          borderTop: 1,
+          borderColor: "divider",
+          zIndex: (t) => t.zIndex.appBar - 1,
+          backdropFilter: "blur(8px)",
+          backgroundColor: isDark ? "rgba(10,26,42,0.92)" : "rgba(255,255,255,0.92)",
+        }}
+      >
+        <Box sx={{ maxWidth: 640, mx: "auto" }}>
+          <Button
+            fullWidth
+            variant="contained"
+            size="large"
+            startIcon={<SaveIcon />}
+            onClick={handleSave}
+            disabled={saving}
+            sx={{ py: 1.5, fontWeight: 700, fontSize: "1rem", borderRadius: 2, boxShadow: 3 }}
+          >
+            {saving ? "儲存中..." : isEdit ? "儲存變更" : "新增 Banner"}
+          </Button>
+        </Box>
+      </Box>
+
+      <HintSnackBar
+        open={hintState.open}
+        message={hintState.message}
+        severity={hintState.severity}
+        onClose={closeHint}
+      />
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx
+git commit -m "feat(frontend): add gacha banner create/edit form page"
+```
+
+---
+
+## Task 10: 註冊前端路由與導覽選單
+
+**Files:**
+- Modify: `frontend/src/App.jsx`
+- Modify: `frontend/src/components/NavDrawer.jsx`
+
+- [ ] **Step 1: 修改 App.jsx — 加入 import**
+
+在 import 區塊（line 28-29 附近，AdminGachaPool 下方）加入：
+
+```javascript
+import AdminGachaBanner from "./pages/Admin/GachaBanner";
+import AdminGachaBannerForm from "./pages/Admin/GachaBanner/GachaBannerForm";
+```
+
+- [ ] **Step 2: 修改 App.jsx — 加入路由**
+
+在 `admin/gacha-pool/:id/edit` 路由（line 85）下方加入：
+
+```jsx
+          <Route path="admin/gacha-banner" element={<AdminGachaBanner />} />
+          <Route path="admin/gacha-banner/new" element={<AdminGachaBannerForm />} />
+          <Route path="admin/gacha-banner/:id/edit" element={<AdminGachaBannerForm />} />
+```
+
+- [ ] **Step 3: 修改 NavDrawer.jsx — 加入選單項目**
+
+在 `NavDrawer.jsx` 的 `adminItems` 陣列（line 54-62），在第一項「轉蛋管理」後面加入：
+
+```javascript
+  { label: "活動 Banner", path: "/admin/gacha-banner", icon: CelebrationIcon },
+```
+
+並在頂部 import 區加入：
+
+```javascript
+import CelebrationIcon from "@mui/icons-material/Celebration";
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/App.jsx frontend/src/components/NavDrawer.jsx
+git commit -m "feat(frontend): register gacha banner routes and nav menu item"
+```
+
+---
+
+## Task 11: 歐洲抽 europe banner 花費支援
+
+**Files:**
+- Modify: `app/src/controller/princess/gacha.js`
+
+- [ ] **Step 1: 修改歐洲抽的花費邏輯**
+
+在 Task 6 Step 3 修改後的歐洲抽判斷處，將查到的 europe banner 存為變數，供後續花費使用。
+
+將 Step 3 中的歐洲抽判斷改為：
+
+```javascript
+  // 歐洲抽：查詢是否有進行中的 europe banner
+  let activeEuropeBanner = null;
+  if (europe) {
+    const europeBanners = await GachaBanner.getActiveBanners({ type: "europe" });
+    if (europeBanners.length === 0) {
+      return context.replyText(i18n.__("message.gacha.cross_year_only"));
+    }
+    activeEuropeBanner = europeBanners[0];
+  }
+```
+
+然後修改 line 246 附近的 `europeCost` 計算：
+
+將：
+```javascript
+  const europeCost = config.get("gacha.europe_cost");
+```
+
+改為：
+```javascript
+  const europeCost = (activeEuropeBanner && activeEuropeBanner.cost > 0)
+    ? activeEuropeBanner.cost
+    : config.get("gacha.europe_cost");
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/controller/princess/gacha.js
+git commit -m "feat(gacha): support dynamic europe banner cost from admin config"
+```
+
+---
+
+## Task 12: 整合驗證
+
+- [ ] **Step 1: 執行 migration**
+
+Run: `cd /home/hanshino/workspace/redive_linebot/app && npx knex migrate:latest`
+
+- [ ] **Step 2: 執行後端 lint**
+
+Run: `cd /home/hanshino/workspace/redive_linebot/app && yarn lint`
+
+- [ ] **Step 3: 執行後端測試**
+
+Run: `cd /home/hanshino/workspace/redive_linebot/app && yarn test`
+
+- [ ] **Step 4: 執行前端 build 驗證**
+
+Run: `cd /home/hanshino/workspace/redive_linebot/frontend && yarn build`
+
+- [ ] **Step 5: 修正任何 lint/test/build 錯誤**
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: fix lint and build issues for gacha banner feature"
+```

--- a/docs/superpowers/plans/2026-04-10-frontend-auth-admin-guard.md
+++ b/docs/superpowers/plans/2026-04-10-frontend-auth-admin-guard.md
@@ -1,0 +1,576 @@
+# Frontend Auth & Admin Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix infinite reload loop on unauthorized admin page access by adding proper 401/403 HTTP semantics, auth context with admin info, route guards, and nav visibility control.
+
+**Architecture:** Backend middleware returns 403 for authorization failures (was 401). Frontend LiffProvider calls `/api/me` on login to populate `isAdmin`. A `RequireAdmin` layout route guard protects admin routes. The axios interceptor handles 401 (clear token, redirect home) and 403 (fire event, redirect home) separately.
+
+**Tech Stack:** Express middleware (backend), React 17+, react-router-dom v6, MUI Snackbar, axios interceptors, CustomEvent API.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-frontend-auth-admin-guard-design.md`
+
+---
+
+### Task 1: Backend — Return 403 for authorization failures
+
+**Files:**
+- Modify: `app/src/middleware/validation.js:70-96` (verifyAdmin, verifyPrivilege)
+- Modify: `app/src/middleware/validation.js:141-143` (add Forbidden helper)
+
+- [ ] **Step 1: Add `Forbidden` helper function**
+
+At the bottom of `app/src/middleware/validation.js`, add the `Forbidden` helper next to the existing `Unauthorized`:
+
+```js
+function Forbidden(res) {
+  res.status(403).json({ message: "forbidden" });
+}
+```
+
+- [ ] **Step 2: Change `verifyAdmin` to return 403**
+
+In `app/src/middleware/validation.js`, change line 75:
+
+```js
+// Before:
+if (adminData === undefined) return Unauthorized(res);
+
+// After:
+if (adminData === undefined) return Forbidden(res);
+```
+
+- [ ] **Step 3: Change `verifyPrivilege` to return 403**
+
+In `app/src/middleware/validation.js`, change line 91:
+
+```js
+// Before:
+if (privilege < allow) {
+  return Unauthorized(res);
+}
+
+// After:
+if (privilege < allow) {
+  return Forbidden(res);
+}
+```
+
+- [ ] **Step 4: Verify `verifyToken` is unchanged**
+
+Confirm `verifyToken` (lines 44-68) still calls `Unauthorized(res)` — this is correct because invalid/missing tokens are 401.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/middleware/validation.js
+git commit -m "fix(auth): return 403 for authorization failures instead of 401
+
+verifyAdmin and verifyPrivilege now return 403 Forbidden when the user
+is authenticated but lacks admin privileges. verifyToken remains 401
+for invalid/missing tokens. This lets the frontend distinguish between
+'not logged in' and 'not authorized'."
+```
+
+---
+
+### Task 2: Frontend — Refactor API interceptor for 401/403
+
+**Files:**
+- Modify: `frontend/src/services/api.js:17-28`
+
+- [ ] **Step 1: Replace the interceptor**
+
+Replace the entire interceptor block in `frontend/src/services/api.js` (lines 17-28):
+
+```js
+// Before:
+// Clear expired token and reload on 401
+api.interceptors.response.use(
+  res => res,
+  err => {
+    if (err.response?.status === 401) {
+      window.localStorage.removeItem(TOKEN_KEY);
+      clearAuthToken();
+      window.location.reload();
+    }
+    return Promise.reject(err);
+  }
+);
+
+// After:
+api.interceptors.response.use(
+  res => res,
+  err => {
+    const status = err.response?.status;
+    if (status === 401) {
+      window.localStorage.removeItem(TOKEN_KEY);
+      clearAuthToken();
+      window.location.href = "/";
+    } else if (status === 403) {
+      window.dispatchEvent(new CustomEvent("auth:forbidden"));
+      window.location.href = "/";
+    }
+    return Promise.reject(err);
+  }
+);
+```
+
+Key changes:
+- 401: `window.location.reload()` → `window.location.href = "/"` (breaks the infinite loop)
+- 403: new handler — dispatches `auth:forbidden` event, redirects home, does NOT clear token
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/services/api.js
+git commit -m "fix(api): handle 401 and 403 separately in axios interceptor
+
+401 clears token and redirects to home (not reload, which caused
+infinite loops). 403 dispatches auth:forbidden event for UI notification
+and redirects to home without clearing the token."
+```
+
+---
+
+### Task 3: Frontend — Add admin info to LiffProvider context
+
+**Files:**
+- Modify: `frontend/src/context/LiffProvider.jsx`
+
+- [ ] **Step 1: Add `isAdmin` and `profile` state**
+
+In `LiffProvider.jsx`, add new state variables after the existing ones (after line 34):
+
+```js
+const [profile, setProfile] = useState(null);
+const [isAdmin, setIsAdmin] = useState(false);
+```
+
+- [ ] **Step 2: Create `fetchProfile` helper**
+
+Add a helper function inside `LiffProvider` (before the `useEffect`), that calls `/api/me` and populates admin state:
+
+```js
+const fetchProfile = useCallback(async () => {
+  try {
+    const { data } = await api.get("/api/me");
+    setProfile(data);
+    setIsAdmin(data.privilege !== undefined);
+  } catch {
+    // Token invalid or network error — treat as not logged in
+    window.localStorage.removeItem(TOKEN_KEY);
+    clearAuthToken();
+    setLoggedIn(false);
+    setProfile(null);
+    setIsAdmin(false);
+  }
+}, []);
+```
+
+Add `useCallback` to the import from "react" if not already present.
+
+- [ ] **Step 3: Call `fetchProfile` in the fast-path (stored token)**
+
+Replace the fast-path block (lines 42-47) to call `fetchProfile` before setting `ready`:
+
+```js
+// Before:
+if (!isLiffRoute && storedToken) {
+  setAuthToken(storedToken);
+  setLoggedIn(true);
+  setReady(true);
+  return;
+}
+
+// After:
+if (!isLiffRoute && storedToken) {
+  setAuthToken(storedToken);
+  setLoggedIn(true);
+  fetchProfile().finally(() => setReady(true));
+  return;
+}
+```
+
+This ensures `isAdmin` and `profile` are populated before `ready` becomes `true`.
+
+- [ ] **Step 4: Call `fetchProfile` in the LIFF-path**
+
+In the LIFF route block (lines 50-67), add `fetchProfile()` after setting the token. Replace the `.then` chain:
+
+```js
+// Before:
+if (isLiffRoute) {
+  initPromiseRef.current = initLiffSdk()
+    .then(() => {
+      if (liff.isLoggedIn()) {
+        const token = liff.getAccessToken();
+        window.localStorage.setItem(TOKEN_KEY, token);
+        setAuthToken(token);
+        setLoggedIn(true);
+        try {
+          setLiffCtx(liff.getContext() || {});
+        } catch (err) {
+          console.warn("Failed to get LIFF context:", err);
+        }
+      }
+    })
+    .catch(err => console.warn("LIFF init failed:", err))
+    .finally(() => setReady(true));
+  return;
+}
+
+// After:
+if (isLiffRoute) {
+  initPromiseRef.current = initLiffSdk()
+    .then(async () => {
+      if (liff.isLoggedIn()) {
+        const token = liff.getAccessToken();
+        window.localStorage.setItem(TOKEN_KEY, token);
+        setAuthToken(token);
+        setLoggedIn(true);
+        try {
+          setLiffCtx(liff.getContext() || {});
+        } catch (err) {
+          console.warn("Failed to get LIFF context:", err);
+        }
+        await fetchProfile();
+      }
+    })
+    .catch(err => console.warn("LIFF init failed:", err))
+    .finally(() => setReady(true));
+  return;
+}
+```
+
+- [ ] **Step 5: Update `logout` to clear new state**
+
+In the `logout` callback (lines 90-99), add cleanup for the new state:
+
+```js
+const logout = useCallback(() => {
+  window.localStorage.removeItem(TOKEN_KEY);
+  clearAuthToken();
+  setProfile(null);
+  setIsAdmin(false);
+  try {
+    liff.logout();
+  } catch {
+    // SDK not initialized, nothing to clean up
+  }
+  window.location.reload();
+}, []);
+```
+
+- [ ] **Step 6: Update context value**
+
+Update the `useMemo` value (lines 101-104) to include the new fields:
+
+```js
+// Before:
+const value = useMemo(
+  () => ({ ready, loggedIn, liffContext: liffCtx, login, logout }),
+  [ready, loggedIn, liffCtx, login, logout]
+);
+
+// After:
+const value = useMemo(
+  () => ({ ready, loggedIn, isAdmin, profile, liffContext: liffCtx, login, logout }),
+  [ready, loggedIn, isAdmin, profile, liffCtx, login, logout]
+);
+```
+
+- [ ] **Step 7: Update `LiffContext` default value**
+
+Update the `createContext` default (lines 10-16) to include the new fields:
+
+```js
+export const LiffContext = createContext({
+  ready: false,
+  loggedIn: false,
+  isAdmin: false,
+  profile: null,
+  liffContext: {},
+  login: () => {},
+  logout: () => {},
+});
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/context/LiffProvider.jsx
+git commit -m "feat(auth): add isAdmin and profile to LiffProvider context
+
+Call GET /api/me after login to fetch admin status. Context now provides
+isAdmin (boolean) and profile (user data). If /api/me fails, user is
+treated as not logged in. The /api/me call completes before ready=true
+so downstream components always have auth state."
+```
+
+---
+
+### Task 4: Frontend — Create RequireAdmin route guard
+
+**Files:**
+- Create: `frontend/src/components/RequireAdmin.jsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `frontend/src/components/RequireAdmin.jsx`:
+
+```jsx
+import { Navigate, Outlet } from "react-router-dom";
+import useLiff from "../context/useLiff";
+
+export default function RequireAdmin() {
+  const { loggedIn, isAdmin } = useLiff();
+
+  if (!loggedIn || !isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/components/RequireAdmin.jsx
+git commit -m "feat(auth): add RequireAdmin route guard component
+
+Layout route that checks loggedIn and isAdmin from LiffContext.
+Redirects to home if either check fails. Uses Outlet for child routes."
+```
+
+---
+
+### Task 5: Frontend — Wrap admin routes with RequireAdmin
+
+**Files:**
+- Modify: `frontend/src/App.jsx:1-109`
+
+- [ ] **Step 1: Add import**
+
+Add the import at the top of `frontend/src/App.jsx`, after the other component imports (after line 38):
+
+```js
+import RequireAdmin from "./components/RequireAdmin";
+```
+
+- [ ] **Step 2: Wrap admin routes**
+
+Replace the admin routes block (lines 84-101) with a nested layout route:
+
+```jsx
+// Before:
+          {/* Admin */}
+          <Route path="admin/gacha-pool" element={<AdminGachaPool />} />
+          <Route path="admin/gacha-pool/new" element={<AdminGachaPoolForm />} />
+          <Route path="admin/gacha-pool/:id/edit" element={<AdminGachaPoolForm />} />
+          <Route path="admin/gacha-banner" element={<AdminGachaBanner />} />
+          <Route path="admin/gacha-banner/new" element={<AdminGachaBannerForm />} />
+          <Route path="admin/gacha-banner/:id/edit" element={<AdminGachaBannerForm />} />
+          <Route path="admin/gacha-shop" element={<AdminGachaShop />} />
+          <Route path="admin/global-order" element={<AdminGlobalOrder />} />
+          <Route path="admin/messages" element={<AdminMessages />} />
+          <Route path="admin/worldboss" element={<AdminWorldboss />} />
+          <Route path="admin/worldboss-event" element={<AdminWorldbossEvent />} />
+          <Route path="admin/worldboss-message" element={<AdminWorldbossMessage />} />
+          <Route path="admin/worldboss-message/create" element={<AdminWorldbossMessageCreate />} />
+          <Route
+            path="admin/worldboss-message/update/:id"
+            element={<AdminWorldbossMessageUpdate />}
+          />
+
+// After:
+          {/* Admin — requires admin privilege */}
+          <Route element={<RequireAdmin />}>
+            <Route path="admin/gacha-pool" element={<AdminGachaPool />} />
+            <Route path="admin/gacha-pool/new" element={<AdminGachaPoolForm />} />
+            <Route path="admin/gacha-pool/:id/edit" element={<AdminGachaPoolForm />} />
+            <Route path="admin/gacha-banner" element={<AdminGachaBanner />} />
+            <Route path="admin/gacha-banner/new" element={<AdminGachaBannerForm />} />
+            <Route path="admin/gacha-banner/:id/edit" element={<AdminGachaBannerForm />} />
+            <Route path="admin/gacha-shop" element={<AdminGachaShop />} />
+            <Route path="admin/global-order" element={<AdminGlobalOrder />} />
+            <Route path="admin/messages" element={<AdminMessages />} />
+            <Route path="admin/worldboss" element={<AdminWorldboss />} />
+            <Route path="admin/worldboss-event" element={<AdminWorldbossEvent />} />
+            <Route path="admin/worldboss-message" element={<AdminWorldbossMessage />} />
+            <Route path="admin/worldboss-message/create" element={<AdminWorldbossMessageCreate />} />
+            <Route
+              path="admin/worldboss-message/update/:id"
+              element={<AdminWorldbossMessageUpdate />}
+            />
+          </Route>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/App.jsx
+git commit -m "feat(auth): protect admin routes with RequireAdmin guard
+
+All /admin/* routes now wrapped in RequireAdmin layout route. Non-admin
+users are redirected to home before any admin page component mounts."
+```
+
+---
+
+### Task 6: Frontend — Hide admin nav for non-admins
+
+**Files:**
+- Modify: `frontend/src/components/NavDrawer.jsx:122-123,187`
+
+- [ ] **Step 1: Destructure `isAdmin` from context**
+
+In `frontend/src/components/NavDrawer.jsx`, update the `useLiff()` call (line 123):
+
+```js
+// Before:
+const { loggedIn } = useLiff();
+
+// After:
+const { isAdmin } = useLiff();
+```
+
+- [ ] **Step 2: Change admin section visibility condition**
+
+Update line 187:
+
+```jsx
+// Before:
+      {loggedIn && (
+        <NavSection
+
+// After:
+      {isAdmin && (
+        <NavSection
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/NavDrawer.jsx
+git commit -m "fix(nav): hide admin section for non-admin users
+
+Admin nav group now checks isAdmin (from /api/me) instead of loggedIn.
+Non-admin users no longer see the admin menu items."
+```
+
+---
+
+### Task 7: Frontend — Add 403 Snackbar notification in MainLayout
+
+**Files:**
+- Modify: `frontend/src/layouts/MainLayout.jsx`
+
+- [ ] **Step 1: Add imports**
+
+Update the imports at the top of `frontend/src/layouts/MainLayout.jsx`:
+
+```js
+// Add useEffect to the react import (line 1):
+import { useState, useEffect } from "react";
+
+// Add Snackbar and Alert to the MUI import (lines 2-13):
+import {
+  Box,
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Divider,
+  Drawer,
+  Tooltip,
+  Snackbar,
+  Alert,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+```
+
+- [ ] **Step 2: Add forbidden state and event listener**
+
+Inside the `MainLayout` component, after the existing state declarations (after line 31), add:
+
+```js
+const [forbiddenOpen, setForbiddenOpen] = useState(false);
+
+useEffect(() => {
+  const handleForbidden = () => setForbiddenOpen(true);
+  window.addEventListener("auth:forbidden", handleForbidden);
+  return () => window.removeEventListener("auth:forbidden", handleForbidden);
+}, []);
+```
+
+- [ ] **Step 3: Add Snackbar JSX**
+
+Add the Snackbar at the end of the root `<Box>`, just before the closing `</Box>` (before line 128):
+
+```jsx
+      <Snackbar
+        open={forbiddenOpen}
+        autoHideDuration={3000}
+        onClose={() => setForbiddenOpen(false)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          onClose={() => setForbiddenOpen(false)}
+          severity="warning"
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          您沒有權限存取此頁面
+        </Alert>
+      </Snackbar>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/layouts/MainLayout.jsx
+git commit -m "feat(auth): show snackbar notification on 403 forbidden
+
+MainLayout listens for auth:forbidden CustomEvent dispatched by the
+axios interceptor. Shows a warning snackbar with '您沒有權限存取此頁面'."
+```
+
+---
+
+### Task 8: Verify — Build and manual smoke test
+
+- [ ] **Step 1: Run frontend build**
+
+```bash
+cd frontend && yarn build
+```
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 2: Run backend lint**
+
+```bash
+cd app && yarn lint
+```
+
+Expected: No new lint errors.
+
+- [ ] **Step 3: Manual verification checklist**
+
+Verify these scenarios work correctly:
+
+1. **Non-admin logged in:** Nav does NOT show admin section
+2. **Non-admin direct URL:** Navigating to `/admin/gacha-pool` redirects to `/` immediately (no API call, no reload loop)
+3. **Admin logged in:** Nav shows admin section, admin pages load normally
+4. **Token expired:** Any API call returns 401 → token cleared, redirected to `/`, no loop
+5. **Backend 403:** If an admin with insufficient privilege tries a high-privilege action, they see the warning snackbar and get redirected
+
+- [ ] **Step 4: Final commit (if any lint/build fixes needed)**
+
+```bash
+git add -A
+git commit -m "fix: address lint/build issues from auth guard implementation"
+```

--- a/docs/superpowers/specs/2026-04-10-frontend-auth-admin-guard-design.md
+++ b/docs/superpowers/specs/2026-04-10-frontend-auth-admin-guard-design.md
@@ -1,0 +1,231 @@
+# Frontend Auth & Admin Guard Design
+
+**Date:** 2026-04-10
+**Status:** Approved
+**Scope:** Fix infinite reload loop on unauthorized admin page access; add proper auth/permission handling
+
+---
+
+## Problem
+
+1. **NavDrawer** shows the admin section to all logged-in users (not just admins)
+2. **Admin routes** have no frontend guard — any user can navigate directly via URL
+3. **Axios 401 interceptor** does `window.location.reload()`, causing an infinite reload loop when a non-admin user lands on an admin page:
+   - Non-admin visits `/admin/*` → API returns 401 → interceptor clears token + reloads → LIFF re-authenticates (user is valid, just not admin) → page reloads at same URL → API returns 401 again → infinite loop
+4. **Backend** returns 401 for both "invalid token" and "insufficient privileges", making it impossible for the frontend to distinguish between the two cases
+
+## Solution Overview
+
+Six changes across backend and frontend to implement proper HTTP semantics and route-level protection.
+
+---
+
+## 1. Backend: Distinguish 401 vs 403
+
+**File:** `app/src/middleware/validation.js`
+
+### Current behavior
+
+- `verifyToken`, `verifyAdmin`, and `verifyPrivilege` all return **401** on failure
+
+### New behavior
+
+| Middleware | Failure meaning | Status code |
+|-----------|----------------|-------------|
+| `verifyToken` | Token missing or invalid (not authenticated) | **401** (unchanged) |
+| `verifyAdmin` | Valid token but user is not in Admin table | **403** |
+| `verifyPrivilege` | Valid token + admin, but privilege level too low | **403** |
+
+### Changes
+
+- Add `Forbidden(res)` helper: returns `res.status(403).json({ message: "forbidden" })`
+- `verifyAdmin`: change `Unauthorized(res)` → `Forbidden(res)`
+- `verifyPrivilege`: change `Unauthorized(res)` → `Forbidden(res)`
+- `verifyToken`: unchanged (remains 401)
+
+### Socket.IO
+
+- `socketVerifyAdmin`: change error message from generic to "forbidden" for consistency, but keep using `next(new Error(...))` pattern — socket auth failures are handled separately by the socket client
+
+---
+
+## 2. Frontend: Auth Context — Add Admin Info
+
+**File:** `frontend/src/context/LiffProvider.jsx`
+
+### Current state
+
+- Context provides: `{ ready, loggedIn, liffContext, login, logout }`
+- No knowledge of whether the user is an admin
+
+### New behavior
+
+- After setting the auth token (both fast-path and LIFF-path), call `GET /api/me`
+- Extract admin status from the response (presence of `privilege` field)
+- Context provides: `{ ready, loggedIn, isAdmin, profile, login, logout }`
+
+### Details
+
+- `isAdmin`: `true` if `/api/me` returns a `privilege` field, `false` otherwise
+- `profile`: the full `/api/me` response (`userId`, `displayName`, `pictureUrl`, and optionally `privilege`)
+- If `/api/me` fails (network error, 401), treat as not logged in — clear token, set `loggedIn = false`
+- The `/api/me` call must complete before `ready` becomes `true`, so downstream components always have auth state available
+
+---
+
+## 3. Frontend: API Interceptor — Separate 401/403 Handling
+
+**File:** `frontend/src/services/api.js`
+
+### Current behavior
+
+```js
+if (err.response?.status === 401) {
+  window.localStorage.removeItem(TOKEN_KEY);
+  clearAuthToken();
+  window.location.reload(); // causes infinite loop
+}
+```
+
+### New behavior
+
+- **401 (Unauthorized):** Token is invalid/expired. Clear token from localStorage, clear auth header, redirect to `"/"` (not reload).
+- **403 (Forbidden):** User is authenticated but lacks permission. Do NOT clear token. Dispatch a `CustomEvent("auth:forbidden")` so the UI layer can show a notification. Redirect to `"/"`.
+
+### Implementation
+
+```js
+api.interceptors.response.use(
+  res => res,
+  err => {
+    const status = err.response?.status;
+    if (status === 401) {
+      window.localStorage.removeItem(TOKEN_KEY);
+      clearAuthToken();
+      window.location.href = "/";
+    } else if (status === 403) {
+      window.dispatchEvent(new CustomEvent("auth:forbidden"));
+      window.location.href = "/";
+    }
+    return Promise.reject(err);
+  }
+);
+```
+
+### Why CustomEvent
+
+- The interceptor is outside React's component tree (plain axios module)
+- `CustomEvent` lets any React component subscribe via `useEffect` + `addEventListener`
+- MainLayout listens for `auth:forbidden` and shows a Snackbar notification
+
+---
+
+## 4. Frontend: RequireAdmin Route Guard
+
+**New file:** `frontend/src/components/RequireAdmin.jsx`
+
+### Behavior
+
+- Reads `loggedIn` and `isAdmin` from LiffContext
+- If not logged in → `<Navigate to="/" replace />`
+- If logged in but not admin → `<Navigate to="/" replace />`
+- If logged in and admin → `<Outlet />` (render child routes)
+
+### Implementation
+
+```jsx
+import { Navigate, Outlet } from "react-router-dom";
+import useLiff from "../context/useLiff";
+
+export default function RequireAdmin() {
+  const { loggedIn, isAdmin } = useLiff();
+  if (!loggedIn || !isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+  return <Outlet />;
+}
+```
+
+Uses `<Outlet />` so it works as a layout route wrapper in react-router-dom v6.
+
+---
+
+## 5. Frontend: Wrap Admin Routes
+
+**File:** `frontend/src/App.jsx`
+
+### Current structure
+
+```jsx
+{/* Admin */}
+<Route path="admin/gacha-pool" element={<AdminGachaPool />} />
+<Route path="admin/gacha-pool/new" element={<AdminGachaPoolForm />} />
+...
+```
+
+### New structure
+
+```jsx
+{/* Admin — requires admin privilege */}
+<Route element={<RequireAdmin />}>
+  <Route path="admin/gacha-pool" element={<AdminGachaPool />} />
+  <Route path="admin/gacha-pool/new" element={<AdminGachaPoolForm />} />
+  ...all admin routes...
+</Route>
+```
+
+All existing admin routes move inside the `<RequireAdmin />` layout route. No path changes needed.
+
+---
+
+## 6. Frontend: NavDrawer — Hide Admin for Non-Admins
+
+**File:** `frontend/src/components/NavDrawer.jsx`
+
+### Current (line 187)
+
+```jsx
+{loggedIn && (
+  <NavSection title="管理員" items={adminItems} ... />
+)}
+```
+
+### New
+
+```jsx
+{isAdmin && (
+  <NavSection title="管理員" items={adminItems} ... />
+)}
+```
+
+Where `isAdmin` comes from `useLiff()`.
+
+---
+
+## 7. Frontend: MainLayout — 403 Snackbar
+
+**File:** `frontend/src/layouts/MainLayout.jsx`
+
+- Add a `useEffect` listener for the `auth:forbidden` CustomEvent
+- On event, show a Snackbar: "您沒有權限存取此頁面"
+- Use existing Snackbar/HintSnackBar pattern from the project
+
+---
+
+## Files Changed
+
+| File | Change type | Description |
+|------|------------|-------------|
+| `app/src/middleware/validation.js` | Modify | verifyAdmin/verifyPrivilege return 403 |
+| `frontend/src/context/LiffProvider.jsx` | Modify | Call /api/me, expose isAdmin + profile |
+| `frontend/src/services/api.js` | Modify | 401 redirect home, 403 event + redirect |
+| `frontend/src/components/RequireAdmin.jsx` | **New** | Route guard component |
+| `frontend/src/App.jsx` | Modify | Wrap admin routes with RequireAdmin |
+| `frontend/src/components/NavDrawer.jsx` | Modify | loggedIn → isAdmin for admin section |
+| `frontend/src/layouts/MainLayout.jsx` | Modify | Listen for auth:forbidden, show Snackbar |
+
+## Out of Scope
+
+- Granular per-privilege route guards (e.g., showing different admin pages based on privilege 1 vs 9) — can be added later if needed
+- Refactoring other pages (Group, Trade, etc.) to use route guards for `loggedIn` — separate concern
+- Backend returning 403 for non-admin socket.io connections — socket auth has its own error handling

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,8 @@ import BattleSign from "./pages/Panel/BattleSign";
 import CustomerOrder from "./pages/CustomerOrder";
 import AdminGachaPool from "./pages/Admin/GachaPool";
 import AdminGachaPoolForm from "./pages/Admin/GachaPool/GachaPoolForm";
+import AdminGachaBanner from "./pages/Admin/GachaBanner";
+import AdminGachaBannerForm from "./pages/Admin/GachaBanner/GachaBannerForm";
 import AdminGachaShop from "./pages/Admin/GachaShop";
 import AdminGlobalOrder from "./pages/Admin/GlobalOrder";
 import AdminMessages from "./pages/Admin/Messages";
@@ -83,6 +85,9 @@ export default function App() {
           <Route path="admin/gacha-pool" element={<AdminGachaPool />} />
           <Route path="admin/gacha-pool/new" element={<AdminGachaPoolForm />} />
           <Route path="admin/gacha-pool/:id/edit" element={<AdminGachaPoolForm />} />
+          <Route path="admin/gacha-banner" element={<AdminGachaBanner />} />
+          <Route path="admin/gacha-banner/new" element={<AdminGachaBannerForm />} />
+          <Route path="admin/gacha-banner/:id/edit" element={<AdminGachaBannerForm />} />
           <Route path="admin/gacha-shop" element={<AdminGachaShop />} />
           <Route path="admin/global-order" element={<AdminGlobalOrder />} />
           <Route path="admin/messages" element={<AdminMessages />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,7 @@ import AdminWorldbossMessage from "./pages/Admin/WorldbossMessage";
 import AdminWorldbossMessageCreate from "./pages/Admin/WorldbossMessageCreate";
 import AdminWorldbossMessageUpdate from "./pages/Admin/WorldbossMessageUpdate";
 import ToolsBattleTime from "./pages/Tools/BattleTime";
+import RequireAdmin from "./components/RequireAdmin";
 
 export default function App() {
   return (
@@ -81,24 +82,29 @@ export default function App() {
           {/* Customer Order */}
           <Route path="source/:sourceId/customer/orders" element={<CustomerOrder />} />
 
-          {/* Admin */}
-          <Route path="admin/gacha-pool" element={<AdminGachaPool />} />
-          <Route path="admin/gacha-pool/new" element={<AdminGachaPoolForm />} />
-          <Route path="admin/gacha-pool/:id/edit" element={<AdminGachaPoolForm />} />
-          <Route path="admin/gacha-banner" element={<AdminGachaBanner />} />
-          <Route path="admin/gacha-banner/new" element={<AdminGachaBannerForm />} />
-          <Route path="admin/gacha-banner/:id/edit" element={<AdminGachaBannerForm />} />
-          <Route path="admin/gacha-shop" element={<AdminGachaShop />} />
-          <Route path="admin/global-order" element={<AdminGlobalOrder />} />
-          <Route path="admin/messages" element={<AdminMessages />} />
-          <Route path="admin/worldboss" element={<AdminWorldboss />} />
-          <Route path="admin/worldboss-event" element={<AdminWorldbossEvent />} />
-          <Route path="admin/worldboss-message" element={<AdminWorldbossMessage />} />
-          <Route path="admin/worldboss-message/create" element={<AdminWorldbossMessageCreate />} />
-          <Route
-            path="admin/worldboss-message/update/:id"
-            element={<AdminWorldbossMessageUpdate />}
-          />
+          {/* Admin — requires admin privilege */}
+          <Route element={<RequireAdmin />}>
+            <Route path="admin/gacha-pool" element={<AdminGachaPool />} />
+            <Route path="admin/gacha-pool/new" element={<AdminGachaPoolForm />} />
+            <Route path="admin/gacha-pool/:id/edit" element={<AdminGachaPoolForm />} />
+            <Route path="admin/gacha-banner" element={<AdminGachaBanner />} />
+            <Route path="admin/gacha-banner/new" element={<AdminGachaBannerForm />} />
+            <Route path="admin/gacha-banner/:id/edit" element={<AdminGachaBannerForm />} />
+            <Route path="admin/gacha-shop" element={<AdminGachaShop />} />
+            <Route path="admin/global-order" element={<AdminGlobalOrder />} />
+            <Route path="admin/messages" element={<AdminMessages />} />
+            <Route path="admin/worldboss" element={<AdminWorldboss />} />
+            <Route path="admin/worldboss-event" element={<AdminWorldbossEvent />} />
+            <Route path="admin/worldboss-message" element={<AdminWorldbossMessage />} />
+            <Route
+              path="admin/worldboss-message/create"
+              element={<AdminWorldbossMessageCreate />}
+            />
+            <Route
+              path="admin/worldboss-message/update/:id"
+              element={<AdminWorldbossMessageUpdate />}
+            />
+          </Route>
 
           {/* Tools */}
           <Route path="tools/battle-time" element={<ToolsBattleTime />} />

--- a/frontend/src/components/DebugOverlay.jsx
+++ b/frontend/src/components/DebugOverlay.jsx
@@ -1,0 +1,136 @@
+import { useState, useEffect, useCallback } from "react";
+import { Box, IconButton, Typography, Chip } from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import CloseIcon from "@mui/icons-material/Close";
+import { getDebugLogs, formatDebugLogs, isDebugMode } from "../utils/debugLogger";
+
+export default function DebugOverlay() {
+  const [expanded, setExpanded] = useState(true);
+  const [logs, setLogs] = useState([]);
+  const [copied, setCopied] = useState(false);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (!isDebugMode()) return;
+    const interval = setInterval(() => {
+      setLogs([...getDebugLogs()]);
+    }, 500);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(formatDebugLogs());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement("textarea");
+      textarea.value = formatDebugLogs();
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, []);
+
+  if (!isDebugMode() || !visible) return null;
+
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        bgcolor: "rgba(0, 0, 0, 0.9)",
+        color: "#0f0",
+        fontFamily: "monospace",
+        fontSize: "11px",
+        maxHeight: expanded ? "50vh" : "36px",
+        transition: "max-height 0.2s",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Header bar */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          px: 1,
+          py: 0.5,
+          borderBottom: expanded ? "1px solid #333" : "none",
+          minHeight: "36px",
+          gap: 0.5,
+        }}
+      >
+        <Typography sx={{ fontSize: "11px", fontFamily: "monospace", color: "#0f0", flex: 1 }}>
+          DEBUG ({logs.length})
+        </Typography>
+        {copied && (
+          <Chip
+            label="Copied!"
+            size="small"
+            sx={{ height: 20, fontSize: "10px", bgcolor: "#2e7d32", color: "#fff" }}
+          />
+        )}
+        <IconButton size="small" onClick={handleCopy} sx={{ color: "#0f0", p: 0.5 }}>
+          <ContentCopyIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+        <IconButton
+          size="small"
+          onClick={() => setExpanded(v => !v)}
+          sx={{ color: "#0f0", p: 0.5 }}
+        >
+          {expanded ? (
+            <ExpandMoreIcon sx={{ fontSize: 16 }} />
+          ) : (
+            <ExpandLessIcon sx={{ fontSize: 16 }} />
+          )}
+        </IconButton>
+        <IconButton size="small" onClick={() => setVisible(false)} sx={{ color: "#666", p: 0.5 }}>
+          <CloseIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+      </Box>
+
+      {/* Log entries */}
+      {expanded && (
+        <Box sx={{ overflow: "auto", flex: 1, px: 1, py: 0.5 }}>
+          {logs.map((log, i) => (
+            <Box key={i} sx={{ py: 0.25, lineHeight: 1.4 }}>
+              <Typography
+                component="span"
+                sx={{ color: "#666", fontSize: "11px", fontFamily: "monospace" }}
+              >
+                [{log.timestamp}]
+              </Typography>{" "}
+              <Typography
+                component="span"
+                sx={{ color: "#4fc3f7", fontSize: "11px", fontFamily: "monospace" }}
+              >
+                {log.event}
+              </Typography>{" "}
+              <Typography
+                component="span"
+                sx={{ color: "#aaa", fontSize: "11px", fontFamily: "monospace" }}
+              >
+                {log.dataStr}
+              </Typography>
+            </Box>
+          ))}
+          {logs.length === 0 && (
+            <Typography sx={{ color: "#666", fontSize: "11px", fontFamily: "monospace" }}>
+              Waiting for events...
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/DebugOverlay.jsx
+++ b/frontend/src/components/DebugOverlay.jsx
@@ -4,7 +4,8 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CloseIcon from "@mui/icons-material/Close";
-import { getDebugLogs, formatDebugLogs, isDebugMode } from "../utils/debugLogger";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { getDebugLogs, formatDebugLogs, isDebugMode, clearDebugLogs } from "../utils/debugLogger";
 
 export default function DebugOverlay() {
   const [expanded, setExpanded] = useState(true);
@@ -82,6 +83,16 @@ export default function DebugOverlay() {
         )}
         <IconButton size="small" onClick={handleCopy} sx={{ color: "#0f0", p: 0.5 }}>
           <ContentCopyIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+        <IconButton
+          size="small"
+          onClick={() => {
+            clearDebugLogs();
+            setLogs([]);
+          }}
+          sx={{ color: "#f44336", p: 0.5 }}
+        >
+          <DeleteOutlineIcon sx={{ fontSize: 16 }} />
         </IconButton>
         <IconButton
           size="small"

--- a/frontend/src/components/DebugOverlay.jsx
+++ b/frontend/src/components/DebugOverlay.jsx
@@ -16,7 +16,8 @@ export default function DebugOverlay() {
   useEffect(() => {
     if (!isDebugMode()) return;
     const interval = setInterval(() => {
-      setLogs([...getDebugLogs()]);
+      const current = getDebugLogs();
+      setLogs(prev => (prev.length === current.length ? prev : [...current]));
     }, 500);
     return () => clearInterval(interval);
   }, []);

--- a/frontend/src/components/NavDrawer.jsx
+++ b/frontend/src/components/NavDrawer.jsx
@@ -29,6 +29,7 @@ import GitHubIcon from "@mui/icons-material/GitHub";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import LinkIcon from "@mui/icons-material/Link";
+import CelebrationIcon from "@mui/icons-material/Celebration";
 
 const mainItems = [
   { label: "首頁", path: "/", icon: HomeIcon },
@@ -53,6 +54,7 @@ const personalItems = [
 
 const adminItems = [
   { label: "轉蛋管理", path: "/admin/gacha-pool", icon: SportsEsportsIcon },
+  { label: "活動 Banner", path: "/admin/gacha-banner", icon: CelebrationIcon },
   { label: "女神石商店", path: "/admin/gacha-shop", icon: StorefrontIcon },
   { label: "全群指令管理", path: "/admin/global-order", icon: MessageIcon },
   { label: "訊息實況", path: "/admin/messages", icon: MessageIcon },

--- a/frontend/src/components/NavDrawer.jsx
+++ b/frontend/src/components/NavDrawer.jsx
@@ -120,7 +120,7 @@ function NavSection({ title, items, open, onToggle, onNavigate, currentPath }) {
 }
 
 export default function NavDrawer({ onClose }) {
-  const { loggedIn } = useLiff();
+  const { isAdmin } = useLiff();
   const location = useLocation();
   const navigate = useNavigate();
   const [openSections, setOpenSections] = useState({
@@ -184,7 +184,7 @@ export default function NavDrawer({ onClose }) {
         onNavigate={handleNavigate}
         currentPath={location.pathname}
       />
-      {loggedIn && (
+      {isAdmin && (
         <NavSection
           title="管理員"
           items={adminItems}

--- a/frontend/src/components/NavDrawer.jsx
+++ b/frontend/src/components/NavDrawer.jsx
@@ -53,8 +53,8 @@ const personalItems = [
 ];
 
 const adminItems = [
-  { label: "轉蛋管理", path: "/admin/gacha-pool", icon: SportsEsportsIcon },
-  { label: "活動 Banner", path: "/admin/gacha-banner", icon: CelebrationIcon },
+  { label: "角色卡池", path: "/admin/gacha-pool", icon: SportsEsportsIcon },
+  { label: "轉蛋活動", path: "/admin/gacha-banner", icon: CelebrationIcon },
   { label: "女神石商店", path: "/admin/gacha-shop", icon: StorefrontIcon },
   { label: "全群指令管理", path: "/admin/global-order", icon: MessageIcon },
   { label: "訊息實況", path: "/admin/messages", icon: MessageIcon },

--- a/frontend/src/components/RequireAdmin.jsx
+++ b/frontend/src/components/RequireAdmin.jsx
@@ -1,0 +1,12 @@
+import { Navigate, Outlet } from "react-router-dom";
+import useLiff from "../context/useLiff";
+
+export default function RequireAdmin() {
+  const { loggedIn, isAdmin } = useLiff();
+
+  if (!loggedIn || !isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/frontend/src/context/LiffProvider.jsx
+++ b/frontend/src/context/LiffProvider.jsx
@@ -2,6 +2,7 @@ import { createContext, useEffect, useRef, useState, useMemo, useCallback } from
 import liff from "@line/liff";
 import api, { setAuthToken, clearAuthToken } from "../services/api";
 import { FullPageLoading } from "../components/Loading";
+import { debugLog } from "../utils/debugLogger";
 
 const TOKEN_KEY = "liff_access_token";
 const SIZE_KEY = "liff_size";
@@ -39,11 +40,15 @@ export default function LiffProvider({ children }) {
   const initPromiseRef = useRef(null);
 
   const fetchProfile = useCallback(async () => {
+    debugLog("FETCH_PROFILE_START");
     try {
       const { data } = await api.get("/api/me");
       setProfile(data);
-      setIsAdmin(data.privilege !== undefined);
-    } catch {
+      const admin = data.privilege !== undefined;
+      setIsAdmin(admin);
+      debugLog("FETCH_PROFILE_OK", { isAdmin: admin, userId: data.userId?.substring(0, 8) });
+    } catch (err) {
+      debugLog("FETCH_PROFILE_FAIL", { status: err.response?.status, message: err.message });
       // Token invalid or network error — treat as not logged in
       window.localStorage.removeItem(TOKEN_KEY);
       clearAuthToken();
@@ -56,12 +61,21 @@ export default function LiffProvider({ children }) {
   useEffect(() => {
     const isLiffRoute = window.location.pathname.startsWith("/liff/");
     const storedToken = window.localStorage.getItem(TOKEN_KEY);
+    debugLog("INIT_START", {
+      route: window.location.pathname,
+      isLiffRoute,
+      hasStoredToken: !!storedToken,
+    });
 
     // Fast path: not a LIFF route and we have a stored token
     if (!isLiffRoute && storedToken) {
       setAuthToken(storedToken);
       setLoggedIn(true);
-      fetchProfile().finally(() => setReady(true));
+      debugLog("FAST_PATH", { tokenPrefix: storedToken.substring(0, 8) });
+      fetchProfile().finally(() => {
+        debugLog("READY", { path: "fast" });
+        setReady(true);
+      });
       return;
     }
 
@@ -69,8 +83,10 @@ export default function LiffProvider({ children }) {
     if (isLiffRoute) {
       initPromiseRef.current = initLiffSdk()
         .then(async () => {
+          debugLog("LIFF_SDK_INIT", { success: true });
           if (liff.isLoggedIn()) {
             const token = liff.getAccessToken();
+            debugLog("LIFF_LOGGED_IN", { tokenPrefix: token?.substring(0, 8) });
             window.localStorage.setItem(TOKEN_KEY, token);
             setAuthToken(token);
             setLoggedIn(true);
@@ -80,14 +96,23 @@ export default function LiffProvider({ children }) {
               console.warn("Failed to get LIFF context:", err);
             }
             await fetchProfile();
+          } else {
+            debugLog("LIFF_NOT_LOGGED_IN");
           }
         })
-        .catch(err => console.warn("LIFF init failed:", err))
-        .finally(() => setReady(true));
+        .catch(err => {
+          debugLog("LIFF_SDK_INIT", { success: false, error: err.message });
+          console.warn("LIFF init failed:", err);
+        })
+        .finally(() => {
+          debugLog("READY", { path: "liff" });
+          setReady(true);
+        });
       return;
     }
 
     // Non-LIFF route, no stored token: just mark ready (not logged in)
+    debugLog("READY", { path: "no-token" });
     setReady(true);
   }, []);
 

--- a/frontend/src/context/LiffProvider.jsx
+++ b/frontend/src/context/LiffProvider.jsx
@@ -38,6 +38,7 @@ export default function LiffProvider({ children }) {
   const [profile, setProfile] = useState(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const initPromiseRef = useRef(null);
+  const initStartedRef = useRef(false);
 
   const fetchProfile = useCallback(async () => {
     debugLog("FETCH_PROFILE_START");
@@ -59,6 +60,10 @@ export default function LiffProvider({ children }) {
   }, []);
 
   useEffect(() => {
+    // Guard against StrictMode double-invoke — ref survives unmount/remount
+    if (initStartedRef.current) return;
+    initStartedRef.current = true;
+
     const isLiffRoute = window.location.pathname.startsWith("/liff/");
     const storedToken = window.localStorage.getItem(TOKEN_KEY);
     debugLog("INIT_START", {
@@ -81,7 +86,10 @@ export default function LiffProvider({ children }) {
 
     // LIFF route: full SDK init to process OAuth code
     if (isLiffRoute) {
-      initPromiseRef.current = initLiffSdk()
+      if (!initPromiseRef.current) {
+        initPromiseRef.current = initLiffSdk();
+      }
+      initPromiseRef.current
         .then(async () => {
           debugLog("LIFF_SDK_INIT", { success: true });
           if (liff.isLoggedIn()) {

--- a/frontend/src/context/LiffProvider.jsx
+++ b/frontend/src/context/LiffProvider.jsx
@@ -10,6 +10,8 @@ const DEFAULT_SIZE = "full";
 export const LiffContext = createContext({
   ready: false,
   loggedIn: false,
+  isAdmin: false,
+  profile: null,
   liffContext: {},
   login: () => {},
   logout: () => {},
@@ -32,7 +34,24 @@ export default function LiffProvider({ children }) {
   const [ready, setReady] = useState(false);
   const [loggedIn, setLoggedIn] = useState(false);
   const [liffCtx, setLiffCtx] = useState({});
+  const [profile, setProfile] = useState(null);
+  const [isAdmin, setIsAdmin] = useState(false);
   const initPromiseRef = useRef(null);
+
+  const fetchProfile = useCallback(async () => {
+    try {
+      const { data } = await api.get("/api/me");
+      setProfile(data);
+      setIsAdmin(data.privilege !== undefined);
+    } catch {
+      // Token invalid or network error — treat as not logged in
+      window.localStorage.removeItem(TOKEN_KEY);
+      clearAuthToken();
+      setLoggedIn(false);
+      setProfile(null);
+      setIsAdmin(false);
+    }
+  }, []);
 
   useEffect(() => {
     const isLiffRoute = window.location.pathname.startsWith("/liff/");
@@ -42,14 +61,14 @@ export default function LiffProvider({ children }) {
     if (!isLiffRoute && storedToken) {
       setAuthToken(storedToken);
       setLoggedIn(true);
-      setReady(true);
+      fetchProfile().finally(() => setReady(true));
       return;
     }
 
     // LIFF route: full SDK init to process OAuth code
     if (isLiffRoute) {
       initPromiseRef.current = initLiffSdk()
-        .then(() => {
+        .then(async () => {
           if (liff.isLoggedIn()) {
             const token = liff.getAccessToken();
             window.localStorage.setItem(TOKEN_KEY, token);
@@ -60,6 +79,7 @@ export default function LiffProvider({ children }) {
             } catch (err) {
               console.warn("Failed to get LIFF context:", err);
             }
+            await fetchProfile();
           }
         })
         .catch(err => console.warn("LIFF init failed:", err))
@@ -90,6 +110,8 @@ export default function LiffProvider({ children }) {
   const logout = useCallback(() => {
     window.localStorage.removeItem(TOKEN_KEY);
     clearAuthToken();
+    setProfile(null);
+    setIsAdmin(false);
     try {
       liff.logout();
     } catch {
@@ -99,8 +121,8 @@ export default function LiffProvider({ children }) {
   }, []);
 
   const value = useMemo(
-    () => ({ ready, loggedIn, liffContext: liffCtx, login, logout }),
-    [ready, loggedIn, liffCtx, login, logout]
+    () => ({ ready, loggedIn, isAdmin, profile, liffContext: liffCtx, login, logout }),
+    [ready, loggedIn, isAdmin, profile, liffCtx, login, logout]
   );
 
   if (!ready) {

--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -20,6 +20,7 @@ import LightModeIcon from "@mui/icons-material/LightMode";
 import LoginIcon from "@mui/icons-material/Login";
 import LogoutIcon from "@mui/icons-material/Logout";
 import NavDrawer from "../components/NavDrawer";
+import DebugOverlay from "../components/DebugOverlay";
 import { useColorMode } from "../theme/ColorModeContext";
 import useLiff from "../context/useLiff";
 
@@ -155,6 +156,7 @@ export default function MainLayout() {
           您沒有權限存取此頁面
         </Alert>
       </Snackbar>
+      <DebugOverlay />
     </Box>
   );
 }

--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import {
   Box,
@@ -9,6 +9,8 @@ import {
   Divider,
   Drawer,
   Tooltip,
+  Snackbar,
+  Alert,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
@@ -29,6 +31,14 @@ export default function MainLayout() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const { mode, toggleColorMode } = useColorMode();
   const { loggedIn, ready, login, logout } = useLiff();
+
+  const [forbiddenOpen, setForbiddenOpen] = useState(false);
+
+  useEffect(() => {
+    const handleForbidden = () => setForbiddenOpen(true);
+    window.addEventListener("auth:forbidden", handleForbidden);
+    return () => window.removeEventListener("auth:forbidden", handleForbidden);
+  }, []);
 
   return (
     <Box sx={{ display: "flex", minHeight: "100vh" }}>
@@ -61,7 +71,11 @@ export default function MainLayout() {
           </Tooltip>
           {ready && (
             <>
-              <Divider orientation="vertical" flexItem sx={{ mx: 0.5, borderColor: "rgba(255,255,255,0.3)" }} />
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={{ mx: 0.5, borderColor: "rgba(255,255,255,0.3)" }}
+              />
               <Tooltip title={loggedIn ? "登出" : "登入"}>
                 <IconButton
                   color="inherit"
@@ -125,6 +139,22 @@ export default function MainLayout() {
       >
         <Outlet />
       </Box>
+
+      <Snackbar
+        open={forbiddenOpen}
+        autoHideDuration={3000}
+        onClose={() => setForbiddenOpen(false)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          onClose={() => setForbiddenOpen(false)}
+          severity="warning"
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          您沒有權限存取此頁面
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx
+++ b/frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx
@@ -65,14 +65,17 @@ export default function GachaBannerForm() {
   const fetchInitialData = useCallback(async () => {
     try {
       setLoading(true);
-      const poolData = await gachaPoolService.fetchData();
+      const [poolData, banner] = await Promise.all([
+        gachaPoolService.fetchData(),
+        isEdit ? gachaBannerService.fetchBanner(id) : Promise.resolve(null),
+      ]);
+
       const ssrCharacters = poolData
         .filter(c => parseInt(c.star, 10) === 3)
         .map(c => ({ id: c.id, name: c.name, imageUrl: c.imageUrl }));
       setCharacters(ssrCharacters);
 
-      if (isEdit) {
-        const banner = await gachaBannerService.fetchBanner(id);
+      if (banner) {
         setFormData({
           name: banner.name || "",
           type: banner.type || "rate_up",

--- a/frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx
+++ b/frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx
@@ -1,0 +1,356 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Button,
+  TextField,
+  MenuItem,
+  Typography,
+  Stack,
+  Paper,
+  IconButton,
+  Chip,
+  Autocomplete,
+  Switch,
+  FormControlLabel,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import SaveIcon from "@mui/icons-material/Save";
+import HintSnackBar from "../../../components/HintSnackBar";
+import { FullPageLoading } from "../../../components/Loading";
+import useHintBar from "../../../hooks/useHintBar";
+import * as gachaBannerService from "../../../services/gachaBanner";
+import * as gachaPoolService from "../../../services/gachaPool";
+
+const TYPE_OPTIONS = [
+  { value: "rate_up", label: "機率提升" },
+  { value: "europe", label: "歐洲抽" },
+];
+
+const EMPTY_FORM = {
+  name: "",
+  type: "rate_up",
+  rate_boost: 150,
+  cost: 0,
+  start_at: "",
+  end_at: "",
+  is_active: true,
+  characterIds: [],
+};
+
+function toLocalDateTimeString(dateStr) {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  const offset = d.getTimezoneOffset();
+  const local = new Date(d.getTime() - offset * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
+export default function GachaBannerForm() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isDark = theme.palette.mode === "dark";
+  const isEdit = Boolean(id);
+
+  const [formData, setFormData] = useState(EMPTY_FORM);
+  const [characters, setCharacters] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [hintState, { handleOpen: showHint, handleClose: closeHint }] = useHintBar();
+
+  const fetchInitialData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const poolData = await gachaPoolService.fetchData();
+      const ssrCharacters = poolData
+        .filter((c) => parseInt(c.star, 10) === 3)
+        .map((c) => ({ id: c.id, name: c.name, imageUrl: c.imageUrl }));
+      setCharacters(ssrCharacters);
+
+      if (isEdit) {
+        const banner = await gachaBannerService.fetchBanner(id);
+        setFormData({
+          name: banner.name || "",
+          type: banner.type || "rate_up",
+          rate_boost: banner.rate_boost || 0,
+          cost: banner.cost || 0,
+          start_at: toLocalDateTimeString(banner.start_at),
+          end_at: toLocalDateTimeString(banner.end_at),
+          is_active: Boolean(banner.is_active),
+          characterIds: banner.characterIds || [],
+        });
+      }
+    } catch {
+      showHint("載入資料失敗", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [id, isEdit, showHint]);
+
+  useEffect(() => {
+    document.title = isEdit ? "編輯 Banner" : "新增 Banner";
+    fetchInitialData();
+  }, [isEdit, fetchInitialData]);
+
+  const handleChange = (field) => (e) => {
+    setFormData((prev) => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleSave = async () => {
+    if (!formData.name.trim()) {
+      showHint("請輸入 Banner 名稱", "warning");
+      return;
+    }
+    if (!formData.start_at || !formData.end_at) {
+      showHint("請設定活動時間", "warning");
+      return;
+    }
+    if (new Date(formData.start_at) >= new Date(formData.end_at)) {
+      showHint("結束時間必須晚於開始時間", "warning");
+      return;
+    }
+
+    const payload = {
+      name: formData.name,
+      type: formData.type,
+      rate_boost: formData.type === "rate_up" ? parseInt(formData.rate_boost, 10) : 0,
+      cost: formData.type === "europe" ? parseInt(formData.cost, 10) : 0,
+      start_at: new Date(formData.start_at).toISOString(),
+      end_at: new Date(formData.end_at).toISOString(),
+      is_active: formData.is_active,
+      characterIds: formData.type === "rate_up" ? formData.characterIds : [],
+    };
+
+    try {
+      setSaving(true);
+      if (isEdit) {
+        await gachaBannerService.updateBanner(Number(id), payload);
+      } else {
+        await gachaBannerService.createBanner(payload);
+      }
+      showHint(isEdit ? "更新成功" : "新增成功", "success");
+      setTimeout(() => navigate("/admin/gacha-banner"), 800);
+    } catch {
+      showHint(isEdit ? "更新失敗" : "新增失敗", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <FullPageLoading />;
+  }
+
+  const selectedCharacters = characters.filter((c) =>
+    formData.characterIds.includes(c.id)
+  );
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: 640, mx: "auto", pb: 10 }}>
+      {/* Header */}
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 3 }}>
+        <IconButton
+          onClick={() => navigate("/admin/gacha-banner")}
+          sx={{
+            bgcolor: isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.04)",
+            "&:hover": { bgcolor: isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.08)" },
+          }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          {isEdit ? "編輯 Banner" : "新增 Banner"}
+        </Typography>
+      </Stack>
+
+      {/* Form */}
+      <Paper
+        elevation={0}
+        sx={{ p: { xs: 2.5, sm: 3 }, borderRadius: 3, border: 1, borderColor: "divider" }}
+      >
+        <Stack spacing={2.5}>
+          <Typography variant="overline" sx={{ color: "text.secondary", fontWeight: 700 }}>
+            基本設定
+          </Typography>
+
+          <TextField
+            fullWidth
+            label="Banner 名稱"
+            value={formData.name}
+            onChange={handleChange("name")}
+            required
+          />
+
+          <TextField
+            fullWidth
+            select
+            label="活動類型"
+            value={formData.type}
+            onChange={handleChange("type")}
+          >
+            {TYPE_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={formData.is_active}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, is_active: e.target.checked }))
+                }
+              />
+            }
+            label="啟用"
+          />
+
+          {/* 時間設定 */}
+          <Typography variant="overline" sx={{ color: "text.secondary", fontWeight: 700, mt: 1 }}>
+            活動時間
+          </Typography>
+
+          <Stack direction={isMobile ? "column" : "row"} spacing={2}>
+            <TextField
+              fullWidth
+              label="開始時間"
+              type="datetime-local"
+              value={formData.start_at}
+              onChange={handleChange("start_at")}
+              required
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+            <TextField
+              fullWidth
+              label="結束時間"
+              type="datetime-local"
+              value={formData.end_at}
+              onChange={handleChange("end_at")}
+              required
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+          </Stack>
+
+          {/* rate_up 專用欄位 */}
+          {formData.type === "rate_up" && (
+            <>
+              <Typography
+                variant="overline"
+                sx={{ color: "text.secondary", fontWeight: 700, mt: 1 }}
+              >
+                機率提升設定
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="機率加成 (%)"
+                value={formData.rate_boost}
+                onChange={handleChange("rate_boost")}
+                type="number"
+                helperText="例如 150 表示指定角色機率變為 (100+150)/100 = 2.5 倍"
+                slotProps={{ htmlInput: { min: 0, step: 10 } }}
+              />
+
+              <Autocomplete
+                multiple
+                options={characters}
+                getOptionLabel={(option) => option.name}
+                value={selectedCharacters}
+                onChange={(_, newValue) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    characterIds: newValue.map((c) => c.id),
+                  }))
+                }
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                renderTags={(value, getTagProps) =>
+                  value.map((option, index) => (
+                    <Chip
+                      label={option.name}
+                      size="small"
+                      {...getTagProps({ index })}
+                      key={option.id}
+                    />
+                  ))
+                }
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="選擇加成角色（僅 SSR）"
+                    placeholder="搜尋角色名稱..."
+                  />
+                )}
+              />
+            </>
+          )}
+
+          {/* europe 專用欄位 */}
+          {formData.type === "europe" && (
+            <>
+              <Typography
+                variant="overline"
+                sx={{ color: "text.secondary", fontWeight: 700, mt: 1 }}
+              >
+                歐洲抽設定
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="花費女神石"
+                value={formData.cost}
+                onChange={handleChange("cost")}
+                type="number"
+                helperText="設為 0 則使用系統預設值 (10,000)"
+                slotProps={{ htmlInput: { min: 0, step: 100 } }}
+              />
+            </>
+          )}
+        </Stack>
+      </Paper>
+
+      {/* Sticky Save Button */}
+      <Box
+        sx={{
+          position: "fixed",
+          bottom: 0,
+          left: { xs: 0, md: 260 },
+          right: 0,
+          p: 2,
+          bgcolor: "background.paper",
+          borderTop: 1,
+          borderColor: "divider",
+          zIndex: (t) => t.zIndex.appBar - 1,
+          backdropFilter: "blur(8px)",
+          backgroundColor: isDark ? "rgba(10,26,42,0.92)" : "rgba(255,255,255,0.92)",
+        }}
+      >
+        <Box sx={{ maxWidth: 640, mx: "auto" }}>
+          <Button
+            fullWidth
+            variant="contained"
+            size="large"
+            startIcon={<SaveIcon />}
+            onClick={handleSave}
+            disabled={saving}
+            sx={{ py: 1.5, fontWeight: 700, fontSize: "1rem", borderRadius: 2, boxShadow: 3 }}
+          >
+            {saving ? "儲存中..." : isEdit ? "儲存變更" : "新增 Banner"}
+          </Button>
+        </Box>
+      </Box>
+
+      <HintSnackBar
+        open={hintState.open}
+        message={hintState.message}
+        severity={hintState.severity}
+        onClose={closeHint}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx
+++ b/frontend/src/pages/Admin/GachaBanner/GachaBannerForm.jsx
@@ -67,8 +67,8 @@ export default function GachaBannerForm() {
       setLoading(true);
       const poolData = await gachaPoolService.fetchData();
       const ssrCharacters = poolData
-        .filter((c) => parseInt(c.star, 10) === 3)
-        .map((c) => ({ id: c.id, name: c.name, imageUrl: c.imageUrl }));
+        .filter(c => parseInt(c.star, 10) === 3)
+        .map(c => ({ id: c.id, name: c.name, imageUrl: c.imageUrl }));
       setCharacters(ssrCharacters);
 
       if (isEdit) {
@@ -92,17 +92,17 @@ export default function GachaBannerForm() {
   }, [id, isEdit, showHint]);
 
   useEffect(() => {
-    document.title = isEdit ? "編輯 Banner" : "新增 Banner";
+    document.title = isEdit ? "編輯轉蛋活動" : "新增轉蛋活動";
     fetchInitialData();
   }, [isEdit, fetchInitialData]);
 
-  const handleChange = (field) => (e) => {
-    setFormData((prev) => ({ ...prev, [field]: e.target.value }));
+  const handleChange = field => e => {
+    setFormData(prev => ({ ...prev, [field]: e.target.value }));
   };
 
   const handleSave = async () => {
     if (!formData.name.trim()) {
-      showHint("請輸入 Banner 名稱", "warning");
+      showHint("請輸入活動名稱", "warning");
       return;
     }
     if (!formData.start_at || !formData.end_at) {
@@ -145,9 +145,7 @@ export default function GachaBannerForm() {
     return <FullPageLoading />;
   }
 
-  const selectedCharacters = characters.filter((c) =>
-    formData.characterIds.includes(c.id)
-  );
+  const selectedCharacters = characters.filter(c => formData.characterIds.includes(c.id));
 
   return (
     <Box sx={{ width: "100%", maxWidth: 640, mx: "auto", pb: 10 }}>
@@ -163,7 +161,7 @@ export default function GachaBannerForm() {
           <ArrowBackIcon />
         </IconButton>
         <Typography variant="h5" sx={{ fontWeight: 700 }}>
-          {isEdit ? "編輯 Banner" : "新增 Banner"}
+          {isEdit ? "編輯活動" : "新增活動"}
         </Typography>
       </Stack>
 
@@ -179,7 +177,7 @@ export default function GachaBannerForm() {
 
           <TextField
             fullWidth
-            label="Banner 名稱"
+            label="活動名稱"
             value={formData.name}
             onChange={handleChange("name")}
             required
@@ -192,24 +190,12 @@ export default function GachaBannerForm() {
             value={formData.type}
             onChange={handleChange("type")}
           >
-            {TYPE_OPTIONS.map((opt) => (
+            {TYPE_OPTIONS.map(opt => (
               <MenuItem key={opt.value} value={opt.value}>
                 {opt.label}
               </MenuItem>
             ))}
           </TextField>
-
-          <FormControlLabel
-            control={
-              <Switch
-                checked={formData.is_active}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, is_active: e.target.checked }))
-                }
-              />
-            }
-            label="啟用"
-          />
 
           {/* 時間設定 */}
           <Typography variant="overline" sx={{ color: "text.secondary", fontWeight: 700, mt: 1 }}>
@@ -249,23 +235,23 @@ export default function GachaBannerForm() {
 
               <TextField
                 fullWidth
-                label="機率加成 (%)"
+                label="機率加成基數"
                 value={formData.rate_boost}
                 onChange={handleChange("rate_boost")}
                 type="number"
-                helperText="例如 150 表示指定角色機率變為 (100+150)/100 = 2.5 倍"
-                slotProps={{ htmlInput: { min: 0, step: 10 } }}
+                helperText="輸入 100 → 角色機率 ×2 倍、150 → ×2.5 倍、200 → ×3 倍"
+                slotProps={{ htmlInput: { min: 0, max: 1000, step: 10 } }}
               />
 
               <Autocomplete
                 multiple
                 options={characters}
-                getOptionLabel={(option) => option.name}
+                getOptionLabel={option => option.name}
                 value={selectedCharacters}
                 onChange={(_, newValue) =>
-                  setFormData((prev) => ({
+                  setFormData(prev => ({
                     ...prev,
-                    characterIds: newValue.map((c) => c.id),
+                    characterIds: newValue.map(c => c.id),
                   }))
                 }
                 isOptionEqualToValue={(option, value) => option.id === value.id}
@@ -279,7 +265,7 @@ export default function GachaBannerForm() {
                     />
                   ))
                 }
-                renderInput={(params) => (
+                renderInput={params => (
                   <TextField
                     {...params}
                     label="選擇加成角色（僅 SSR）"
@@ -303,14 +289,27 @@ export default function GachaBannerForm() {
               <TextField
                 fullWidth
                 label="花費女神石"
-                value={formData.cost}
+                value={formData.cost || ""}
                 onChange={handleChange("cost")}
                 type="number"
-                helperText="設為 0 則使用系統預設值 (10,000)"
+                placeholder="10000"
+                helperText="留空則使用系統預設值（每次抽卡花費 10,000 女神石）"
                 slotProps={{ htmlInput: { min: 0, step: 100 } }}
               />
             </>
           )}
+
+          {/* 啟用開關 */}
+          <FormControlLabel
+            control={
+              <Switch
+                checked={formData.is_active}
+                onChange={e => setFormData(prev => ({ ...prev, is_active: e.target.checked }))}
+              />
+            }
+            label="立即啟用此活動"
+            sx={{ mt: 1 }}
+          />
         </Stack>
       </Paper>
 
@@ -325,7 +324,7 @@ export default function GachaBannerForm() {
           bgcolor: "background.paper",
           borderTop: 1,
           borderColor: "divider",
-          zIndex: (t) => t.zIndex.appBar - 1,
+          zIndex: t => t.zIndex.appBar - 1,
           backdropFilter: "blur(8px)",
           backgroundColor: isDark ? "rgba(10,26,42,0.92)" : "rgba(255,255,255,0.92)",
         }}
@@ -340,7 +339,7 @@ export default function GachaBannerForm() {
             disabled={saving}
             sx={{ py: 1.5, fontWeight: 700, fontSize: "1rem", borderRadius: 2, boxShadow: 3 }}
           >
-            {saving ? "儲存中..." : isEdit ? "儲存變更" : "新增 Banner"}
+            {saving ? "儲存中..." : isEdit ? "儲存變更" : "新增活動"}
           </Button>
         </Box>
       </Box>

--- a/frontend/src/pages/Admin/GachaBanner/index.jsx
+++ b/frontend/src/pages/Admin/GachaBanner/index.jsx
@@ -55,7 +55,7 @@ export default function AdminGachaBanner() {
     try {
       setLoading(true);
       const data = await gachaBannerService.fetchBanners();
-      setRows(data.sort((a, b) => new Date(b.start_at) - new Date(a.start_at)));
+      setRows(data);
     } catch {
       showHint("載入資料失敗", "error");
     } finally {
@@ -151,93 +151,95 @@ export default function AdminGachaBanner() {
             </Button>
           </Box>
         )}
-        {rows.map((banner, index) => (
-          <Box key={banner.id}>
-            {index > 0 && <Divider />}
-            <Box
-              sx={{
-                px: { xs: 2.5, sm: 3 },
-                py: { xs: 2, sm: 2.5 },
-                display: "flex",
-                alignItems: "center",
-                gap: 2,
-              }}
-            >
-              <CelebrationIcon
+        {rows.map((banner, index) => {
+          const status = getBannerStatus(banner);
+          return (
+            <Box key={banner.id}>
+              {index > 0 && <Divider />}
+              <Box
                 sx={{
-                  fontSize: 32,
-                  color:
-                    getBannerStatus(banner).color === "success" ? "warning.main" : "text.disabled",
+                  px: { xs: 2.5, sm: 3 },
+                  py: { xs: 2, sm: 2.5 },
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 2,
                 }}
-              />
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Stack
-                  direction="row"
-                  spacing={1}
-                  alignItems="center"
-                  flexWrap="wrap"
-                  sx={{ mb: 0.5 }}
-                >
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                    {banner.name}
+              >
+                <CelebrationIcon
+                  sx={{
+                    fontSize: 32,
+                    color: status.color === "success" ? "warning.main" : "text.disabled",
+                  }}
+                />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    alignItems="center"
+                    flexWrap="wrap"
+                    sx={{ mb: 0.5 }}
+                  >
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                      {banner.name}
+                    </Typography>
+                    <Chip
+                      label={TYPE_CONFIG[banner.type]?.label || banner.type}
+                      color={TYPE_CONFIG[banner.type]?.color || "default"}
+                      size="small"
+                    />
+                    <Chip
+                      label={status.label}
+                      color={status.color}
+                      size="small"
+                      variant="outlined"
+                    />
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDateTime(banner.start_at)} ～ {formatDateTime(banner.end_at)}
                   </Typography>
-                  <Chip
-                    label={TYPE_CONFIG[banner.type]?.label || banner.type}
-                    color={TYPE_CONFIG[banner.type]?.color || "default"}
-                    size="small"
-                  />
-                  <Chip
-                    label={getBannerStatus(banner).label}
-                    color={getBannerStatus(banner).color}
-                    size="small"
-                    variant="outlined"
-                  />
+                  {banner.type === "rate_up" && (
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                      機率加成: {banner.rate_boost}%
+                    </Typography>
+                  )}
+                  {banner.type === "europe" && banner.cost > 0 && (
+                    <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                      花費: {banner.cost} 女神石
+                    </Typography>
+                  )}
+                </Box>
+                <Stack direction="row" spacing={0.5}>
+                  <Tooltip title="編輯" arrow>
+                    <IconButton
+                      size="small"
+                      onClick={() => navigate(`/admin/gacha-banner/${banner.id}/edit`)}
+                      sx={{
+                        color: "primary.main",
+                        transition: "all 0.2s",
+                        "&:hover": { bgcolor: "primary.main", color: "primary.contrastText" },
+                      }}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="刪除" arrow>
+                    <IconButton
+                      size="small"
+                      onClick={() => handleDeleteClick(banner)}
+                      sx={{
+                        color: "error.main",
+                        transition: "all 0.2s",
+                        "&:hover": { bgcolor: "error.main", color: "error.contrastText" },
+                      }}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
                 </Stack>
-                <Typography variant="caption" color="text.secondary">
-                  {formatDateTime(banner.start_at)} ～ {formatDateTime(banner.end_at)}
-                </Typography>
-                {banner.type === "rate_up" && (
-                  <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
-                    機率加成: {banner.rate_boost}%
-                  </Typography>
-                )}
-                {banner.type === "europe" && banner.cost > 0 && (
-                  <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
-                    花費: {banner.cost} 女神石
-                  </Typography>
-                )}
               </Box>
-              <Stack direction="row" spacing={0.5}>
-                <Tooltip title="編輯" arrow>
-                  <IconButton
-                    size="small"
-                    onClick={() => navigate(`/admin/gacha-banner/${banner.id}/edit`)}
-                    sx={{
-                      color: "primary.main",
-                      transition: "all 0.2s",
-                      "&:hover": { bgcolor: "primary.main", color: "primary.contrastText" },
-                    }}
-                  >
-                    <EditIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="刪除" arrow>
-                  <IconButton
-                    size="small"
-                    onClick={() => handleDeleteClick(banner)}
-                    sx={{
-                      color: "error.main",
-                      transition: "all 0.2s",
-                      "&:hover": { bgcolor: "error.main", color: "error.contrastText" },
-                    }}
-                  >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              </Stack>
             </Box>
-          </Box>
-        ))}
+          );
+        })}
       </Paper>
 
       <AlertDialog

--- a/frontend/src/pages/Admin/GachaBanner/index.jsx
+++ b/frontend/src/pages/Admin/GachaBanner/index.jsx
@@ -33,10 +33,12 @@ function formatDateTime(value) {
   return new Date(value).toLocaleString("zh-TW");
 }
 
-function isActive(banner) {
-  if (!banner.is_active) return false;
+function getBannerStatus(banner) {
+  if (!banner.is_active) return { label: "已停用", color: "default" };
   const now = new Date();
-  return new Date(banner.start_at) <= now && new Date(banner.end_at) >= now;
+  if (new Date(banner.start_at) > now) return { label: "待開始", color: "info" };
+  if (new Date(banner.end_at) < now) return { label: "已結束", color: "default" };
+  return { label: "進行中", color: "success" };
 }
 
 export default function AdminGachaBanner() {
@@ -53,7 +55,7 @@ export default function AdminGachaBanner() {
     try {
       setLoading(true);
       const data = await gachaBannerService.fetchBanners();
-      setRows(data);
+      setRows(data.sort((a, b) => new Date(b.start_at) - new Date(a.start_at)));
     } catch {
       showHint("載入資料失敗", "error");
     } finally {
@@ -62,14 +64,14 @@ export default function AdminGachaBanner() {
   }, [showHint]);
 
   useEffect(() => {
-    document.title = "活動 Banner 管理";
+    document.title = "轉蛋活動管理";
     fetchData();
   }, [fetchData]);
 
-  const handleDeleteClick = (row) => {
+  const handleDeleteClick = row => {
     showAlert({
       title: "確認刪除",
-      description: `確定要刪除 Banner「${row.name}」嗎？`,
+      description: `確定要刪除活動「${row.name}」嗎？`,
       onSubmit: async () => {
         try {
           await gachaBannerService.deleteBanner(row.id);
@@ -107,10 +109,10 @@ export default function AdminGachaBanner() {
         <Stack direction="row" justifyContent="space-between" alignItems="center">
           <Box>
             <Typography variant="h5" sx={{ fontWeight: 700 }}>
-              活動 Banner 管理
+              轉蛋活動管理
             </Typography>
             <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
-              共 {rows.length} 個 Banner
+              共 {rows.length} 個活動
             </Typography>
           </Box>
           <Button
@@ -119,7 +121,7 @@ export default function AdminGachaBanner() {
             onClick={() => navigate("/admin/gacha-banner/new")}
             sx={{ borderRadius: 2, px: 2.5, boxShadow: 2 }}
           >
-            新增 Banner
+            新增活動
           </Button>
         </Stack>
       </Paper>
@@ -127,10 +129,26 @@ export default function AdminGachaBanner() {
       {/* Banner List */}
       <Paper elevation={0} sx={{ borderRadius: 3, border: 1, borderColor: "divider" }}>
         {rows.length === 0 && (
-          <Box sx={{ p: 3 }}>
-            <Typography variant="body2" color="text.secondary">
-              尚無 Banner 資料
+          <Box
+            sx={{
+              py: 8,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 2,
+            }}
+          >
+            <CelebrationIcon sx={{ fontSize: 48, color: "text.disabled" }} />
+            <Typography variant="body1" color="text.secondary">
+              尚無活動資料
             </Typography>
+            <Button
+              variant="outlined"
+              startIcon={<AddIcon />}
+              onClick={() => navigate("/admin/gacha-banner/new")}
+            >
+              新增第一個活動
+            </Button>
           </Box>
         )}
         {rows.map((banner, index) => (
@@ -148,11 +166,18 @@ export default function AdminGachaBanner() {
               <CelebrationIcon
                 sx={{
                   fontSize: 32,
-                  color: isActive(banner) ? "warning.main" : "text.disabled",
+                  color:
+                    getBannerStatus(banner).color === "success" ? "warning.main" : "text.disabled",
                 }}
               />
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  flexWrap="wrap"
+                  sx={{ mb: 0.5 }}
+                >
                   <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                     {banner.name}
                   </Typography>
@@ -161,11 +186,12 @@ export default function AdminGachaBanner() {
                     color={TYPE_CONFIG[banner.type]?.color || "default"}
                     size="small"
                   />
-                  {isActive(banner) ? (
-                    <Chip label="進行中" color="success" size="small" variant="outlined" />
-                  ) : (
-                    <Chip label="未啟用" size="small" variant="outlined" />
-                  )}
+                  <Chip
+                    label={getBannerStatus(banner).label}
+                    color={getBannerStatus(banner).color}
+                    size="small"
+                    variant="outlined"
+                  />
                 </Stack>
                 <Typography variant="caption" color="text.secondary">
                   {formatDateTime(banner.start_at)} ～ {formatDateTime(banner.end_at)}
@@ -186,7 +212,11 @@ export default function AdminGachaBanner() {
                   <IconButton
                     size="small"
                     onClick={() => navigate(`/admin/gacha-banner/${banner.id}/edit`)}
-                    sx={{ color: "primary.main" }}
+                    sx={{
+                      color: "primary.main",
+                      transition: "all 0.2s",
+                      "&:hover": { bgcolor: "primary.main", color: "primary.contrastText" },
+                    }}
                   >
                     <EditIcon fontSize="small" />
                   </IconButton>
@@ -195,7 +225,11 @@ export default function AdminGachaBanner() {
                   <IconButton
                     size="small"
                     onClick={() => handleDeleteClick(banner)}
-                    sx={{ color: "error.main" }}
+                    sx={{
+                      color: "error.main",
+                      transition: "all 0.2s",
+                      "&:hover": { bgcolor: "error.main", color: "error.contrastText" },
+                    }}
                   >
                     <DeleteIcon fontSize="small" />
                   </IconButton>

--- a/frontend/src/pages/Admin/GachaBanner/index.jsx
+++ b/frontend/src/pages/Admin/GachaBanner/index.jsx
@@ -1,0 +1,225 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Button,
+  Typography,
+  Chip,
+  IconButton,
+  Stack,
+  Paper,
+  Tooltip,
+  Divider,
+  useTheme,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import CelebrationIcon from "@mui/icons-material/Celebration";
+import { FullPageLoading } from "../../../components/Loading";
+import HintSnackBar from "../../../components/HintSnackBar";
+import AlertDialog from "../../../components/AlertDialog";
+import useHintBar from "../../../hooks/useHintBar";
+import useAlertDialog from "../../../hooks/useAlertDialog";
+import * as gachaBannerService from "../../../services/gachaBanner";
+
+const TYPE_CONFIG = {
+  rate_up: { label: "機率提升", color: "warning" },
+  europe: { label: "歐洲抽", color: "info" },
+};
+
+function formatDateTime(value) {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("zh-TW");
+}
+
+function isActive(banner) {
+  if (!banner.is_active) return false;
+  const now = new Date();
+  return new Date(banner.start_at) <= now && new Date(banner.end_at) >= now;
+}
+
+export default function AdminGachaBanner() {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [hintState, { handleOpen: showHint, handleClose: closeHint }] = useHintBar();
+  const [alertState, { handleOpen: showAlert, handleClose: closeAlert }] = useAlertDialog();
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await gachaBannerService.fetchBanners();
+      setRows(data);
+    } catch {
+      showHint("載入資料失敗", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showHint]);
+
+  useEffect(() => {
+    document.title = "活動 Banner 管理";
+    fetchData();
+  }, [fetchData]);
+
+  const handleDeleteClick = (row) => {
+    showAlert({
+      title: "確認刪除",
+      description: `確定要刪除 Banner「${row.name}」嗎？`,
+      onSubmit: async () => {
+        try {
+          await gachaBannerService.deleteBanner(row.id);
+          showHint("刪除成功", "success");
+          fetchData();
+        } catch {
+          showHint("刪除失敗", "error");
+        } finally {
+          closeAlert();
+        }
+      },
+    });
+  };
+
+  if (loading && rows.length === 0) {
+    return <FullPageLoading />;
+  }
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      {/* Header */}
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 2, sm: 3 },
+          mb: 3,
+          borderRadius: 3,
+          border: 1,
+          borderColor: "divider",
+          background: isDark
+            ? "linear-gradient(135deg, rgba(251,191,36,0.08) 0%, rgba(168,85,247,0.06) 100%)"
+            : "linear-gradient(135deg, rgba(245,158,11,0.06) 0%, rgba(168,85,247,0.04) 100%)",
+        }}
+      >
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            <Typography variant="h5" sx={{ fontWeight: 700 }}>
+              活動 Banner 管理
+            </Typography>
+            <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+              共 {rows.length} 個 Banner
+            </Typography>
+          </Box>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => navigate("/admin/gacha-banner/new")}
+            sx={{ borderRadius: 2, px: 2.5, boxShadow: 2 }}
+          >
+            新增 Banner
+          </Button>
+        </Stack>
+      </Paper>
+
+      {/* Banner List */}
+      <Paper elevation={0} sx={{ borderRadius: 3, border: 1, borderColor: "divider" }}>
+        {rows.length === 0 && (
+          <Box sx={{ p: 3 }}>
+            <Typography variant="body2" color="text.secondary">
+              尚無 Banner 資料
+            </Typography>
+          </Box>
+        )}
+        {rows.map((banner, index) => (
+          <Box key={banner.id}>
+            {index > 0 && <Divider />}
+            <Box
+              sx={{
+                px: { xs: 2.5, sm: 3 },
+                py: { xs: 2, sm: 2.5 },
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+              }}
+            >
+              <CelebrationIcon
+                sx={{
+                  fontSize: 32,
+                  color: isActive(banner) ? "warning.main" : "text.disabled",
+                }}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    {banner.name}
+                  </Typography>
+                  <Chip
+                    label={TYPE_CONFIG[banner.type]?.label || banner.type}
+                    color={TYPE_CONFIG[banner.type]?.color || "default"}
+                    size="small"
+                  />
+                  {isActive(banner) ? (
+                    <Chip label="進行中" color="success" size="small" variant="outlined" />
+                  ) : (
+                    <Chip label="未啟用" size="small" variant="outlined" />
+                  )}
+                </Stack>
+                <Typography variant="caption" color="text.secondary">
+                  {formatDateTime(banner.start_at)} ～ {formatDateTime(banner.end_at)}
+                </Typography>
+                {banner.type === "rate_up" && (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                    機率加成: {banner.rate_boost}%
+                  </Typography>
+                )}
+                {banner.type === "europe" && banner.cost > 0 && (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                    花費: {banner.cost} 女神石
+                  </Typography>
+                )}
+              </Box>
+              <Stack direction="row" spacing={0.5}>
+                <Tooltip title="編輯" arrow>
+                  <IconButton
+                    size="small"
+                    onClick={() => navigate(`/admin/gacha-banner/${banner.id}/edit`)}
+                    sx={{ color: "primary.main" }}
+                  >
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="刪除" arrow>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleDeleteClick(banner)}
+                    sx={{ color: "error.main" }}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+            </Box>
+          </Box>
+        ))}
+      </Paper>
+
+      <AlertDialog
+        open={alertState.open}
+        onClose={closeAlert}
+        onSubmit={alertState.onSubmit}
+        onCancel={closeAlert}
+        title={alertState.title}
+        description={alertState.description}
+      />
+      <HintSnackBar
+        open={hintState.open}
+        message={hintState.message}
+        severity={hintState.severity}
+        onClose={closeHint}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -14,14 +14,18 @@ export function clearAuthToken() {
   delete api.defaults.headers.common["Authorization"];
 }
 
-// Clear expired token and reload on 401
+// Clear expired token and redirect on 401; dispatch event and redirect on 403
 api.interceptors.response.use(
   res => res,
   err => {
-    if (err.response?.status === 401) {
+    const status = err.response?.status;
+    if (status === 401) {
       window.localStorage.removeItem(TOKEN_KEY);
       clearAuthToken();
-      window.location.reload();
+      window.location.href = "/";
+    } else if (status === 403) {
+      window.dispatchEvent(new CustomEvent("auth:forbidden"));
+      window.location.href = "/";
     }
     return Promise.reject(err);
   }

--- a/frontend/src/services/gachaBanner.js
+++ b/frontend/src/services/gachaBanner.js
@@ -1,0 +1,16 @@
+import api from "./api";
+
+export const fetchBanners = () =>
+  api.get("/api/admin/gacha-banners").then(r => r.data);
+
+export const fetchBanner = (id) =>
+  api.get(`/api/admin/gacha-banners/${id}`).then(r => r.data);
+
+export const createBanner = (data) =>
+  api.post("/api/admin/gacha-banners", data).then(r => r.data);
+
+export const updateBanner = (id, data) =>
+  api.put(`/api/admin/gacha-banners/${id}`, data).then(r => r.data);
+
+export const deleteBanner = (id) =>
+  api.delete(`/api/admin/gacha-banners/${id}`).then(r => r.data);

--- a/frontend/src/utils/debugLogger.js
+++ b/frontend/src/utils/debugLogger.js
@@ -1,0 +1,54 @@
+const logs = [];
+const startTime = Date.now();
+
+function isDebugEnabled() {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("debug") === "1") {
+    window.localStorage.setItem("liff_debug", "1");
+    return true;
+  }
+  return window.localStorage.getItem("liff_debug") === "1";
+}
+
+const debugEnabled = isDebugEnabled();
+
+export function debugLog(event, data = {}) {
+  if (!debugEnabled) return;
+  const elapsed = Date.now() - startTime;
+  const mins = Math.floor(elapsed / 60000);
+  const secs = Math.floor((elapsed % 60000) / 1000);
+  const ms = elapsed % 1000;
+  const timestamp = `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}.${String(ms).padStart(3, "0")}`;
+
+  const dataStr = Object.entries(data)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(" ");
+  const entry = { timestamp, event, dataStr, raw: data };
+  logs.push(entry);
+
+  // Also log to console for desktop debugging
+  console.log(`[DEBUG ${timestamp}] ${event} ${dataStr}`);
+}
+
+export function getDebugLogs() {
+  return logs;
+}
+
+export function formatDebugLogs() {
+  const header = [
+    `LIFF Debug Log`,
+    `URL: ${window.location.href}`,
+    `UA: ${navigator.userAgent}`,
+    `Time: ${new Date().toISOString()}`,
+    `---`,
+  ].join("\n");
+
+  const body = logs.map(l => `[${l.timestamp}] ${l.event} ${l.dataStr}`).join("\n");
+
+  return `${header}\n${body}`;
+}
+
+export function isDebugMode() {
+  return debugEnabled;
+}

--- a/frontend/src/utils/debugLogger.js
+++ b/frontend/src/utils/debugLogger.js
@@ -1,4 +1,4 @@
-const logs = [];
+const STORAGE_KEY = "liff_debug_logs";
 const startTime = Date.now();
 
 function isDebugEnabled() {
@@ -13,6 +13,38 @@ function isDebugEnabled() {
 
 const debugEnabled = isDebugEnabled();
 
+// Load existing logs from sessionStorage (survives redirects)
+function loadLogs() {
+  try {
+    const stored = window.sessionStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveLogs(logs) {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(logs));
+  } catch {
+    // sessionStorage full or unavailable
+  }
+}
+
+const logs = loadLogs();
+
+// Mark each page load so we can see redirects in the log
+if (debugEnabled) {
+  const entry = {
+    timestamp: "---",
+    event: "PAGE_LOAD",
+    dataStr: `url=${window.location.href}`,
+    raw: { url: window.location.href },
+  };
+  logs.push(entry);
+  saveLogs(logs);
+}
+
 export function debugLog(event, data = {}) {
   if (!debugEnabled) return;
   const elapsed = Date.now() - startTime;
@@ -26,6 +58,7 @@ export function debugLog(event, data = {}) {
     .join(" ");
   const entry = { timestamp, event, dataStr, raw: data };
   logs.push(entry);
+  saveLogs(logs);
 
   // Also log to console for desktop debugging
   console.log(`[DEBUG ${timestamp}] ${event} ${dataStr}`);
@@ -38,7 +71,6 @@ export function getDebugLogs() {
 export function formatDebugLogs() {
   const header = [
     `LIFF Debug Log`,
-    `URL: ${window.location.href}`,
     `UA: ${navigator.userAgent}`,
     `Time: ${new Date().toISOString()}`,
     `---`,
@@ -51,4 +83,9 @@ export function formatDebugLogs() {
 
 export function isDebugMode() {
   return debugEnabled;
+}
+
+export function clearDebugLogs() {
+  logs.length = 0;
+  window.sessionStorage.removeItem(STORAGE_KEY);
 }

--- a/frontend/src/utils/debugLogger.js
+++ b/frontend/src/utils/debugLogger.js
@@ -1,4 +1,5 @@
 const STORAGE_KEY = "liff_debug_logs";
+const MAX_LOGS = 200;
 const startTime = Date.now();
 
 function isDebugEnabled() {
@@ -58,6 +59,7 @@ export function debugLog(event, data = {}) {
     .join(" ");
   const entry = { timestamp, event, dataStr, raw: data };
   logs.push(entry);
+  if (logs.length > MAX_LOGS) logs.shift();
   saveLogs(logs);
 
   // Also log to console for desktop debugging

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,15 +9,15 @@ export default defineConfig({
     allowedHosts: ["host.docker.internal", ".ngrok-free.app"],
     proxy: {
       "/api": {
-        target: "http://localhost:9000",
+        target: "http://localhost:9527",
         changeOrigin: true,
       },
       "/webhooks": {
-        target: "http://localhost:9000",
+        target: "http://localhost:9527",
         changeOrigin: true,
       },
       "/socket.io": {
-        target: "http://localhost:5000",
+        target: "http://localhost:9527",
         changeOrigin: true,
         ws: true,
       },


### PR DESCRIPTION
## Summary

- **Gacha Banner System**: Add backend model, controller, API routes, DB migrations, and frontend admin pages for managing gacha events (rate-up campaigns and europe limited gacha)
- **Frontend Auth Guard**: Fix infinite redirect loop for non-admin users accessing admin pages. Properly separate 401 (unauthenticated) vs 403 (unauthorized), add `RequireAdmin` route guard, hide admin nav for non-admin users, show Snackbar on 403
- **Admin UX Improvements**: Rename nav labels for clarity (角色卡池/轉蛋活動), add 4-state status chips (已停用/待開始/進行中/已結束), sort by start_at, improve empty state, form field improvements
- **Debug Infrastructure**: Add LIFF auth lifecycle debug overlay with sessionStorage persistence across redirects, activated via `?debug=1`
- **StrictMode Fix**: Prevent double-invoke of LIFF init in React StrictMode

## Changes

### Backend
- `gacha_banner` + `gacha_banner_characters` DB migrations
- `GachaBanner` model with active banner queries
- CRUD controller + admin API routes (`/api/admin/gacha-banners`)
- Banner integration in gacha play logic (rate-up stacking, europe cost)
- Return 403 (not 401) for authorization failures in middleware

### Frontend
- Gacha banner admin pages (list + create/edit form)
- `RequireAdmin` route guard wrapping all admin routes
- `isAdmin` + `profile` state in `LiffProvider` context
- 401/403 separation in axios interceptor
- Admin nav hidden for non-admin users
- Debug overlay + logger utilities
- StrictMode double-invoke guard

## Test plan
- [ ] Verify admin can create/edit/delete gacha events
- [ ] Verify status chips show correct state (已停用/待開始/進行中/已結束)
- [ ] Verify non-admin users cannot see admin nav items
- [ ] Verify non-admin users are redirected when accessing `/admin/*` routes directly
- [ ] Verify gacha play applies active rate-up banners correctly
- [ ] Verify europe gacha uses banner cost when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)