### PR TITLE
fix(gacha): handle empty rate strings to prevent NaN crash

### DIFF
--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -580,6 +580,11 @@ function trimParamter(rowData) {
   return objParam;
 }
 
+function validateRate(value) {
+  const rateValue = parseFloat(value);
+  if (isNaN(rateValue) || rateValue < 0) throw new GachaException("rate must be a valid number >= 0", 5);
+}
+
 function sanitizeImageUrl(url) {
   if (!url) return url;
   const cleaned = url.trim().replace(/^['"]+|['"]+$/g, "").trim();
@@ -606,10 +611,7 @@ async function updateCharacter(req, res) {
 
     let objParam = trimParamter(data);
 
-    if (objParam.rate !== undefined) {
-      const rateValue = parseFloat(objParam.rate);
-      if (isNaN(rateValue) || rateValue < 0) throw new GachaException("rate must be a valid number >= 0", 5);
-    }
+    if (objParam.rate !== undefined) validateRate(objParam.rate);
 
     applyImageUrlSanitize(objParam);
 
@@ -634,8 +636,7 @@ async function insertCharacter(req, res) {
 
     if (Object.keys(objParam).length < 5) throw new GachaException("Parameter Leak", 3);
 
-    const rateValue = parseFloat(objParam.rate);
-    if (isNaN(rateValue) || rateValue < 0) throw new GachaException("rate must be a valid number >= 0", 5);
+    validateRate(objParam.rate);
 
     applyImageUrlSanitize(objParam);
 

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -605,6 +605,12 @@ async function updateCharacter(req, res) {
     if (data === undefined) throw new GachaException("Parameter data missing", 2);
 
     let objParam = trimParamter(data);
+
+    if (objParam.rate !== undefined) {
+      const rateValue = parseFloat(objParam.rate);
+      if (isNaN(rateValue) || rateValue < 0) throw new GachaException("rate must be a valid number >= 0", 5);
+    }
+
     applyImageUrlSanitize(objParam);
 
     await GachaModel.updateData(id, objParam);
@@ -627,6 +633,9 @@ async function insertCharacter(req, res) {
     let objParam = trimParamter(data);
 
     if (Object.keys(objParam).length < 5) throw new GachaException("Parameter Leak", 3);
+
+    const rateValue = parseFloat(objParam.rate);
+    if (isNaN(rateValue) || rateValue < 0) throw new GachaException("rate must be a valid number >= 0", 5);
 
     applyImageUrlSanitize(objParam);
 

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -30,8 +30,8 @@ GachaException.prototype = new Error();
 
 function getTotalRate(gachaPool) {
   let result = gachaPool
-    .map(data => parseFloat(data.rate.replace("%", "")))
-    .reduce((pre, curr) => pre + curr);
+    .map(data => parseFloat(data.rate.replace("%", "")) || 0)
+    .reduce((pre, curr) => pre + curr, 0);
   return [Math.round(result * 10000), 10000];
 }
 

--- a/frontend/src/pages/Admin/GachaPool/GachaPoolForm.jsx
+++ b/frontend/src/pages/Admin/GachaPool/GachaPoolForm.jsx
@@ -79,7 +79,7 @@ export default function GachaPoolForm() {
         imageUrl: character.imageUrl || "",
         star: Number(character.star) || 3,
         rate: isNaN(parsedRate) ? "" : parsedRate,
-        isPrincess: parseInt(character.isPrincess, 10) || 1,
+        isPrincess: parseInt(character.isPrincess, 10) ?? 1,
         tag: character.tag || "",
       });
     } catch {
@@ -125,7 +125,8 @@ export default function GachaPoolForm() {
       return;
     }
 
-    if (formData.rate === "" || isNaN(Number(formData.rate)) || Number(formData.rate) < 0) {
+    const parsedRateValue = parseFloat(formData.rate);
+    if (formData.rate === "" || isNaN(parsedRateValue) || parsedRateValue < 0) {
       showHint("請輸入有效的機率（>= 0）", "warning");
       return;
     }

--- a/frontend/src/pages/Admin/GachaPool/GachaPoolForm.jsx
+++ b/frontend/src/pages/Admin/GachaPool/GachaPoolForm.jsx
@@ -73,11 +73,12 @@ export default function GachaPoolForm() {
         navigate("/admin/gacha-pool");
         return;
       }
+      const parsedRate = parseFloat(character.rate);
       setFormData({
         name: character.name || "",
         imageUrl: character.imageUrl || "",
         star: Number(character.star) || 3,
-        rate: parseFloat(character.rate) || "",
+        rate: isNaN(parsedRate) ? "" : parsedRate,
         isPrincess: parseInt(character.isPrincess, 10) || 1,
         tag: character.tag || "",
       });
@@ -121,6 +122,11 @@ export default function GachaPoolForm() {
   const handleSave = async () => {
     if (!formData.name.trim()) {
       showHint("請輸入角色名稱", "warning");
+      return;
+    }
+
+    if (formData.rate === "" || isNaN(Number(formData.rate)) || Number(formData.rate) < 0) {
+      showHint("請輸入有效的機率（>= 0）", "warning");
       return;
     }
 


### PR DESCRIPTION
## Summary

- 三個夏日角色（可可蘿 id=62、美冬 id=66、香織 id=90）的 `rate` 欄位為空字串
- `parseFloat("") = NaN` 污染 `getTotalRate` 的 reduce，導致 `max = NaN`
- `play()` 抽不到任何獎勵，`rareCount = {}`，flex message footer text 變成空字串
- LINE API 拒絕：`/footer/contents/1/text: must be non-empty text`

## Fix

`getTotalRate` 加上 `|| 0` fallback 及 reduce 初始值，讓空/無效 rate 當作 0% 處理。

## Test plan

- [ ] `#抽` 指令正常回傳轉蛋結果
- [ ] 建議後台將 id=62, 66, 90 的 rate 補上正確值（或設 `"0%"`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)