### PR TITLE
fix: convert ISO datetime strings to Date objects for MySQL

### DIFF
--- a/app/src/controller/princess/GachaBannerController.js
+++ b/app/src/controller/princess/GachaBannerController.js
@@ -39,6 +39,8 @@ async function getBanner(req, res) {
 async function createBanner(req, res) {
   try {
     const { characterIds = [], ...bannerData } = req.body;
+    if (bannerData.start_at) bannerData.start_at = new Date(bannerData.start_at);
+    if (bannerData.end_at) bannerData.end_at = new Date(bannerData.end_at);
     const id = await GachaBanner.create(bannerData);
 
     if (bannerData.type === "rate_up" && characterIds.length > 0) {
@@ -60,11 +62,10 @@ async function updateBanner(req, res) {
   try {
     const { id } = req.params;
     const { characterIds, ...bannerData } = req.body;
+    if (bannerData.start_at) bannerData.start_at = new Date(bannerData.start_at);
+    if (bannerData.end_at) bannerData.end_at = new Date(bannerData.end_at);
 
-    await GachaBanner.update(parseInt(id), {
-      ...bannerData,
-      updated_at: new Date(),
-    });
+    await GachaBanner.update(parseInt(id), bannerData);
 
     if (characterIds !== undefined) {
       await GachaBanner.setBannerCharacters(parseInt(id), characterIds);


### PR DESCRIPTION
## Summary

- MySQL `timestamp` columns reject ISO 8601 strings with `Z` suffix (e.g. `2026-04-10T09:10:00.000Z`)
- Convert `start_at`/`end_at` to `Date` objects in `createBanner` and `updateBanner` handlers so Knex serializes them correctly
- Remove dead `updated_at` assignment that was silently dropped by `Base.update()`'s `pick()` (not in `fillable`)

**Error on production:**
```
ER_TRUNCATED_WRONG_VALUE: Incorrect datetime value: '2026-04-17T09:10:00.000Z' for column 'end_at' at row 1
```

## Test plan
- [x] Verified locally: `GachaBanner.create()` with `new Date()` succeeds
- [ ] Create a new gacha event on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)