### PR TITLE
fix(achievement): fix unlock rate denominator to include legacy users

### DIFF
--- a/app/src/model/application/Achievement.js
+++ b/app/src/model/application/Achievement.js
@@ -53,9 +53,14 @@ exports.findByType = async type => {
 };
 
 exports.getStats = async () => {
-  const activeUsers = await mysql("user_achievement_progress")
-    .countDistinct({ count: "user_id" })
-    .first();
+  const [rows] = await mysql.raw(`
+    SELECT COUNT(DISTINCT user_id) as count FROM (
+      SELECT user_id FROM user_achievement_progress
+      UNION
+      SELECT user_id FROM user_achievements
+    ) as combined
+  `);
+  const activeUsers = rows[0];
   const stats = await mysql("user_achievements")
     .select("achievement_id")
     .count({ unlock_count: "id" })


### PR DESCRIPTION
The active user count for unlock rate calculation only counted users in user_achievement_progress, missing 6,644 legacy users who only have user_achievements records. Use UNION of both tables as denominator.
This pull request updates the way active users are counted in the `getStats` method of `Achievement.js` to provide a more accurate metric. Instead of counting distinct users only from `user_achievement_progress`, it now counts unique users across both `user_achievement_progress` and `user_achievements`.

**Statistics calculation improvements:**

* Updated the active user count in `getStats` to aggregate distinct `user_id`s from both `user_achievement_progress` and `user_achievements` using a SQL `UNION`, ensuring users present in either table are counted only once.