### PR TITLE
feat(achievement): mention-keyword trigger + unlock notifications

### DIFF
--- a/.claude/skills/add-achievement.md
+++ b/.claude/skills/add-achievement.md
@@ -1,6 +1,6 @@
 ---
 name: add-achievement
-description: Guide for adding new achievements to the achievement system. Use this skill whenever the user mentions adding, creating, or defining new achievements, unlock conditions, or achievement categories. Also applies when discussing new event types that should trigger achievement progress.
+description: Guide for adding new achievements to the achievement system. Use this skill whenever the user mentions adding, creating, or defining new achievements, unlock conditions, achievement categories, mention-based triggers, or unlock notifications. Also applies when discussing new event types that should trigger achievement progress, or when configuring a reply message to be sent back to chat on unlock.
 ---
 
 # Add Achievement to the System
@@ -50,6 +50,14 @@ exports.up = async function (knex) {
     target_value: <number>,        // how many times / what threshold to unlock
     reward_stones: <number>,       // goddess stones reward
     order: <number>,               // display order within category
+
+    // --- Optional: condition JSON for strategies that need per-achievement config
+    //     (mention_keyword is the primary user). Omit if strategy doesn't read it.
+    condition: JSON.stringify({ /* strategy-specific shape */ }),
+
+    // --- Optional: send a chat reply when this achievement unlocks
+    notify_on_unlock: true,              // default false → silent unlock (logs only)
+    notify_message: "<template or null>" // null → use default template
   });
 };
 
@@ -89,6 +97,7 @@ In `ACHIEVEMENT_STRATEGY`, define how progress is calculated. Choose from built-
 | `contextValue` | Progress comes from external data | Level reached, unique count |
 | `threshold` | Context value must exceed a minimum | Score >= 100 in one game |
 | `timeWindow` | Must happen during specific hours | Action between 3-4 AM |
+| `mentionKeyword` | @mention a target userId, optionally with keywords | Greet an admin; touch a specific god |
 
 ```js
 const ACHIEVEMENT_STRATEGY = {
@@ -139,6 +148,139 @@ If no icon is mapped, the system falls back to the category icon, then to `LockI
 
 If the achievement can be retroactively checked for existing users (e.g. "registered 30+ days ago"), add batch logic in `batchEvaluate()` in `AchievementEngine.js`. This runs as a cron job.
 
+## Mention-Keyword Achievements (event type: `mention_keyword`)
+
+A data-driven trigger that fires when a user sends a text message that @mentions one or more target userIds, optionally also containing specific keywords. Useful for easter-egg achievements like "greet an admin", "touch a specific god", etc.
+
+**Key property**: the trigger logic is generic. All per-achievement data lives in the `condition` JSON column — so a new mention-keyword achievement is just a migration + two lines in `AchievementEngine.js`. No business-logic wiring needed: `statistics.js` already dispatches `mention_keyword` for every text message containing `mention.mentionees`.
+
+### Condition schema
+
+```json
+{
+  "targetUserIds": ["U123...", "U456..."],  // ALL must be @mentioned
+  "keywords": ["謝謝", "感謝"]               // ALL must appear as substrings. May be empty.
+}
+```
+
+Semantics:
+- `targetUserIds` is **required**. Empty → never unlocks.
+- `keywords` is **optional**. Empty array (`[]`) means "mention-only trigger" — the achievement fires on any message that @mentions all target userIds, regardless of text content.
+- Both lists use all-must-match (AND) semantics, not any-match.
+
+### When to use empty keywords
+
+Use mention-only triggers (`keywords: []`) when:
+- The target userId is rarely @mentioned (e.g. a niche persona), so the trigger threshold is naturally low.
+- You want the achievement to feel serendipitous — the user doesn't need to know what to say.
+
+Avoid empty keywords when the target userId is a frequently-mentioned admin/active user — the achievement will fire on almost any interaction and feel cheap. In that case, gate it with 1–2 keywords.
+
+**Cost of empty keywords**: none beyond the existing dispatch. Once a user unlocks the achievement, `evaluate()` short-circuits on the already-unlocked check before running the strategy, so there's no repeated computation — just one indexed DB lookup per @mention event from that user.
+
+### Example migration (keyword-gated)
+
+```js
+await knex("achievements").insert({
+  category_id: category.id,
+  key: "mention_admin_hi",
+  name: "來自鬆餅的祝福",
+  description: "與管理員打招呼",
+  icon: "🥞",
+  type: "hidden",
+  rarity: 2,
+  target_value: 1,
+  reward_stones: 100,
+  order: 99,
+  condition: JSON.stringify({
+    targetUserIds: ["U41b31c07a3279ca64355d2de43101b3d"],
+    keywords: ["鬆餅", "祝福"],
+  }),
+  notify_on_unlock: true,
+  notify_message: "恭喜你加入鬆餅教(((o(*ﾟ▽ﾟ*)o)))\n已解鎖隱藏成就：{icon} {name}",
+});
+```
+
+### Example migration (mention-only, no keywords)
+
+```js
+await knex("achievements").insert({
+  category_id: category.id,
+  key: "mention_memory_seeker",
+  name: "追尋神祇回憶的人",
+  description: "觸碰到了布丁古神的意識",
+  icon: "🍮",
+  type: "hidden",
+  rarity: 2,
+  target_value: 1,
+  reward_stones: 100,
+  order: 100,
+  condition: JSON.stringify({
+    targetUserIds: ["U80ca6f24809c9a00981562b771fb6b84"],
+    keywords: [],  // ← empty: fires on any mention of the target userId
+  }),
+  notify_on_unlock: true,
+  notify_message:
+    "你觸摸到了布丁古神，古老的符文緩緩浮現……\n「穿越時光的旅人啊，神祇向你致意」\n已解鎖隱藏成就：{icon} {name}",
+});
+```
+
+### Engine wiring (two one-liners)
+
+```js
+// 1. Add the key to the mention_keyword event map
+EVENT_ACHIEVEMENT_MAP.mention_keyword = ["mention_admin_hi", "mention_memory_seeker"];
+
+// 2. Wire the strategy (reuse STRATEGIES.mentionKeyword)
+ACHIEVEMENT_STRATEGY.mention_memory_seeker = (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx);
+```
+
+No controller changes needed — `statistics.js` already dispatches `mention_keyword` on every text message with mentionees.
+
+## Unlock Notifications (`notify_on_unlock`)
+
+Select achievements can send a reply back to the chat where the unlock was triggered, via Bottender's batched reply queue (zero extra LINE API cost — batched into the same `reply` call as other messages).
+
+### How to enable
+
+Set two columns on the achievement row:
+- `notify_on_unlock: true` (default `false` → silent, logs only)
+- `notify_message: "<template>"` (or `null` to use the default template)
+
+### Template placeholders
+
+Supported in custom `notify_message`:
+- `{user}` — the unlocker's `display_name` (falls back to literal `"玩家"` if missing)
+- `{name}` — achievement name
+- `{icon}` — achievement icon
+- `{reward}` — reward stone count as integer
+
+Repeated placeholders are replaced globally. `{description}` is intentionally not supported.
+
+### Default templates (when `notify_message` is `null`)
+
+- With reward (`reward_stones > 0`): `🎉 {user} 解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石`
+- No reward: `🎉 {user} 解鎖成就「{icon} {name}」！`
+
+### Call-site pattern
+
+`AchievementEngine.evaluate()` returns `{ unlocked: Achievement[] }`. For any call site that has a Bottender `context`, use the `notifyUnlocks` helper to emit replies:
+
+```js
+const AchievementEngine = require("../service/AchievementEngine");
+const { notifyUnlocks } = require("../service/achievementNotifier");
+
+const { unlocked } = await AchievementEngine.evaluate(userId, "<eventType>", ctx)
+  .catch(() => ({ unlocked: [] }));
+await notifyUnlocks(context, userId, unlocked);
+```
+
+Batch/cron call sites (no `context`) simply ignore the return value — that's fine.
+
+### Reply-queue cap
+
+LINE reply tokens cap at 5 messages per reply. If a single event generates >5 `context.replyText` calls (controller replies + unlock notifications combined), Bottender drops the overflow and logs a warning. This is tolerated as-is — unlikely in practice and harmless.
+
 ## Achievement Types Reference
 
 | Type | Behavior | Example |
@@ -180,7 +322,9 @@ Before finishing, verify:
 - [ ] Achievement key is unique across all achievements
 - [ ] Event type added to `EVENT_ACHIEVEMENT_MAP`
 - [ ] Strategy defined in `ACHIEVEMENT_STRATEGY`
-- [ ] `evaluate()` called from the relevant business logic
+- [ ] `evaluate()` called from the relevant business logic (skip for `mention_keyword` — `statistics.js` dispatches it automatically)
+- [ ] If `condition` is needed, `JSON.stringify(...)` the object before insert
+- [ ] If `notify_on_unlock: true`, confirm the relevant call site destructures `{ unlocked }` and calls `notifyUnlocks(context, userId, unlocked)` (already wired for `statistics.js`, gacha, janken, subscribe)
 - [ ] Migration runs cleanly: `cd app && yarn migrate`
 - [ ] (Optional) Frontend icon mapped
 - [ ] (Optional) Batch evaluation added if retroactive check is needed

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -186,6 +186,108 @@ describe("AchievementEngine", () => {
     });
   });
 
+  describe("mention_keyword event", () => {
+    const baseAchievement = {
+      id: 99,
+      key: "mention_admin_hi",
+      target_value: 1,
+      reward_stones: 100,
+      notify_on_unlock: true,
+      notify_message: null,
+      icon: "🫡",
+      name: "管理員粉絲",
+      condition: { targetUserIds: ["Uadmin"], keywords: ["大大好"] },
+    };
+
+    beforeEach(() => {
+      AchievementEngine._setCache([baseAchievement]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgress.mockResolvedValue(null);
+      UserProgressModel.upsert.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue();
+      UserProgressModel.delete.mockResolvedValue();
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+        insert: jest.fn().mockResolvedValue(),
+      });
+    });
+
+    afterEach(() => {
+      // Restore the default mysql mock chain so later describes (e.g. getUserSummary)
+      // don't inherit the mention_keyword override
+      mysql.mockImplementation(() => ({
+        insert: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        whereIn: jest.fn().mockReturnThis(),
+        update: jest.fn().mockResolvedValue(1),
+        first: jest.fn().mockResolvedValue(undefined),
+        select: jest.fn().mockReturnThis(),
+      }));
+    });
+
+    it("unlocks when all target userIds are mentioned and all keywords are present", async () => {
+      const ctx = { mentionedUserIds: ["Uadmin"], text: "嗨 大大好 今天過得如何" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked.map(a => a.key)).toEqual(["mention_admin_hi"]);
+    });
+
+    it("does not unlock when mention is missing", async () => {
+      const ctx = { mentionedUserIds: [], text: "大大好" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked).toEqual([]);
+    });
+
+    it("does not unlock when keyword is missing", async () => {
+      const ctx = { mentionedUserIds: ["Uadmin"], text: "嗨" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked).toEqual([]);
+    });
+
+    it("does not unlock when condition is null", async () => {
+      AchievementEngine._setCache([{ ...baseAchievement, condition: null }]);
+      const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked).toEqual([]);
+    });
+
+    it("requires ALL target userIds (not just one)", async () => {
+      AchievementEngine._setCache([
+        {
+          ...baseAchievement,
+          condition: { targetUserIds: ["Uadmin", "Umod"], keywords: ["大大好"] },
+        },
+      ]);
+      const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked).toEqual([]);
+    });
+
+    it("requires ALL keywords (not just one)", async () => {
+      AchievementEngine._setCache([
+        {
+          ...baseAchievement,
+          condition: { targetUserIds: ["Uadmin"], keywords: ["大大好", "早安"] },
+        },
+      ]);
+      const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked).toEqual([]);
+    });
+  });
+
   describe("getUserSummary", () => {
     it("should return structured summary", async () => {
       AchievementModel.allWithCategories.mockResolvedValue([

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -273,6 +273,34 @@ describe("AchievementEngine", () => {
       expect(result.unlocked).toEqual([]);
     });
 
+    it("unlocks when keywords is empty and all target userIds are mentioned", async () => {
+      AchievementEngine._setCache([
+        {
+          ...baseAchievement,
+          condition: { targetUserIds: ["Uadmin"], keywords: [] },
+        },
+      ]);
+      const ctx = { mentionedUserIds: ["Uadmin"], text: "隨便打什麼都行" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked.map(a => a.key)).toEqual(["mention_admin_hi"]);
+    });
+
+    it("does not unlock when targetUserIds is empty even if keywords is also empty", async () => {
+      AchievementEngine._setCache([
+        {
+          ...baseAchievement,
+          condition: { targetUserIds: [], keywords: [] },
+        },
+      ]);
+      const ctx = { mentionedUserIds: ["Uadmin"], text: "隨便" };
+
+      const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+      expect(result.unlocked).toEqual([]);
+    });
+
     it("requires ALL keywords (not just one)", async () => {
       AchievementEngine._setCache([
         {

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -52,6 +52,7 @@ const UserAchievementModel = require("../../src/model/application/UserAchievemen
 const UserProgressModel = require("../../src/model/application/UserAchievementProgress");
 const CategoryModel = require("../../src/model/application/AchievementCategory");
 const { DefaultLogger } = require("../../src/util/Logger");
+const mysql = require("../../src/util/mysql");
 
 const CACHE_DATA = [
   { id: 1, key: "chat_100", type: "milestone", target_value: 100, reward_stones: 50 },
@@ -110,6 +111,78 @@ describe("AchievementEngine", () => {
     it("should not throw on event with no mapped achievements", async () => {
       await AchievementEngine.evaluate("user1", "unknown_event", {});
       expect(DefaultLogger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("evaluate return value", () => {
+    it("returns { unlocked: [] } when no achievement crosses threshold", async () => {
+      AchievementEngine._setCache([
+        {
+          id: 1,
+          key: "chat_100",
+          target_value: 100,
+          reward_stones: 0,
+          notify_on_unlock: false,
+          notify_message: null,
+          condition: null,
+        },
+      ]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgress.mockResolvedValue({ current_value: 1 });
+      UserProgressModel.upsert.mockResolvedValue();
+
+      const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      expect(result).toEqual({ unlocked: [] });
+    });
+
+    it("returns the unlocked achievement row when threshold is crossed", async () => {
+      const achievement = {
+        id: 2,
+        key: "chat_100",
+        target_value: 100,
+        reward_stones: 50,
+        notify_on_unlock: true,
+        notify_message: null,
+        condition: null,
+        icon: "💬",
+        name: "百句達人",
+      };
+      AchievementEngine._setCache([achievement]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgress.mockResolvedValue({ current_value: 99 });
+      UserProgressModel.upsert.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue();
+      UserProgressModel.delete.mockResolvedValue();
+      mysql.mockImplementationOnce(() => ({
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+        insert: jest.fn().mockResolvedValue(),
+      }));
+
+      const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      expect(result.unlocked).toHaveLength(1);
+      expect(result.unlocked[0].key).toBe("chat_100");
+    });
+
+    it("returns { unlocked: [] } when inner error is swallowed", async () => {
+      AchievementEngine._setCache([
+        {
+          id: 3,
+          key: "chat_100",
+          target_value: 100,
+          reward_stones: 0,
+          notify_on_unlock: false,
+          notify_message: null,
+          condition: null,
+        },
+      ]);
+      UserAchievementModel.getUnlockedIds.mockRejectedValue(new Error("db down"));
+
+      const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      expect(result).toEqual({ unlocked: [] });
     });
   });
 

--- a/app/__tests__/service/achievementNotifier.test.js
+++ b/app/__tests__/service/achievementNotifier.test.js
@@ -1,0 +1,143 @@
+jest.mock("../../src/util/mysql");
+const mysql = require("../../src/util/mysql");
+const { notifyUnlocks, renderTemplate } = require("../../src/service/achievementNotifier");
+
+describe("achievementNotifier", () => {
+  describe("renderTemplate", () => {
+    it("uses the with-reward default when notify_message is null and reward > 0", () => {
+      const out = renderTemplate(
+        { name: "夜貓子", icon: "🌙", reward_stones: 50, notify_message: null },
+        "Alice"
+      );
+      expect(out).toBe("🎉 Alice 解鎖成就「🌙 夜貓子」！獲得 50 顆女神石");
+    });
+
+    it("uses the no-reward default when notify_message is null and reward is 0", () => {
+      const out = renderTemplate(
+        { name: "彩蛋", icon: "🥚", reward_stones: 0, notify_message: null },
+        "Bob"
+      );
+      expect(out).toBe("🎉 Bob 解鎖成就「🥚 彩蛋」！");
+    });
+
+    it("substitutes placeholders in a custom notify_message", () => {
+      const out = renderTemplate(
+        {
+          name: "測試",
+          icon: "🧪",
+          reward_stones: 10,
+          notify_message: "{user} -> {name} ({icon}) +{reward}",
+        },
+        "Carol"
+      );
+      expect(out).toBe("Carol -> 測試 (🧪) +10");
+    });
+
+    it("replaces repeated placeholders globally", () => {
+      const out = renderTemplate(
+        {
+          name: "重複",
+          icon: "🔁",
+          reward_stones: 1,
+          notify_message: "{user} {user} {name} {name}",
+        },
+        "Dan"
+      );
+      expect(out).toBe("Dan Dan 重複 重複");
+    });
+  });
+
+  describe("notifyUnlocks", () => {
+    let context;
+
+    beforeEach(() => {
+      context = { replyText: jest.fn() };
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue({ display_name: "Eve" }),
+      });
+    });
+
+    it("does nothing when no achievement opts in", async () => {
+      await notifyUnlocks(context, "user1", [
+        { notify_on_unlock: false, name: "X", icon: "X", reward_stones: 0, notify_message: null },
+      ]);
+      expect(context.replyText).not.toHaveBeenCalled();
+    });
+
+    it("skips user lookup when list is empty", async () => {
+      await notifyUnlocks(context, "user1", []);
+      expect(context.replyText).not.toHaveBeenCalled();
+      expect(mysql).not.toHaveBeenCalled();
+    });
+
+    it("replies once per opt-in achievement", async () => {
+      await notifyUnlocks(context, "user1", [
+        {
+          notify_on_unlock: true,
+          name: "A",
+          icon: "🅰",
+          reward_stones: 10,
+          notify_message: null,
+        },
+        {
+          notify_on_unlock: false,
+          name: "B",
+          icon: "🅱",
+          reward_stones: 0,
+          notify_message: null,
+        },
+        {
+          notify_on_unlock: true,
+          name: "C",
+          icon: "🇨",
+          reward_stones: 0,
+          notify_message: null,
+        },
+      ]);
+      expect(context.replyText).toHaveBeenCalledTimes(2);
+      expect(context.replyText).toHaveBeenNthCalledWith(
+        1,
+        "🎉 Eve 解鎖成就「🅰 A」！獲得 10 顆女神石"
+      );
+      expect(context.replyText).toHaveBeenNthCalledWith(2, "🎉 Eve 解鎖成就「🇨 C」！");
+    });
+
+    it("uses fallback display name 玩家 when user row is missing", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      });
+      await notifyUnlocks(context, "missing-user", [
+        {
+          notify_on_unlock: true,
+          name: "Z",
+          icon: "🅉",
+          reward_stones: 0,
+          notify_message: null,
+        },
+      ]);
+      expect(context.replyText).toHaveBeenCalledWith("🎉 玩家 解鎖成就「🅉 Z」！");
+    });
+
+    it("swallows internal errors so the middleware chain never breaks", async () => {
+      mysql.mockImplementation(() => {
+        throw new Error("db down");
+      });
+      await expect(
+        notifyUnlocks(context, "user1", [
+          {
+            notify_on_unlock: true,
+            name: "A",
+            icon: "🅰",
+            reward_stones: 0,
+            notify_message: null,
+          },
+        ])
+      ).resolves.toBeUndefined();
+      expect(context.replyText).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/migrations/20260417154659_add_achievement_condition_and_notify.js
+++ b/app/migrations/20260417154659_add_achievement_condition_and_notify.js
@@ -1,0 +1,28 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("achievements", table => {
+    table.json("condition").nullable().comment("觸發條件資料，策略自行解析");
+    table
+      .boolean("notify_on_unlock")
+      .notNullable()
+      .defaultTo(false)
+      .comment("解鎖時是否通知聊天室");
+    table.text("notify_message").nullable().comment("通知模板，null 走預設");
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("achievements", table => {
+    table.dropColumn("condition");
+    table.dropColumn("notify_on_unlock");
+    table.dropColumn("notify_message");
+  });
+};

--- a/app/migrations/20260417163434_seed_mention_admin_hi_achievement.js
+++ b/app/migrations/20260417163434_seed_mention_admin_hi_achievement.js
@@ -1,0 +1,41 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const KEY = "mention_admin_hi";
+const CATEGORY_KEY = "social";
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  const category = await knex("achievement_categories").where({ key: CATEGORY_KEY }).first();
+  if (!category) {
+    throw new Error(`achievement_categories row with key='${CATEGORY_KEY}' not found`);
+  }
+
+  await knex("achievements").insert({
+    category_id: category.id,
+    key: KEY,
+    name: "來自鬆餅的祝福",
+    description: "與管理員打招呼",
+    icon: "🥞",
+    type: "hidden",
+    rarity: 2,
+    target_value: 1,
+    reward_stones: 100,
+    order: 99,
+    condition: JSON.stringify({
+      targetUserIds: ["U41b31c07a3279ca64355d2de43101b3d"],
+      keywords: ["鬆餅", "祝福"],
+    }),
+    notify_on_unlock: true,
+    notify_message: "恭喜你加入鬆餅教(((o(*ﾟ▽ﾟ*)o)))\n已解鎖隱藏成就：{icon} {name}",
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex("achievements").where({ key: KEY }).del();
+};

--- a/app/migrations/20260417170027_seed_mention_memory_seeker_achievement.js
+++ b/app/migrations/20260417170027_seed_mention_memory_seeker_achievement.js
@@ -1,0 +1,42 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const KEY = "mention_memory_seeker";
+const CATEGORY_KEY = "social";
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  const category = await knex("achievement_categories").where({ key: CATEGORY_KEY }).first();
+  if (!category) {
+    throw new Error(`achievement_categories row with key='${CATEGORY_KEY}' not found`);
+  }
+
+  await knex("achievements").insert({
+    category_id: category.id,
+    key: KEY,
+    name: "追尋神祇回憶的人",
+    description: "觸碰到了布丁古神的意識",
+    icon: "🍮",
+    type: "hidden",
+    rarity: 2,
+    target_value: 1,
+    reward_stones: 100,
+    order: 100,
+    condition: JSON.stringify({
+      targetUserIds: ["U80ca6f24809c9a00981562b771fb6b84"],
+      keywords: [],
+    }),
+    notify_on_unlock: true,
+    notify_message:
+      "你觸摸到了布丁古神，古老的符文緩緩浮現……\n「穿越時光的旅人啊，神祇向你致意」\n已解鎖隱藏成就：{icon} {name}",
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex("achievements").where({ key: KEY }).del();
+};

--- a/app/migrations/20260417171921_seed_mention_void_gazer_achievement.js
+++ b/app/migrations/20260417171921_seed_mention_void_gazer_achievement.js
@@ -1,0 +1,42 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const KEY = "mention_void_gazer";
+const CATEGORY_KEY = "social";
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  const category = await knex("achievement_categories").where({ key: CATEGORY_KEY }).first();
+  if (!category) {
+    throw new Error(`achievement_categories row with key='${CATEGORY_KEY}' not found`);
+  }
+
+  await knex("achievements").insert({
+    category_id: category.id,
+    key: KEY,
+    name: "凝視虛無者",
+    description: "當你凝視著深淵，深淵也凝視著你",
+    icon: "👁️",
+    type: "hidden",
+    rarity: 2,
+    target_value: 1,
+    reward_stones: 100,
+    order: 101,
+    condition: JSON.stringify({
+      targetUserIds: ["Uc28b2e002c86886fffdb6cabea060c6e"],
+      keywords: ["sudo su"],
+    }),
+    notify_on_unlock: true,
+    notify_message:
+      "$ tail -f /dev/abyss\n[WARN] the void is watching back.\n你凝視著程式碼深處的虛無，虛無透過螢幕凝視著你。\n已解鎖隱藏成就：{icon} {name}",
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex("achievements").where({ key: KEY }).del();
+};

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -11,6 +11,7 @@ const JankenService = require("../../service/JankenService");
 const uuid = require("uuid-random");
 const { DefaultLogger } = require("../../util/Logger");
 const AchievementEngine = require("../../service/AchievementEngine");
+const { notifyUnlocks } = require("../../service/achievementNotifier");
 
 const baseUrl = `https://${process.env.APP_DOMAIN}`;
 const ASSET_VERSION = Date.now();
@@ -264,8 +265,16 @@ exports.decide = async (context, { payload }) => {
 
   if (p1Result !== "draw") {
     const winnerId = p1Result === "win" ? userId : targetUserId;
-    AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => {});
-    AchievementEngine.evaluate(targetUserId, "janken_challenge", {}).catch(() => {});
+    const [winResult, challengeResult] = await Promise.all([
+      AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => ({
+        unlocked: [],
+      })),
+      AchievementEngine.evaluate(targetUserId, "janken_challenge", {}).catch(() => ({
+        unlocked: [],
+      })),
+    ]);
+    await notifyUnlocks(context, winnerId, winResult.unlocked);
+    await notifyUnlocks(context, targetUserId, challengeResult.unlocked);
 
     if (loserBounty > 0) {
       const breakerName = p1Result === "win" ? p1Name : p2Name;
@@ -433,8 +442,16 @@ exports.challenge = async (context, { payload }) => {
 
     if (p1Result !== "draw") {
       const winnerId = p1Result === "win" ? holderUserId : challengerUserId;
-      AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => {});
-      AchievementEngine.evaluate(challengerUserId, "janken_challenge", {}).catch(() => {});
+      const [winResult, challengeResult] = await Promise.all([
+        AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => ({
+          unlocked: [],
+        })),
+        AchievementEngine.evaluate(challengerUserId, "janken_challenge", {}).catch(() => ({
+          unlocked: [],
+        })),
+      ]);
+      await notifyUnlocks(context, winnerId, winResult.unlocked);
+      await notifyUnlocks(context, challengerUserId, challengeResult.unlocked);
 
       if (loserBounty > 0) {
         const breakerName = p1Result === "win" ? p1Name : p2Name;

--- a/app/src/controller/application/SubscribeController.js
+++ b/app/src/controller/application/SubscribeController.js
@@ -12,6 +12,7 @@ const GachaController = require("../princess/gacha");
 const config = require("config");
 const { generateCard, generateEffect } = require("../../templates/application/Subscribe");
 const AchievementEngine = require("../../service/AchievementEngine");
+const { notifyUnlocks } = require("../../service/achievementNotifier");
 
 exports.router = [
   text(/^[.#/](訂閱|sub)$/, showInformation),
@@ -82,7 +83,10 @@ async function buyMonthCard(context, props) {
 
     trx.commit();
 
-    AchievementEngine.evaluate(userId, "subscribe").catch(() => {});
+    const { unlocked } = await AchievementEngine.evaluate(userId, "subscribe").catch(() => ({
+      unlocked: [],
+    }));
+    await notifyUnlocks(context, userId, unlocked);
   } catch (e) {
     trx.rollback();
     console.error(e);
@@ -252,7 +256,10 @@ async function subscribeCouponExchange(context, props) {
   await context.replyText(messages.join("\n"));
   !isContinue && (await DailyRation());
 
-  AchievementEngine.evaluate(userId, "subscribe").catch(() => {});
+  const { unlocked } = await AchievementEngine.evaluate(userId, "subscribe").catch(() => ({
+    unlocked: [],
+  }));
+  await notifyUnlocks(context, userId, unlocked);
 }
 
 /**

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -20,6 +20,7 @@ const config = require("config");
 const i18n = require("../../util/i18n");
 const commonTemplate = require("../../templates/common");
 const AchievementEngine = require("../../service/AchievementEngine");
+const { notifyUnlocks } = require("../../service/achievementNotifier");
 
 function GachaException(message, code) {
   this.message = message;
@@ -473,10 +474,11 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     })
   );
 
-  AchievementEngine.evaluate(userId, "gacha_pull", {
+  const { unlocked } = await AchievementEngine.evaluate(userId, "gacha_pull", {
     threeStarCount: rareCount[3] || 0,
     uniqueCount: dailyResult.ownCharactersCount + dailyResult.newCharacters.length,
-  }).catch(() => {});
+  }).catch(() => ({ unlocked: [] }));
+  await notifyUnlocks(context, userId, unlocked);
 
   return context.replyFlex("每日一抽結果", {
     type: "carousel",

--- a/app/src/middleware/statistics.js
+++ b/app/src/middleware/statistics.js
@@ -1,6 +1,8 @@
+const { get } = require("lodash");
 const { io } = require("../util/connection");
 const redis = require("../util/redis");
 const AchievementEngine = require("../service/AchievementEngine");
+const { notifyUnlocks } = require("../service/achievementNotifier");
 const MessageIO = io.of("/admin/messages");
 
 /**
@@ -16,7 +18,27 @@ const statistics = async (context, props) => {
     const userId = context.event.source.userId;
     const groupId = context.event.source.groupId;
     if (userId) {
-      AchievementEngine.evaluate(userId, "chat_message", { groupId }).catch(() => {});
+      const mentionees = get(context, "event.message.mention.mentionees", []) || [];
+      const mentionedUserIds = mentionees.map(m => m && m.userId).filter(Boolean);
+      const text = context.event.text || "";
+
+      const tasks = [
+        AchievementEngine.evaluate(userId, "chat_message", { groupId, text }).catch(() => ({
+          unlocked: [],
+        })),
+      ];
+      if (mentionedUserIds.length) {
+        tasks.push(
+          AchievementEngine.evaluate(userId, "mention_keyword", {
+            mentionedUserIds,
+            text,
+          }).catch(() => ({ unlocked: [] }))
+        );
+      }
+
+      const results = await Promise.all(tasks);
+      const unlocked = results.flatMap(r => (r && r.unlocked) || []);
+      await notifyUnlocks(context, userId, unlocked);
     }
   }
 

--- a/app/src/model/application/Achievement.js
+++ b/app/src/model/application/Achievement.js
@@ -13,6 +13,9 @@ const fillable = [
   "target_value",
   "reward_stones",
   "order",
+  "condition",
+  "notify_on_unlock",
+  "notify_message",
 ];
 
 class Achievement extends Base {}

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -35,7 +35,7 @@ const EVENT_ACHIEVEMENT_MAP = {
   boss_attack: ["boss_first_kill", "boss_level_10", "boss_level_50", "boss_top_damage"],
   command_use: ["social_first_command", "social_all_features"],
   subscribe: ["subscribe_first", "subscribe_3", "subscribe_6", "subscribe_12"],
-  mention_keyword: ["mention_admin_hi", "mention_memory_seeker"],
+  mention_keyword: ["mention_admin_hi", "mention_memory_seeker", "mention_void_gazer"],
 };
 
 // --- Progress calculation strategies by achievement type ---
@@ -100,6 +100,7 @@ const ACHIEVEMENT_STRATEGY = {
   subscribe_12: cv => STRATEGIES.increment(cv),
   mention_admin_hi: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
   mention_memory_seeker: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
+  mention_void_gazer: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
 };
 
 const GODDESS_STONE_ITEM_ID = 999;

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -35,6 +35,7 @@ const EVENT_ACHIEVEMENT_MAP = {
   boss_attack: ["boss_first_kill", "boss_level_10", "boss_level_50", "boss_top_damage"],
   command_use: ["social_first_command", "social_all_features"],
   subscribe: ["subscribe_first", "subscribe_3", "subscribe_6", "subscribe_12"],
+  mention_keyword: ["mention_admin_hi"],
 };
 
 // --- Progress calculation strategies by achievement type ---
@@ -55,6 +56,19 @@ const STRATEGIES = {
   timeWindow(currentValue, achievement, startHour, endHour) {
     const hour = new Date(Date.now() + 8 * 60 * 60 * 1000).getUTCHours(); // Asia/Taipei
     return hour >= startHour && hour < endHour ? achievement.target_value : currentValue;
+  },
+  mentionKeyword(currentValue, achievement, context) {
+    const condition = achievement.condition || {};
+    const targetUserIds = Array.isArray(condition.targetUserIds) ? condition.targetUserIds : [];
+    const keywords = Array.isArray(condition.keywords) ? condition.keywords : [];
+    if (!targetUserIds.length || !keywords.length) return currentValue;
+
+    const mentioned = Array.isArray(context.mentionedUserIds) ? context.mentionedUserIds : [];
+    const text = typeof context.text === "string" ? context.text : "";
+
+    const allTagged = targetUserIds.every(id => mentioned.includes(id));
+    const allKeyword = keywords.every(k => text.includes(k));
+    return allTagged && allKeyword ? achievement.target_value : currentValue;
   },
 };
 
@@ -84,6 +98,7 @@ const ACHIEVEMENT_STRATEGY = {
   subscribe_3: cv => STRATEGIES.increment(cv),
   subscribe_6: cv => STRATEGIES.increment(cv),
   subscribe_12: cv => STRATEGIES.increment(cv),
+  mention_admin_hi: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
 };
 
 const GODDESS_STONE_ITEM_ID = 999;

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -91,16 +91,18 @@ const REDIS_TTL = 90 * 24 * 60 * 60; // 90 days
 
 /**
  * Evaluate achievements for a user after an event.
- * Fire-and-forget — errors are logged, never thrown.
+ * Errors are logged and swallowed, never thrown.
+ * @returns {Promise<{ unlocked: Array }>} newly unlocked achievement rows (empty if none).
  */
 exports.evaluate = async (userId, eventType, context = {}) => {
+  const unlocked = [];
   try {
     const achievementKeys = EVENT_ACHIEVEMENT_MAP[eventType];
-    if (!achievementKeys || achievementKeys.length === 0) return;
+    if (!achievementKeys || achievementKeys.length === 0) return { unlocked };
 
     const cache = await getCache();
     const achievements = achievementKeys.map(key => cache.find(a => a.key === key)).filter(Boolean);
-    if (achievements.length === 0) return;
+    if (achievements.length === 0) return { unlocked };
 
     const unlockedIds = await UserAchievementModel.getUnlockedIds(
       userId,
@@ -120,6 +122,7 @@ exports.evaluate = async (userId, eventType, context = {}) => {
 
         if (newValue >= achievement.target_value) {
           await unlockAchievement(userId, achievement);
+          unlocked.push(achievement);
         }
       } catch (innerErr) {
         DefaultLogger.error(
@@ -131,6 +134,7 @@ exports.evaluate = async (userId, eventType, context = {}) => {
   } catch (err) {
     DefaultLogger.error("AchievementEngine.evaluate error:", err);
   }
+  return { unlocked };
 };
 
 async function calculateProgress(userId, achievement, context) {

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -35,7 +35,7 @@ const EVENT_ACHIEVEMENT_MAP = {
   boss_attack: ["boss_first_kill", "boss_level_10", "boss_level_50", "boss_top_damage"],
   command_use: ["social_first_command", "social_all_features"],
   subscribe: ["subscribe_first", "subscribe_3", "subscribe_6", "subscribe_12"],
-  mention_keyword: ["mention_admin_hi"],
+  mention_keyword: ["mention_admin_hi", "mention_memory_seeker"],
 };
 
 // --- Progress calculation strategies by achievement type ---
@@ -61,13 +61,13 @@ const STRATEGIES = {
     const condition = achievement.condition || {};
     const targetUserIds = Array.isArray(condition.targetUserIds) ? condition.targetUserIds : [];
     const keywords = Array.isArray(condition.keywords) ? condition.keywords : [];
-    if (!targetUserIds.length || !keywords.length) return currentValue;
+    if (!targetUserIds.length) return currentValue;
 
     const mentioned = Array.isArray(context.mentionedUserIds) ? context.mentionedUserIds : [];
     const text = typeof context.text === "string" ? context.text : "";
 
     const allTagged = targetUserIds.every(id => mentioned.includes(id));
-    const allKeyword = keywords.every(k => text.includes(k));
+    const allKeyword = keywords.length === 0 || keywords.every(k => text.includes(k));
     return allTagged && allKeyword ? achievement.target_value : currentValue;
   },
 };
@@ -99,6 +99,7 @@ const ACHIEVEMENT_STRATEGY = {
   subscribe_6: cv => STRATEGIES.increment(cv),
   subscribe_12: cv => STRATEGIES.increment(cv),
   mention_admin_hi: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
+  mention_memory_seeker: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
 };
 
 const GODDESS_STONE_ITEM_ID = 999;

--- a/app/src/service/achievementNotifier.js
+++ b/app/src/service/achievementNotifier.js
@@ -1,0 +1,37 @@
+const mysql = require("../util/mysql");
+const { DefaultLogger } = require("../util/Logger");
+
+const DEFAULT_TEMPLATE_WITH_REWARD = "🎉 {user} 解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石";
+const DEFAULT_TEMPLATE_NO_REWARD = "🎉 {user} 解鎖成就「{icon} {name}」！";
+const FALLBACK_NAME = "玩家";
+
+async function getDisplayName(userId) {
+  const row = await mysql("user").where({ platform_id: userId }).select("display_name").first();
+  return (row && row.display_name) || FALLBACK_NAME;
+}
+
+function renderTemplate(achievement, userName) {
+  const fallback =
+    achievement.reward_stones > 0 ? DEFAULT_TEMPLATE_WITH_REWARD : DEFAULT_TEMPLATE_NO_REWARD;
+  const tpl = achievement.notify_message || fallback;
+  return tpl
+    .replace(/\{user\}/g, userName)
+    .replace(/\{name\}/g, achievement.name)
+    .replace(/\{icon\}/g, achievement.icon)
+    .replace(/\{reward\}/g, String(achievement.reward_stones));
+}
+
+async function notifyUnlocks(context, userId, achievements) {
+  try {
+    const toNotify = (achievements || []).filter(a => a && a.notify_on_unlock);
+    if (!toNotify.length) return;
+    const userName = await getDisplayName(userId);
+    for (const a of toNotify) {
+      context.replyText(renderTemplate(a, userName));
+    }
+  } catch (err) {
+    DefaultLogger.error("achievementNotifier.notifyUnlocks error:", err);
+  }
+}
+
+module.exports = { notifyUnlocks, renderTemplate };

--- a/docs/superpowers/plans/2026-04-17-mention-keyword-achievement-trigger.md
+++ b/docs/superpowers/plans/2026-04-17-mention-keyword-achievement-trigger.md
@@ -1,0 +1,1023 @@
+# Mention-Keyword Achievement Trigger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a data-driven `mention_keyword` event type to the achievement engine and an opt-in unlock-notification path that replies in-chat at zero LINE cost.
+
+**Architecture:** Store per-achievement trigger data + notification toggle in new columns on `achievements` (`condition` JSON, `notify_on_unlock` boolean, `notify_message` text). `AchievementEngine.evaluate()` returns the list of newly unlocked achievements; a standalone `achievementNotifier` helper renders a template and emits through Bottender's batched reply queue (`_shouldBatch = true` defaults to one `client.reply` API call per event).
+
+**Tech Stack:** Node.js + Bottender 1.5.5 + Knex + MySQL + Jest. CommonJS modules throughout.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-17-mention-keyword-achievement-trigger-design.md`
+
+---
+
+## File Structure
+
+**New:**
+- `app/migrations/<ts>_add_achievement_condition_and_notify.js` — adds 3 columns to `achievements`.
+- `app/src/service/achievementNotifier.js` — renders + emits unlock messages.
+- `app/__tests__/service/achievementNotifier.test.js` — notifier unit tests.
+
+**Modified:**
+- `app/src/service/AchievementEngine.js` — `evaluate()` returns `{ unlocked }`; add `mention_keyword` event type + `STRATEGIES.mentionKeyword`.
+- `app/__tests__/service/AchievementEngine.test.js` — new assertions for return value and new strategy.
+- `app/src/middleware/statistics.js` — fire `mention_keyword` + dispatch notifier.
+- `app/src/controller/princess/gacha.js` — consume return value + notify.
+- `app/src/controller/application/JankenController.js` — consume + notify (4 call sites at lines 267/268/436/437).
+- `app/src/controller/application/SubscribeController.js` — consume + notify (2 call sites at lines 85/255).
+
+---
+
+## Task 1: Schema Migration
+
+**Files:**
+- Create: `app/migrations/<yarn-generated-ts>_add_achievement_condition_and_notify.js`
+
+- [ ] **Step 1: Generate migration file**
+
+Run from `app/`:
+```bash
+yarn knex migrate:make add_achievement_condition_and_notify
+```
+
+Expected: new file under `app/migrations/` with UTC timestamp prefix.
+
+- [ ] **Step 2: Write migration contents**
+
+Overwrite the generated file with:
+
+```js
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("achievements", table => {
+    table.json("condition").nullable().comment("觸發條件資料，策略自行解析");
+    table
+      .boolean("notify_on_unlock")
+      .notNullable()
+      .defaultTo(false)
+      .comment("解鎖時是否通知聊天室");
+    table.text("notify_message").nullable().comment("通知模板，null 走預設");
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("achievements", table => {
+    table.dropColumn("condition");
+    table.dropColumn("notify_on_unlock");
+    table.dropColumn("notify_message");
+  });
+};
+```
+
+- [ ] **Step 3: Run migration**
+
+Run from `app/`:
+```bash
+yarn migrate
+```
+
+Expected: `Batch N run: 1 migrations` and no errors.
+
+- [ ] **Step 4: Verify columns exist**
+
+Run from `app/` inside a MySQL session (or via `make bash-redis`-equivalent MySQL shell):
+```sql
+DESCRIBE achievements;
+```
+
+Expected: `condition` (json, YES null), `notify_on_unlock` (tinyint(1), NO, default 0), `notify_message` (text, YES null).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/migrations/
+git commit -m "feat(achievement): add condition, notify_on_unlock, notify_message columns"
+```
+
+---
+
+## Task 2: Engine Returns Unlocked Array — Failing Test
+
+**Files:**
+- Test: `app/__tests__/service/AchievementEngine.test.js`
+
+- [ ] **Step 1: Add failing test for return value**
+
+Append to the existing `describe("AchievementEngine", ...)` block in `app/__tests__/service/AchievementEngine.test.js`:
+
+```js
+describe("evaluate return value", () => {
+  it("returns { unlocked: [] } when no achievement crosses threshold", async () => {
+    AchievementEngine._setCache([
+      {
+        id: 1,
+        key: "chat_100",
+        target_value: 100,
+        reward_stones: 0,
+        notify_on_unlock: false,
+        notify_message: null,
+        condition: null,
+      },
+    ]);
+    UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+    UserProgressModel.getProgress.mockResolvedValue({ current_value: 1 });
+    UserProgressModel.upsert.mockResolvedValue();
+
+    const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+    expect(result).toEqual({ unlocked: [] });
+  });
+
+  it("returns the unlocked achievement row when threshold is crossed", async () => {
+    const achievement = {
+      id: 2,
+      key: "chat_100",
+      target_value: 100,
+      reward_stones: 50,
+      notify_on_unlock: true,
+      notify_message: null,
+      condition: null,
+      icon: "💬",
+      name: "百句達人",
+    };
+    AchievementEngine._setCache([achievement]);
+    UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+    UserProgressModel.getProgress.mockResolvedValue({ current_value: 99 });
+    UserProgressModel.upsert.mockResolvedValue();
+    UserAchievementModel.unlock.mockResolvedValue();
+    UserProgressModel.delete.mockResolvedValue();
+    mysql.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue(),
+    });
+
+    const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+    expect(result.unlocked).toHaveLength(1);
+    expect(result.unlocked[0].key).toBe("chat_100");
+  });
+
+  it("returns { unlocked: [] } when inner error is swallowed", async () => {
+    AchievementEngine._setCache([
+      {
+        id: 3,
+        key: "chat_100",
+        target_value: 100,
+        reward_stones: 0,
+        notify_on_unlock: false,
+        notify_message: null,
+        condition: null,
+      },
+    ]);
+    UserAchievementModel.getUnlockedIds.mockRejectedValue(new Error("db down"));
+
+    const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+    expect(result).toEqual({ unlocked: [] });
+  });
+});
+```
+
+> **Note:** The existing test file already imports `UserAchievementModel`, `UserProgressModel`, `mysql`, and has `AchievementEngine._setCache` usage. Reuse the existing `beforeEach` / mock setup.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from `app/`:
+```bash
+yarn test -- AchievementEngine
+```
+
+Expected: The three new cases fail. Existing cases still pass. The failure messages say `expected { unlocked: [] }` but received `undefined`.
+
+---
+
+## Task 3: Engine Returns Unlocked Array — Implementation
+
+**Files:**
+- Modify: `app/src/service/AchievementEngine.js:96-134` (the `exports.evaluate` function)
+
+- [ ] **Step 1: Update `evaluate` to accumulate and return unlocked**
+
+Replace the body of `exports.evaluate` with:
+
+```js
+exports.evaluate = async (userId, eventType, context = {}) => {
+  const unlocked = [];
+  try {
+    const achievementKeys = EVENT_ACHIEVEMENT_MAP[eventType];
+    if (!achievementKeys || achievementKeys.length === 0) return { unlocked };
+
+    const cache = await getCache();
+    const achievements = achievementKeys.map(key => cache.find(a => a.key === key)).filter(Boolean);
+    if (achievements.length === 0) return { unlocked };
+
+    const unlockedIds = await UserAchievementModel.getUnlockedIds(
+      userId,
+      achievements.map(a => a.id)
+    );
+
+    const ctx = { ...context, _userId: userId };
+
+    for (const achievement of achievements) {
+      try {
+        if (unlockedIds.has(achievement.id)) continue;
+
+        const newValue = await calculateProgress(userId, achievement, ctx);
+        if (newValue === null) continue;
+
+        await UserProgressModel.upsert(userId, achievement.id, newValue);
+
+        if (newValue >= achievement.target_value) {
+          await unlockAchievement(userId, achievement);
+          unlocked.push(achievement);
+        }
+      } catch (innerErr) {
+        DefaultLogger.error(
+          `AchievementEngine.evaluate error for key ${achievement.key}:`,
+          innerErr
+        );
+      }
+    }
+  } catch (err) {
+    DefaultLogger.error("AchievementEngine.evaluate error:", err);
+  }
+  return { unlocked };
+};
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run from `app/`:
+```bash
+yarn test -- AchievementEngine
+```
+
+Expected: all tests including the three new return-value cases pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/service/AchievementEngine.js app/__tests__/service/AchievementEngine.test.js
+git commit -m "feat(achievement): evaluate returns { unlocked } for caller-driven notification"
+```
+
+---
+
+## Task 4: `mentionKeyword` Strategy — Failing Test
+
+**Files:**
+- Test: `app/__tests__/service/AchievementEngine.test.js`
+
+- [ ] **Step 1: Add failing test cases for the new strategy**
+
+Append to the test file:
+
+```js
+describe("mention_keyword event", () => {
+  const baseAchievement = {
+    id: 99,
+    key: "mention_admin_hi",
+    target_value: 1,
+    reward_stones: 100,
+    notify_on_unlock: true,
+    notify_message: null,
+    icon: "🫡",
+    name: "管理員粉絲",
+    condition: { targetUserIds: ["Uadmin"], keywords: ["大大好"] },
+  };
+
+  beforeEach(() => {
+    AchievementEngine._setCache([baseAchievement]);
+    UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+    UserProgressModel.getProgress.mockResolvedValue(null);
+    UserProgressModel.upsert.mockResolvedValue();
+    UserAchievementModel.unlock.mockResolvedValue();
+    UserProgressModel.delete.mockResolvedValue();
+    mysql.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue(),
+    });
+  });
+
+  it("unlocks when all target userIds are mentioned and all keywords are present", async () => {
+    const ctx = { mentionedUserIds: ["Uadmin"], text: "嗨 大大好 今天過得如何" };
+
+    const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+    expect(result.unlocked.map(a => a.key)).toEqual(["mention_admin_hi"]);
+  });
+
+  it("does not unlock when mention is missing", async () => {
+    const ctx = { mentionedUserIds: [], text: "大大好" };
+
+    const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+    expect(result.unlocked).toEqual([]);
+  });
+
+  it("does not unlock when keyword is missing", async () => {
+    const ctx = { mentionedUserIds: ["Uadmin"], text: "嗨" };
+
+    const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+    expect(result.unlocked).toEqual([]);
+  });
+
+  it("does not unlock when condition is null", async () => {
+    AchievementEngine._setCache([{ ...baseAchievement, condition: null }]);
+    const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
+
+    const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+    expect(result.unlocked).toEqual([]);
+  });
+
+  it("requires ALL target userIds (not just one)", async () => {
+    AchievementEngine._setCache([
+      {
+        ...baseAchievement,
+        condition: { targetUserIds: ["Uadmin", "Umod"], keywords: ["大大好"] },
+      },
+    ]);
+    const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
+
+    const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+    expect(result.unlocked).toEqual([]);
+  });
+
+  it("requires ALL keywords (not just one)", async () => {
+    AchievementEngine._setCache([
+      {
+        ...baseAchievement,
+        condition: { targetUserIds: ["Uadmin"], keywords: ["大大好", "早安"] },
+      },
+    ]);
+    const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
+
+    const result = await AchievementEngine.evaluate("user1", "mention_keyword", ctx);
+
+    expect(result.unlocked).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from `app/`:
+```bash
+yarn test -- AchievementEngine
+```
+
+Expected: the six new cases all fail — the first one fails because the `mention_keyword` event type is not in `EVENT_ACHIEVEMENT_MAP`, so `evaluate` short-circuits before strategy runs.
+
+---
+
+## Task 5: `mentionKeyword` Strategy — Implementation
+
+**Files:**
+- Modify: `app/src/service/AchievementEngine.js:28-38` (`EVENT_ACHIEVEMENT_MAP`)
+- Modify: `app/src/service/AchievementEngine.js:42-59` (`STRATEGIES`)
+- Modify: `app/src/service/AchievementEngine.js:61-87` (`ACHIEVEMENT_STRATEGY`)
+
+- [ ] **Step 1: Add the new event type**
+
+Update `EVENT_ACHIEVEMENT_MAP` to include:
+
+```js
+const EVENT_ACHIEVEMENT_MAP = {
+  chat_message: ["chat_100", "chat_1000", "chat_5000", "chat_night_owl", "chat_multi_group"],
+  gacha_pull: ["gacha_first", "gacha_100", "gacha_500", "gacha_collector_50", "gacha_lucky"],
+  janken_win: ["janken_first_win", "janken_win_50", "janken_streak_5", "janken_streak_10"],
+  janken_lose: [],
+  janken_draw: [],
+  janken_challenge: ["janken_challenged_10"],
+  boss_attack: ["boss_first_kill", "boss_level_10", "boss_level_50", "boss_top_damage"],
+  command_use: ["social_first_command", "social_all_features"],
+  subscribe: ["subscribe_first", "subscribe_3", "subscribe_6", "subscribe_12"],
+  mention_keyword: ["mention_admin_hi"],
+};
+```
+
+- [ ] **Step 2: Add the `mentionKeyword` reusable strategy**
+
+Inside `STRATEGIES = { ... }`, add:
+
+```js
+  mentionKeyword(currentValue, achievement, context) {
+    const condition = achievement.condition || {};
+    const targetUserIds = Array.isArray(condition.targetUserIds) ? condition.targetUserIds : [];
+    const keywords = Array.isArray(condition.keywords) ? condition.keywords : [];
+    if (!targetUserIds.length || !keywords.length) return currentValue;
+
+    const mentioned = Array.isArray(context.mentionedUserIds) ? context.mentionedUserIds : [];
+    const text = typeof context.text === "string" ? context.text : "";
+
+    const allTagged = targetUserIds.every(id => mentioned.includes(id));
+    const allKeyword = keywords.every(k => text.includes(k));
+    return allTagged && allKeyword ? achievement.target_value : currentValue;
+  },
+```
+
+- [ ] **Step 3: Wire the per-key strategy**
+
+Inside `ACHIEVEMENT_STRATEGY = { ... }`, append:
+
+```js
+  mention_admin_hi: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run from `app/`:
+```bash
+yarn test -- AchievementEngine
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/service/AchievementEngine.js app/__tests__/service/AchievementEngine.test.js
+git commit -m "feat(achievement): add mention_keyword trigger with all-match semantics"
+```
+
+---
+
+## Task 6: Notifier Helper — Failing Tests
+
+**Files:**
+- Test: `app/__tests__/service/achievementNotifier.test.js`
+
+- [ ] **Step 1: Create the test file**
+
+Create `app/__tests__/service/achievementNotifier.test.js` with:
+
+```js
+jest.mock("../../src/util/mysql");
+const mysql = require("../../src/util/mysql");
+const { notifyUnlocks, renderTemplate } = require("../../src/service/achievementNotifier");
+
+describe("achievementNotifier", () => {
+  describe("renderTemplate", () => {
+    it("uses the with-reward default when notify_message is null and reward > 0", () => {
+      const out = renderTemplate(
+        { name: "夜貓子", icon: "🌙", reward_stones: 50, notify_message: null },
+        "Alice"
+      );
+      expect(out).toBe("🎉 Alice 解鎖成就「🌙 夜貓子」！獲得 50 顆女神石");
+    });
+
+    it("uses the no-reward default when notify_message is null and reward is 0", () => {
+      const out = renderTemplate(
+        { name: "彩蛋", icon: "🥚", reward_stones: 0, notify_message: null },
+        "Bob"
+      );
+      expect(out).toBe("🎉 Bob 解鎖成就「🥚 彩蛋」！");
+    });
+
+    it("substitutes placeholders in a custom notify_message", () => {
+      const out = renderTemplate(
+        {
+          name: "測試",
+          icon: "🧪",
+          reward_stones: 10,
+          notify_message: "{user} -> {name} ({icon}) +{reward}",
+        },
+        "Carol"
+      );
+      expect(out).toBe("Carol -> 測試 (🧪) +10");
+    });
+
+    it("replaces repeated placeholders globally", () => {
+      const out = renderTemplate(
+        {
+          name: "重複",
+          icon: "🔁",
+          reward_stones: 1,
+          notify_message: "{user} {user} {name} {name}",
+        },
+        "Dan"
+      );
+      expect(out).toBe("Dan Dan 重複 重複");
+    });
+  });
+
+  describe("notifyUnlocks", () => {
+    let context;
+
+    beforeEach(() => {
+      context = { replyText: jest.fn() };
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue({ display_name: "Eve" }),
+      });
+    });
+
+    it("does nothing when no achievement opts in", async () => {
+      await notifyUnlocks(context, "user1", [
+        { notify_on_unlock: false, name: "X", icon: "X", reward_stones: 0, notify_message: null },
+      ]);
+      expect(context.replyText).not.toHaveBeenCalled();
+    });
+
+    it("skips user lookup when list is empty", async () => {
+      await notifyUnlocks(context, "user1", []);
+      expect(context.replyText).not.toHaveBeenCalled();
+      expect(mysql).not.toHaveBeenCalled();
+    });
+
+    it("replies once per opt-in achievement", async () => {
+      await notifyUnlocks(context, "user1", [
+        {
+          notify_on_unlock: true,
+          name: "A",
+          icon: "🅰",
+          reward_stones: 10,
+          notify_message: null,
+        },
+        {
+          notify_on_unlock: false,
+          name: "B",
+          icon: "🅱",
+          reward_stones: 0,
+          notify_message: null,
+        },
+        {
+          notify_on_unlock: true,
+          name: "C",
+          icon: "🇨",
+          reward_stones: 0,
+          notify_message: null,
+        },
+      ]);
+      expect(context.replyText).toHaveBeenCalledTimes(2);
+      expect(context.replyText).toHaveBeenNthCalledWith(
+        1,
+        "🎉 Eve 解鎖成就「🅰 A」！獲得 10 顆女神石"
+      );
+      expect(context.replyText).toHaveBeenNthCalledWith(2, "🎉 Eve 解鎖成就「🇨 C」！");
+    });
+
+    it("uses fallback display name 玩家 when user row is missing", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      });
+      await notifyUnlocks(context, "missing-user", [
+        {
+          notify_on_unlock: true,
+          name: "Z",
+          icon: "🅉",
+          reward_stones: 0,
+          notify_message: null,
+        },
+      ]);
+      expect(context.replyText).toHaveBeenCalledWith("🎉 玩家 解鎖成就「🅉 Z」！");
+    });
+
+    it("swallows internal errors so the middleware chain never breaks", async () => {
+      mysql.mockImplementation(() => {
+        throw new Error("db down");
+      });
+      await expect(
+        notifyUnlocks(context, "user1", [
+          {
+            notify_on_unlock: true,
+            name: "A",
+            icon: "🅰",
+            reward_stones: 0,
+            notify_message: null,
+          },
+        ])
+      ).resolves.toBeUndefined();
+      expect(context.replyText).not.toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from `app/`:
+```bash
+yarn test -- achievementNotifier
+```
+
+Expected: tests fail — the module does not exist yet.
+
+---
+
+## Task 7: Notifier Helper — Implementation
+
+**Files:**
+- Create: `app/src/service/achievementNotifier.js`
+
+- [ ] **Step 1: Create the helper**
+
+Create `app/src/service/achievementNotifier.js` with:
+
+```js
+const mysql = require("../util/mysql");
+const { DefaultLogger } = require("../util/Logger");
+
+const DEFAULT_TEMPLATE_WITH_REWARD =
+  "🎉 {user} 解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石";
+const DEFAULT_TEMPLATE_NO_REWARD = "🎉 {user} 解鎖成就「{icon} {name}」！";
+const FALLBACK_NAME = "玩家";
+
+async function getDisplayName(userId) {
+  const row = await mysql("user")
+    .where({ platform_id: userId })
+    .select("display_name")
+    .first();
+  return (row && row.display_name) || FALLBACK_NAME;
+}
+
+function renderTemplate(achievement, userName) {
+  const fallback =
+    achievement.reward_stones > 0 ? DEFAULT_TEMPLATE_WITH_REWARD : DEFAULT_TEMPLATE_NO_REWARD;
+  const tpl = achievement.notify_message || fallback;
+  return tpl
+    .replace(/\{user\}/g, userName)
+    .replace(/\{name\}/g, achievement.name)
+    .replace(/\{icon\}/g, achievement.icon)
+    .replace(/\{reward\}/g, String(achievement.reward_stones));
+}
+
+async function notifyUnlocks(context, userId, achievements) {
+  try {
+    const toNotify = (achievements || []).filter(a => a && a.notify_on_unlock);
+    if (!toNotify.length) return;
+    const userName = await getDisplayName(userId);
+    for (const a of toNotify) {
+      context.replyText(renderTemplate(a, userName));
+    }
+  } catch (err) {
+    DefaultLogger.error("achievementNotifier.notifyUnlocks error:", err);
+  }
+}
+
+module.exports = { notifyUnlocks, renderTemplate };
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run from `app/`:
+```bash
+yarn test -- achievementNotifier
+```
+
+Expected: all seven cases pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/service/achievementNotifier.js app/__tests__/service/achievementNotifier.test.js
+git commit -m "feat(achievement): add achievementNotifier with templated unlock replies"
+```
+
+---
+
+## Task 8: Wire Notifier Into `statistics` Middleware
+
+**Files:**
+- Modify: `app/src/middleware/statistics.js`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `app/src/middleware/statistics.js`, below the existing requires, add:
+
+```js
+const { get } = require("lodash");
+const { notifyUnlocks } = require("../service/achievementNotifier");
+```
+
+> **Verify:** `lodash` is used elsewhere in the project (e.g. `app/src/controller/application/MarketController.js`), so the dependency is already present.
+
+- [ ] **Step 2: Replace the `chat_message` block**
+
+Replace the current `if (context.event.isText) { ... }` block with:
+
+```js
+if (context.event.isText) {
+  const userId = context.event.source.userId;
+  const groupId = context.event.source.groupId;
+  if (userId) {
+    const mentionees = get(context, "event.message.mention.mentionees", []) || [];
+    const mentionedUserIds = mentionees.map(m => m && m.userId).filter(Boolean);
+    const text = context.event.text || "";
+
+    const tasks = [
+      AchievementEngine.evaluate(userId, "chat_message", { groupId, text }).catch(() => ({
+        unlocked: [],
+      })),
+    ];
+    if (mentionedUserIds.length) {
+      tasks.push(
+        AchievementEngine.evaluate(userId, "mention_keyword", {
+          mentionedUserIds,
+          text,
+        }).catch(() => ({ unlocked: [] }))
+      );
+    }
+
+    const results = await Promise.all(tasks);
+    const unlocked = results.flatMap(r => (r && r.unlocked) || []);
+    await notifyUnlocks(context, userId, unlocked);
+  }
+}
+```
+
+- [ ] **Step 3: Lint**
+
+Run from `app/`:
+```bash
+yarn lint
+```
+
+Expected: no errors for `src/middleware/statistics.js`.
+
+- [ ] **Step 4: Run tests**
+
+Run from `app/`:
+```bash
+yarn test
+```
+
+Expected: full suite passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/middleware/statistics.js
+git commit -m "feat(achievement): fire mention_keyword + notify unlocks from statistics"
+```
+
+---
+
+## Task 9: Consume Notifier in `gacha.js`
+
+**Files:**
+- Modify: `app/src/controller/princess/gacha.js:476` (the `AchievementEngine.evaluate` call)
+
+- [ ] **Step 1: Add import**
+
+At the top of `app/src/controller/princess/gacha.js`, near the existing `AchievementEngine` require, add:
+
+```js
+const { notifyUnlocks } = require("../../service/achievementNotifier");
+```
+
+- [ ] **Step 2: Replace the evaluate call**
+
+Replace lines around 476 (`AchievementEngine.evaluate(userId, "gacha_pull", { ... }).catch(() => {});`) with:
+
+```js
+const { unlocked } = await AchievementEngine.evaluate(userId, "gacha_pull", {
+  threeStarCount: rareCount[3] || 0,
+  uniqueCount: dailyResult.ownCharactersCount + dailyResult.newCharacters.length,
+}).catch(() => ({ unlocked: [] }));
+await notifyUnlocks(context, userId, unlocked);
+```
+
+> The original call was fire-and-forget; now it is awaited. If the surrounding function is not already `async`, verify before committing (it must be, because other awaits exist in this controller — grep `grep -n "async" app/src/controller/princess/gacha.js`).
+
+- [ ] **Step 3: Lint**
+
+Run from `app/`:
+```bash
+yarn lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run tests**
+
+Run from `app/`:
+```bash
+yarn test
+```
+
+Expected: full suite passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/controller/princess/gacha.js
+git commit -m "feat(achievement): await gacha evaluate + notify unlocks"
+```
+
+---
+
+## Task 10: Consume Notifier in `JankenController.js`
+
+**Files:**
+- Modify: `app/src/controller/application/JankenController.js:267-268` and `436-437`
+
+- [ ] **Step 1: Add import**
+
+At the top of `app/src/controller/application/JankenController.js`, near the existing `AchievementEngine` require, add:
+
+```js
+const { notifyUnlocks } = require("../../service/achievementNotifier");
+```
+
+- [ ] **Step 2: Replace the first pair of calls (lines ~267-268)**
+
+Replace:
+
+```js
+AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => {});
+AchievementEngine.evaluate(targetUserId, "janken_challenge", {}).catch(() => {});
+```
+
+With:
+
+```js
+const [winResult, challengeResult] = await Promise.all([
+  AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => ({
+    unlocked: [],
+  })),
+  AchievementEngine.evaluate(targetUserId, "janken_challenge", {}).catch(() => ({
+    unlocked: [],
+  })),
+]);
+await notifyUnlocks(context, winnerId, winResult.unlocked);
+await notifyUnlocks(context, targetUserId, challengeResult.unlocked);
+```
+
+- [ ] **Step 3: Replace the second pair of calls (lines ~436-437)**
+
+Apply the same transformation using the local variable names at that call site (`holderUserId` / `challengerUserId`). Use them in the `notifyUnlocks` call so the correct user's display name is looked up:
+
+```js
+const [winResult, challengeResult] = await Promise.all([
+  AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => ({
+    unlocked: [],
+  })),
+  AchievementEngine.evaluate(challengerUserId, "janken_challenge", {}).catch(() => ({
+    unlocked: [],
+  })),
+]);
+await notifyUnlocks(context, winnerId, winResult.unlocked);
+await notifyUnlocks(context, challengerUserId, challengeResult.unlocked);
+```
+
+- [ ] **Step 4: Lint**
+
+Run from `app/`:
+```bash
+yarn lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run tests**
+
+Run from `app/`:
+```bash
+yarn test
+```
+
+Expected: full suite passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/controller/application/JankenController.js
+git commit -m "feat(achievement): await janken evaluate + notify unlocks"
+```
+
+---
+
+## Task 11: Consume Notifier in `SubscribeController.js`
+
+**Files:**
+- Modify: `app/src/controller/application/SubscribeController.js:85` and `:255`
+
+- [ ] **Step 1: Add import**
+
+At the top of `app/src/controller/application/SubscribeController.js`, near the existing `AchievementEngine` require, add:
+
+```js
+const { notifyUnlocks } = require("../../service/achievementNotifier");
+```
+
+- [ ] **Step 2: Replace first call (line ~85)**
+
+Replace:
+
+```js
+AchievementEngine.evaluate(userId, "subscribe").catch(() => {});
+```
+
+With:
+
+```js
+const { unlocked } = await AchievementEngine.evaluate(userId, "subscribe").catch(() => ({
+  unlocked: [],
+}));
+await notifyUnlocks(context, userId, unlocked);
+```
+
+- [ ] **Step 3: Replace second call (line ~255)**
+
+Apply the same replacement at the second occurrence. If the enclosing function lacks a `context` parameter, propagate it from the caller; grep the file to confirm the signature and adjust if necessary.
+
+- [ ] **Step 4: Lint**
+
+Run from `app/`:
+```bash
+yarn lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run tests**
+
+Run from `app/`:
+```bash
+yarn test
+```
+
+Expected: full suite passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/controller/application/SubscribeController.js
+git commit -m "feat(achievement): await subscribe evaluate + notify unlocks"
+```
+
+---
+
+## Task 12: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run from `app/`:
+```bash
+yarn test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Lint full codebase**
+
+Run from `app/`:
+```bash
+yarn lint
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Smoke-test a mention unlock locally**
+
+Using the dev server (`yarn dev`) and a LINE test group:
+
+1. Insert a test achievement row:
+   ```sql
+   INSERT INTO achievements
+     (category_id, key, name, description, icon, type, rarity, target_value, reward_stones, `order`, `condition`, notify_on_unlock)
+   VALUES
+     ((SELECT id FROM achievement_categories WHERE `key`='social'),
+      'mention_admin_hi', '管理員粉絲', '與管理員打招呼', '🫡',
+      'hidden', 2, 1, 100, 99,
+      JSON_OBJECT('targetUserIds', JSON_ARRAY('<your-admin-userId>'),
+                  'keywords', JSON_ARRAY('大大好')),
+      TRUE);
+   ```
+2. In a LINE group with the bot, @mention the admin userId and send the message `大大好`.
+3. Confirm the bot replies with `🎉 <你的名字> 解鎖成就「🫡 管理員粉絲」！獲得 100 顆女神石`.
+4. Confirm the achievement shows up as unlocked in the admin dashboard.
+
+If the smoke test passes, proceed. If it fails, diagnose via `make logs` and `DefaultLogger` output.
+
+- [ ] **Step 4: Merge / PR per repository convention**
+
+Follow the project's PR workflow (see `docs/features/commit-and-pr.md` or equivalent). Do not self-merge.
+
+---
+
+## Self-Review Notes
+
+- All spec sections are covered: schema (Task 1), engine return (Tasks 2-3), new trigger (Tasks 4-5), notifier (Tasks 6-7), dispatch + call-site updates (Tasks 8-11), verification (Task 12).
+- No TBD/TODO placeholders; every code step contains the full code.
+- Property names are consistent across tasks: `notify_on_unlock`, `notify_message`, `condition.targetUserIds`, `condition.keywords`, `{ unlocked }`.
+- `condition.targetUserIds` and `condition.keywords` use `every` semantics throughout (Tasks 4-5 tests and strategy agree).
+- Default fallback names consistent: `玩家` in both spec and Task 7 implementation + Task 6 tests.

--- a/docs/superpowers/specs/2026-04-17-mention-keyword-achievement-trigger-design.md
+++ b/docs/superpowers/specs/2026-04-17-mention-keyword-achievement-trigger-design.md
@@ -1,0 +1,255 @@
+# Mention-Keyword Achievement Trigger + Unlock Notification
+
+**Date:** 2026-04-17
+**Status:** Draft — pending implementation
+
+## Context
+
+The achievement system (shipped in `feat/achievement-system-revamp`) supports event-driven unlocks via `AchievementEngine.evaluate(userId, eventType, context)`. All triggers are hard-coded in `EVENT_ACHIEVEMENT_MAP` and strategy functions in `app/src/service/AchievementEngine.js`.
+
+Two gaps motivate this design:
+
+1. **No mention-based trigger.** A new trigger type is needed where a user mentions a specific target user (e.g. an admin, or any configurable userId) and includes specific keywords in the same message. The target userId list must be configurable per achievement — not hard-coded to admins — so future achievements can target any userId.
+
+2. **Silent unlocks.** `unlockAchievement()` only logs to stdout. The user wants select achievements (opt-in) to emit a visible message back to the chat where the unlock was triggered.
+
+## Goals
+
+- Introduce a data-driven `mention_keyword` event type with per-achievement configurable conditions (target userIds + keywords).
+- Extend `AchievementEngine.evaluate()` to return newly unlocked achievements so callers can notify.
+- Provide a notification helper that renders a templated unlock message and emits it via Bottender's batched reply queue (zero additional LINE API cost).
+- Keep the engine free of Bottender coupling so batch/cron usage is unaffected.
+
+## Non-Goals
+
+- Migrating existing hard-coded strategy parameters (e.g. `timeWindow(3, 4)` for night-owl) to the new `condition` column. That can happen opportunistically later.
+- LINE push messages. Only reply-token messaging is used. Reply is free; push is billed and explicitly rejected.
+- Notification throttling, deduplication, or rate-limiting beyond the Bottender reply-queue's native 5-message cap.
+- Frontend changes to the admin dashboard.
+
+## Design
+
+### 1. Schema
+
+Add three nullable/default columns to the `achievements` table via a new Knex migration:
+
+| Column | Type | Default | Purpose |
+|---|---|---|---|
+| `condition` | `json` | `null` | Strategy-specific trigger data. Schema is owned by the strategy function, not the engine. |
+| `notify_on_unlock` | `boolean` | `false` | Gate for emitting an unlock reply. Existing achievements default to silent (current behavior). |
+| `notify_message` | `text` | `null` | Optional custom template. `null` → default template selected at render time. |
+
+Migration: `app/migrations/<timestamp>_add_achievement_condition_and_notify.js` (generated via `yarn knex migrate:make`).
+
+### 2. Condition Schema (for `mention_keyword` event)
+
+Stored as JSON in `achievements.condition`:
+
+```json
+{
+  "targetUserIds": ["U123...", "U456..."],
+  "keywords": ["謝謝", "感謝"]
+}
+```
+
+Semantics:
+- `targetUserIds`: **all** must appear in the message's `mention.mentionees`. Empty or missing → strategy returns the current progress value unchanged (no unlock).
+- `keywords`: **all** must be substrings of the message text. Empty or missing → strategy returns the current progress value unchanged (no unlock).
+- 1-on-1 chats: no special guard. Mentioning in a 1-on-1 is not supported by LINE, so the condition cannot fire.
+
+Other strategies may define their own condition shape in the future. The engine does not inspect `condition` — it only passes `achievement` through to the strategy function.
+
+### 3. Engine API Change
+
+`AchievementEngine.evaluate()` returns a result object:
+
+```js
+// before: returns undefined (fire-and-forget)
+// after:
+async evaluate(userId, eventType, context = {}) {
+  // ...
+  return { unlocked: Achievement[] };  // empty array if none
+}
+```
+
+- Internal try/catch preserved. On error, returns `{ unlocked: [] }` (never throws).
+- Existing callers using `.catch(() => {})` continue to work — they simply ignore the return value.
+- `unlocked[]` contains the full achievement row (with `notify_on_unlock`, `notify_message`, `icon`, `name`, `reward_stones`).
+
+### 4. New Event Type & Strategy
+
+In `AchievementEngine.js`:
+
+```js
+EVENT_ACHIEVEMENT_MAP.mention_keyword = [/* achievement keys using this trigger */];
+
+// Strategy — reused across all mention_keyword achievements
+STRATEGIES.mentionKeyword = (cv, a, ctx) => {
+  const { targetUserIds = [], keywords = [] } = a.condition || {};
+  if (!targetUserIds.length || !keywords.length) return cv;
+  const mentioned = ctx.mentionedUserIds || [];
+  const allTagged = targetUserIds.every(id => mentioned.includes(id));
+  const allKeyword = keywords.every(k => (ctx.text || "").includes(k));
+  return (allTagged && allKeyword) ? a.target_value : cv;
+};
+
+// Per-achievement wiring
+ACHIEVEMENT_STRATEGY.<mention_achievement_key> = (cv, a, ctx) =>
+  STRATEGIES.mentionKeyword(cv, a, ctx);
+```
+
+### 5. Dispatch Point (statistics middleware)
+
+`app/src/middleware/statistics.js` already fires `chat_message` on every text message. Add a parallel `mention_keyword` fire when `mention.mentionees` is non-empty, then notify unlocks from both:
+
+```js
+if (context.event.isText && userId) {
+  const mentionees = get(context, "event.message.mention.mentionees", []);
+  const mentionedUserIds = mentionees.map(m => m.userId).filter(Boolean);
+  const text = context.event.text || "";
+
+  const tasks = [
+    AchievementEngine.evaluate(userId, "chat_message", { groupId, text }),
+  ];
+  if (mentionedUserIds.length) {
+    tasks.push(
+      AchievementEngine.evaluate(userId, "mention_keyword", { mentionedUserIds, text })
+    );
+  }
+  const results = await Promise.all(tasks.map(p => p.catch(() => ({ unlocked: [] }))));
+  const unlocked = results.flatMap(r => r.unlocked);
+  await notifyUnlocks(context, userId, unlocked);
+}
+```
+
+This adds one `await` to a previously fire-and-forget middleware. The added latency is bounded (in-memory cache + indexed DB lookups).
+
+### 6. Notification Helper
+
+New file: `app/src/service/achievementNotifier.js`
+
+```js
+const DEFAULT_TEMPLATE_WITH_REWARD =
+  "🎉 {user} 解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石";
+const DEFAULT_TEMPLATE_NO_REWARD =
+  "🎉 {user} 解鎖成就「{icon} {name}」！";
+
+async function notifyUnlocks(context, userId, achievements) {
+  const toNotify = achievements.filter(a => a.notify_on_unlock);
+  if (!toNotify.length) return;
+  const userName = await getDisplayName(userId);
+  for (const a of toNotify) {
+    context.replyText(renderTemplate(a, userName));
+  }
+}
+
+function renderTemplate(a, userName) {
+  const fallback = a.reward_stones > 0
+    ? DEFAULT_TEMPLATE_WITH_REWARD
+    : DEFAULT_TEMPLATE_NO_REWARD;
+  const tpl = a.notify_message || fallback;
+  return tpl
+    .replace(/\{user\}/g, userName)
+    .replace(/\{name\}/g, a.name)
+    .replace(/\{icon\}/g, a.icon)
+    .replace(/\{reward\}/g, String(a.reward_stones));
+}
+
+module.exports = { notifyUnlocks };
+```
+
+- `getDisplayName(userId)` queries the `user` table (`platform_id`), returns `display_name`. If the row is missing or `display_name` is null, falls back to the literal string `"玩家"`.
+- Supported placeholders: `{user}`, `{name}`, `{icon}`, `{reward}`. `{description}` intentionally excluded.
+- Bottender's batched reply queue (`_shouldBatch = true` by default in `LineConnector`) absorbs multiple `replyText` calls and flushes them as a single `reply` API call in `handlerDidEnd()` — zero extra LINE cost.
+
+### 7. Other Call-Site Updates
+
+`evaluate()` is also called from:
+
+- `app/src/middleware/statistics.js` (covered above)
+- `app/src/controller/princess/gacha.js:476`
+- `app/src/controller/application/JankenController.js:267, 436`
+- `app/src/controller/application/SubscribeController.js:85, 255`
+
+For consistency — so any achievement with `notify_on_unlock=true` emits regardless of trigger source — all call sites switch to:
+
+```js
+const { unlocked } = await AchievementEngine.evaluate(userId, eventType, ctx)
+  .catch(() => ({ unlocked: [] }));
+await notifyUnlocks(context, userId, unlocked);
+```
+
+Batch evaluation (`AchievementEngine.batchEvaluate()` / cron) ignores the return value — no `context`, no chat to reply to. That is acceptable.
+
+### 8. Reply-Queue 5-Message Cap
+
+LINE reply tokens cap at 5 messages per reply. When a single event causes more than 5 `context.replyText` calls combined (controller replies + unlock notifications), Bottender drops the overflow and emits a warning.
+
+This design **does not** add special handling. Rationale:
+- A single message triggering multiple unlocks is rare.
+- The overflow dropping is handled gracefully by Bottender (no crash).
+- Prioritization (e.g. keep rarest) can be a follow-up if production logs show it happening.
+
+### 9. Adding a Concrete Mention-Keyword Achievement (example flow)
+
+The feature ships without a specific achievement; it provides the trigger type. To add one later (via add-achievement skill):
+
+1. Migration inserts into `achievements` with:
+   - `type: "hidden"`, `rarity: 2`
+   - `target_value: 1`, `reward_stones: 300`
+   - `condition: JSON.stringify({ targetUserIds: ["U..."], keywords: ["..."] })`
+   - `notify_on_unlock: true`, `notify_message: null` (use default) or custom text.
+2. Add the key to `EVENT_ACHIEVEMENT_MAP.mention_keyword`.
+3. Add `ACHIEVEMENT_STRATEGY.<key> = (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx);`.
+
+## Error Handling
+
+- `evaluate()` continues to swallow all internal errors and log via `DefaultLogger`. On error returns `{ unlocked: [] }`.
+- `notifyUnlocks` errors (e.g. user lookup failure) must not break the middleware chain. Wrap in try/catch; log and continue.
+- Missing/malformed `condition` JSON in DB: strategy returns `cv` unchanged (no progress, no crash).
+
+## Testing
+
+Jest tests in `app/src/service/__tests__/`:
+
+- `AchievementEngine.test.js` additions:
+  - `evaluate` returns `{ unlocked: [] }` when no progress.
+  - `evaluate` returns unlocked array with full achievement row when a threshold is crossed.
+  - `mentionKeyword` strategy: all target + all keyword match → unlocks.
+  - `mentionKeyword` strategy: partial target / partial keyword / empty condition → no unlock.
+
+- `achievementNotifier.test.js` (new):
+  - Filters non-`notify_on_unlock` entries.
+  - Uses custom template when `notify_message` set.
+  - Falls back to with-reward template when `reward_stones > 0` and `notify_message` null.
+  - Falls back to no-reward template when `reward_stones === 0` and `notify_message` null.
+  - Placeholder replacement handles repeated placeholders (global regex).
+
+Integration smoke-check: manually trigger a mention-based achievement in a test LINE group.
+
+## Migration & Rollout
+
+1. Schema migration runs in a single step; all existing rows default `notify_on_unlock=false`, `condition=null`, `notify_message=null` → zero user-visible change.
+2. Engine changes are backward compatible (new return value, existing callers ignore).
+3. Call-site updates can roll out incrementally — each site independently benefits from unlock notifications once updated.
+4. New mention-keyword achievements are added via subsequent migrations as content decisions are made.
+
+## Open Questions
+
+None at spec-approval time.
+
+## Files Touched
+
+**New:**
+- `app/src/service/achievementNotifier.js`
+- `app/src/service/__tests__/achievementNotifier.test.js`
+- `app/migrations/<timestamp>_add_achievement_condition_and_notify.js`
+
+**Modified:**
+- `app/src/service/AchievementEngine.js` (return value, new strategy, new event type)
+- `app/src/middleware/statistics.js` (dispatch + notify)
+- `app/src/controller/princess/gacha.js` (call-site update)
+- `app/src/controller/application/JankenController.js` (call-site update, 2 places)
+- `app/src/controller/application/SubscribeController.js` (call-site update, 2 places)
+- `app/src/model/application/Achievement.js` (if column list is explicit)
+- `app/src/service/__tests__/AchievementEngine.test.js` (new cases)


### PR DESCRIPTION
## Summary

- Add a data-driven `mention_keyword` achievement trigger: a message that @mentions all configured target userIds (and optionally includes required keywords) unlocks the achievement. Condition is stored as JSON per-achievement, so new mention-based achievements need only a migration + two lines in `AchievementEngine.js`.
- Add opt-in unlock notifications: achievements with `notify_on_unlock=true` emit a templated reply back to the originating chat via Bottender's batched reply queue (zero extra LINE API cost). Supports custom `notify_message` with `{user}/{name}/{icon}/{reward}` placeholders, falling back to a default template.
- Seed three hidden achievements using the new trigger:
  - 🥞 **來自鬆餅的祝福** — mention a specific admin with keywords `鬆餅` + `祝福`
  - 🍮 **追尋神祇回憶的人** — mention-only (no keywords) for the 布丁古神 persona
  - 👁️ **凝視虛無者** — cyberpunk easter egg, mention + `sudo su`
- Update the `add-achievement` skill doc to cover `mention_keyword` (both keyword-gated and mention-only variants) and the notification mechanism.

## Implementation notes

- `AchievementEngine.evaluate()` now returns `{ unlocked: Achievement[] }`. Existing callers that used `.catch(() => {})` continue to work by ignoring the return value. Call sites with a Bottender `context` (statistics, gacha, janken, subscribe) destructure `unlocked` and call `notifyUnlocks(context, userId, unlocked)`.
- Already-unlocked achievements short-circuit before the strategy runs — repeated @mentions of the target userId don't cause redundant computation beyond a single indexed DB lookup.
- `statistics.js` auto-dispatches `mention_keyword` on every text message with mentionees, so new mention-based achievements don't need controller wiring.

## Test plan

- [x] `yarn jest app/__tests__/service/AchievementEngine.test.js` — 16/16 passing (includes mention_keyword all-match, keyword-absent, mention-only, and empty-condition cases)
- [x] `yarn jest app/__tests__/service/achievementNotifier.test.js` — 9/9 passing (template fallback, placeholder replacement, filter by `notify_on_unlock`)
- [x] Full suite: 170/171 passing (only failure is pre-existing `images.test.js` from the Imgur→PictShare migration, unrelated)
- [x] Migration runs cleanly against local MySQL; rows verified via direct DB query (UTF-8/emoji/JSON all intact)
- [ ] Smoke test in a real LINE group: mention each target userId with the appropriate trigger and confirm the bot replies with the templated unlock message

🤖 Generated with [Claude Code](https://claude.com/claude-code)