### PR TITLE
fix(frontend): align achievement login prompt and make debug overlay dismissable

### DIFF
--- a/frontend/src/components/DebugOverlay.jsx
+++ b/frontend/src/components/DebugOverlay.jsx
@@ -5,7 +5,13 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CloseIcon from "@mui/icons-material/Close";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import { getDebugLogs, formatDebugLogs, isDebugMode, clearDebugLogs } from "../utils/debugLogger";
+import {
+  getDebugLogs,
+  formatDebugLogs,
+  isDebugMode,
+  clearDebugLogs,
+  disableDebugMode,
+} from "../utils/debugLogger";
 
 export default function DebugOverlay() {
   const [expanded, setExpanded] = useState(true);
@@ -106,7 +112,14 @@ export default function DebugOverlay() {
             <ExpandLessIcon sx={{ fontSize: 16 }} />
           )}
         </IconButton>
-        <IconButton size="small" onClick={() => setVisible(false)} sx={{ color: "#666", p: 0.5 }}>
+        <IconButton
+          size="small"
+          onClick={() => {
+            disableDebugMode();
+            setVisible(false);
+          }}
+          sx={{ color: "#666", p: 0.5 }}
+        >
           <CloseIcon sx={{ fontSize: 16 }} />
         </IconButton>
       </Box>

--- a/frontend/src/pages/Achievement/index.jsx
+++ b/frontend/src/pages/Achievement/index.jsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import { useSearchParams } from "react-router-dom";
 import useLiff from "../../context/useLiff";
+import AlertLogin from "../../components/AlertLogin";
 import { getUserAchievements, getAchievementStats } from "../../services/achievement";
 
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
@@ -102,7 +103,7 @@ export default function Achievement() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const { profile } = useLiff();
+  const { loggedIn: isLoggedIn, profile } = useLiff();
   const [searchParams] = useSearchParams();
   const userId = searchParams.get("userId") || profile?.userId || "";
 
@@ -112,7 +113,6 @@ export default function Achievement() {
 
   const fetchData = useCallback(async () => {
     if (!userId) {
-      setError("請先登入以查看成就");
       setLoading(false);
       return;
     }
@@ -156,6 +156,7 @@ export default function Achievement() {
       </Box>
     );
   }
+  if (!isLoggedIn && !userId) return <AlertLogin />;
   if (error)
     return (
       <Box sx={{ py: 2 }}>

--- a/frontend/src/utils/debugLogger.js
+++ b/frontend/src/utils/debugLogger.js
@@ -91,3 +91,13 @@ export function clearDebugLogs() {
   logs.length = 0;
   window.sessionStorage.removeItem(STORAGE_KEY);
 }
+
+export function disableDebugMode() {
+  window.localStorage.removeItem("liff_debug");
+  const url = new URL(window.location.href);
+  if (url.searchParams.has("debug")) {
+    url.searchParams.delete("debug");
+    window.history.replaceState({}, "", url.toString());
+  }
+  clearDebugLogs();
+}


### PR DESCRIPTION
## Summary
- Achievement page now shows `<AlertLogin />` when unauthenticated (matches the convention used by Trade/Group/Admin pages) instead of a plain error `Typography`. Shared-link view via `?userId=` still works.
- DebugOverlay close (✕) button now actually disables debug mode: clears the `liff_debug` localStorage flag and strips `?debug=1` from the URL. Previously the overlay kept reappearing on every page load because the close only toggled an in-component state.

## Test plan
- [ ] Open `/achievements` while logged out → expect the shared `AlertLogin` warning, not the old red text.
- [ ] Open any LIFF page with `?debug=1`, click the ✕ on the green debug bar, reload the page → overlay should NOT reappear.
- [ ] Shared-link view: open `/achievements?userId=<someone>` while logged out → still renders their summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)