### PR TITLE
fix(liff): resolve liff_size by pathname before localStorage

### DIFF
--- a/frontend/src/context/LiffProvider.jsx
+++ b/frontend/src/context/LiffProvider.jsx
@@ -19,6 +19,8 @@ export const LiffContext = createContext({
 });
 
 function getLiffSize() {
+  const match = window.location.pathname.match(/^\/liff\/([^/]+)/);
+  if (match) return match[1];
   return window.localStorage.getItem(SIZE_KEY) || DEFAULT_SIZE;
 }
 


### PR DESCRIPTION
## Summary
- `getLiffSize()` 原本只讀 localStorage，但 localStorage 是由 `LiffLayout` 在 LIFF init 完成後才寫入
- 第一次造訪時 `liff_size` 為 null，`initLiffSdk()` 會 fallback 到 `"full"`，導致 `/liff/tall` 路由拿到錯誤的 LIFF ID
- 修正為優先從 `window.location.pathname` 解析 size，確保每次 page load 都能正確取得對應 LIFF ID

## Test Plan
- [ ] 清除 localStorage 後第一次進入 `/liff/tall`，確認 LIFF SDK 使用 tall LIFF ID 初始化成功
- [ ] 正常重複造訪，確認行為不變
- [ ] 確認 `/liff/full`、`/liff/compact` 路由同樣正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)