### PR TITLE
feat(achievement): seed gacha command tier achievements

### DIFF
--- a/app/migrations/20260417180012_seed_gacha_command_achievements.js
+++ b/app/migrations/20260417180012_seed_gacha_command_achievements.js
@@ -1,0 +1,145 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const CATEGORY_KEY = "gacha";
+
+const ACHIEVEMENTS = [
+  {
+    key: "gacha_europe_1",
+    name: "歐陸初旅",
+    description: "首次使用 #歐洲抽",
+    icon: "🏰",
+    type: "milestone",
+    rarity: 0,
+    target_value: 1,
+    reward_stones: 30,
+    order: 6,
+    pullType: "europe",
+  },
+  {
+    key: "gacha_europe_10",
+    name: "歐洲常客",
+    description: "累計 10 次 #歐洲抽",
+    icon: "🎩",
+    type: "milestone",
+    rarity: 1,
+    target_value: 10,
+    reward_stones: 200,
+    order: 7,
+    pullType: "europe",
+  },
+  {
+    key: "gacha_europe_50",
+    name: "歐洲貴族",
+    description: "累計 50 次 #歐洲抽",
+    icon: "🛡️",
+    type: "milestone",
+    rarity: 2,
+    target_value: 50,
+    reward_stones: 500,
+    order: 8,
+    pullType: "europe",
+  },
+  {
+    key: "gacha_pickup_1",
+    name: "鎖定目標",
+    description: "首次使用 #消耗抽",
+    icon: "🎯",
+    type: "milestone",
+    rarity: 0,
+    target_value: 1,
+    reward_stones: 30,
+    order: 9,
+    pullType: "pickup",
+  },
+  {
+    key: "gacha_pickup_10",
+    name: "愛的追擊",
+    description: "累計 10 次 #消耗抽",
+    icon: "❤️‍🔥",
+    type: "milestone",
+    rarity: 1,
+    target_value: 10,
+    reward_stones: 200,
+    order: 10,
+    pullType: "pickup",
+  },
+  {
+    key: "gacha_pickup_50",
+    name: "偏執獵手",
+    description: "累計 50 次 #消耗抽",
+    icon: "🏹",
+    type: "milestone",
+    rarity: 2,
+    target_value: 50,
+    reward_stones: 500,
+    order: 11,
+    pullType: "pickup",
+  },
+  {
+    key: "gacha_ensure_1",
+    name: "保底信徒",
+    description: "首次使用 #保證抽",
+    icon: "🔒",
+    type: "milestone",
+    rarity: 0,
+    target_value: 1,
+    reward_stones: 30,
+    order: 12,
+    pullType: "ensure",
+  },
+  {
+    key: "gacha_ensure_10",
+    name: "押注命運",
+    description: "累計 10 次 #保證抽",
+    icon: "🎰",
+    type: "milestone",
+    rarity: 1,
+    target_value: 10,
+    reward_stones: 200,
+    order: 13,
+    pullType: "ensure",
+  },
+  {
+    key: "gacha_ensure_50",
+    name: "逆天改命",
+    description: "累計 50 次 #保證抽",
+    icon: "🌈",
+    type: "milestone",
+    rarity: 2,
+    target_value: 50,
+    reward_stones: 500,
+    order: 14,
+    pullType: "ensure",
+  },
+];
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  const category = await knex("achievement_categories").where({ key: CATEGORY_KEY }).first();
+  if (!category) {
+    throw new Error(`achievement_categories row with key='${CATEGORY_KEY}' not found`);
+  }
+
+  const rows = ACHIEVEMENTS.map(({ pullType, ...rest }) => ({
+    ...rest,
+    category_id: category.id,
+    condition: JSON.stringify({ pullType }),
+  }));
+
+  await knex("achievements").insert(rows);
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex("achievements")
+    .whereIn(
+      "key",
+      ACHIEVEMENTS.map(a => a.key)
+    )
+    .del();
+};

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -477,6 +477,7 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
   const { unlocked } = await AchievementEngine.evaluate(userId, "gacha_pull", {
     threeStarCount: rareCount[3] || 0,
     uniqueCount: dailyResult.ownCharactersCount + dailyResult.newCharacters.length,
+    pullType: europe ? "europe" : ensure ? "ensure" : pickup ? "pickup" : undefined,
   }).catch(() => ({ unlocked: [] }));
   await notifyUnlocks(context, userId, unlocked);
 

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -27,7 +27,22 @@ exports._setCache = data => {
 // Maps event types to achievement keys
 const EVENT_ACHIEVEMENT_MAP = {
   chat_message: ["chat_100", "chat_1000", "chat_5000", "chat_night_owl", "chat_multi_group"],
-  gacha_pull: ["gacha_first", "gacha_100", "gacha_500", "gacha_collector_50", "gacha_lucky"],
+  gacha_pull: [
+    "gacha_first",
+    "gacha_100",
+    "gacha_500",
+    "gacha_collector_50",
+    "gacha_lucky",
+    "gacha_europe_1",
+    "gacha_europe_10",
+    "gacha_europe_50",
+    "gacha_pickup_1",
+    "gacha_pickup_10",
+    "gacha_pickup_50",
+    "gacha_ensure_1",
+    "gacha_ensure_10",
+    "gacha_ensure_50",
+  ],
   janken_win: ["janken_first_win", "janken_win_50", "janken_streak_5", "janken_streak_10"],
   janken_lose: [],
   janken_draw: [],
@@ -57,6 +72,12 @@ const STRATEGIES = {
     const hour = new Date(Date.now() + 8 * 60 * 60 * 1000).getUTCHours(); // Asia/Taipei
     return hour >= startHour && hour < endHour ? achievement.target_value : currentValue;
   },
+  conditionalIncrement(currentValue, achievement, context) {
+    const condition = achievement.condition || {};
+    const { pullType } = condition;
+    if (pullType && context.pullType !== pullType) return currentValue;
+    return currentValue + 1;
+  },
   mentionKeyword(currentValue, achievement, context) {
     const condition = achievement.condition || {};
     const targetUserIds = Array.isArray(condition.targetUserIds) ? condition.targetUserIds : [];
@@ -83,6 +104,15 @@ const ACHIEVEMENT_STRATEGY = {
   gacha_500: cv => STRATEGIES.increment(cv),
   gacha_collector_50: (cv, a, ctx) => STRATEGIES.contextValue(cv, a, ctx, "uniqueCount"),
   gacha_lucky: (cv, a, ctx) => STRATEGIES.threshold(cv, a, ctx, "threeStarCount", 3),
+  gacha_europe_1: STRATEGIES.conditionalIncrement,
+  gacha_europe_10: STRATEGIES.conditionalIncrement,
+  gacha_europe_50: STRATEGIES.conditionalIncrement,
+  gacha_pickup_1: STRATEGIES.conditionalIncrement,
+  gacha_pickup_10: STRATEGIES.conditionalIncrement,
+  gacha_pickup_50: STRATEGIES.conditionalIncrement,
+  gacha_ensure_1: STRATEGIES.conditionalIncrement,
+  gacha_ensure_10: STRATEGIES.conditionalIncrement,
+  gacha_ensure_50: STRATEGIES.conditionalIncrement,
   janken_first_win: (cv, a) => STRATEGIES.instant(cv, a),
   janken_win_50: cv => STRATEGIES.increment(cv),
   janken_streak_5: (cv, a, ctx) => STRATEGIES.contextValue(cv, a, ctx, "streak"),
@@ -132,8 +162,8 @@ exports.evaluate = async (userId, eventType, context = {}) => {
       try {
         if (unlockedIds.has(achievement.id)) continue;
 
-        const newValue = await calculateProgress(userId, achievement, ctx);
-        if (newValue === null) continue;
+        const { currentValue, newValue } = await calculateProgress(userId, achievement, ctx);
+        if (newValue === null || newValue === currentValue) continue;
 
         await UserProgressModel.upsert(userId, achievement.id, newValue);
 
@@ -159,9 +189,9 @@ async function calculateProgress(userId, achievement, context) {
   const currentValue = progress ? progress.current_value : 0;
 
   const strategy = ACHIEVEMENT_STRATEGY[achievement.key];
-  if (!strategy) return currentValue;
+  const newValue = strategy ? strategy(currentValue, achievement, context) : currentValue;
 
-  return strategy(currentValue, achievement, context);
+  return { currentValue, newValue };
 }
 
 async function handleTrackedSet(userId, achievementId, newItem, currentValue) {


### PR DESCRIPTION
## Summary
- 新增 9 筆轉蛋指令成就：`#歐洲抽` / `#消耗抽` / `#保證抽` × 1 / 10 / 50 次階梯
- `AchievementEngine` 新增通用 `conditionalIncrement` strategy（從 `achievement.condition.pullType` 判定是否累加），未來要擴充「某指令累計 N 次」類型成就只要加 seed
- `evaluate` loop 加入 no-op upsert guard：`newValue === currentValue` 時跳過 DB 寫入，解決每次 pull 會對未命中的策略產生多餘 upsert 的問題（同時修掉既有 `gacha_lucky`、`chat_night_owl`、`mention_*` 的相同浪費）
- `gacha.js` 在 `gacha_pull` event context 帶入 `pullType`

## 成就表
| Key | 名稱 | Icon | Rarity | Target | 石頭 |
|---|---|---|---|---|---|
| gacha_europe_1 | 歐陸初旅 | 🏰 | 0 | 1 | 30 |
| gacha_europe_10 | 歐洲常客 | 🎩 | 1 | 10 | 200 |
| gacha_europe_50 | 歐洲貴族 | 🛡️ | 2 | 50 | 500 |
| gacha_pickup_1 | 鎖定目標 | 🎯 | 0 | 1 | 30 |
| gacha_pickup_10 | 愛的追擊 | ❤️‍🔥 | 1 | 10 | 200 |
| gacha_pickup_50 | 偏執獵手 | 🏹 | 2 | 50 | 500 |
| gacha_ensure_1 | 保底信徒 | 🔒 | 0 | 1 | 30 |
| gacha_ensure_10 | 押注命運 | 🎰 | 1 | 10 | 200 |
| gacha_ensure_50 | 逆天改命 | 🌈 | 2 | 50 | 500 |

## Test plan
- [ ] `cd app && yarn migrate` 本地執行，確認 9 筆插入成功
- [ ] `#歐洲抽` 首次觸發，成就 `歐陸初旅` 解鎖、發女神石 30
- [ ] `#消耗抽` 首次觸發 `鎖定目標` 解鎖
- [ ] `#保證抽` 首次觸發 `保底信徒` 解鎖
- [ ] 混合使用指令累積，確認各自計數獨立（歐洲抽不會累加到消耗抽計數）
- [ ] 觀察一次 pull 的 DB log，確認 no-op upsert guard 有效（應只看到 3-4 筆 upsert 而非 14 筆）
- [ ] 確認現有 `gacha_first` / `gacha_100` / `gacha_500` / `gacha_collector_50` / `gacha_lucky` 行為不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)