### PR TITLE
feat(flex): unify flex message colors under Miyako brand theme

### DIFF
--- a/app/src/templates/application/Achievement.js
+++ b/app/src/templates/application/Achievement.js
@@ -1,17 +1,13 @@
 const { getLiffUri } = require("../common");
+const { SURFACE, RARITY, FEATURE } = require("../common/theme");
 
-const RARITY_COLORS = {
-  0: { bg: "#757575", text: "#ffffff" }, // Common
-  1: { bg: "#6c5ce7", text: "#ffffff" }, // Rare
-  2: { bg: "#b8860b", text: "#ffffff" }, // Epic
-  3: { bg: "#d63384", text: "#ffffff" }, // Legendary
-};
+const ACCENT = FEATURE.achievement;
 
-const RARITY_NAMES = {
-  0: "普通",
-  1: "稀有",
-  2: "史詩",
-  3: "傳說",
+const RARITY_CONFIG = {
+  0: { ...RARITY.common, label: "普通" },
+  1: { ...RARITY.rare, label: "稀有" },
+  2: { ...RARITY.epic, label: "史詩" },
+  3: { ...RARITY.legendary, label: "傳說" },
 };
 
 exports.generateSummaryFlex = ({ total, unlocked, percentage, recentUnlocks, nearCompletion }) => {
@@ -36,8 +32,10 @@ exports.generateSummaryFlex = ({ total, unlocked, percentage, recentUnlocks, nea
     header: {
       type: "box",
       layout: "vertical",
-      contents: [{ type: "text", text: "成就系統", weight: "bold", size: "xl", color: "#ffffff" }],
-      backgroundColor: "#6c5ce7",
+      contents: [
+        { type: "text", text: "成就系統", weight: "bold", size: "xl", color: ACCENT.contrast },
+      ],
+      backgroundColor: ACCENT.main,
       paddingAll: "lg",
     },
     body: {
@@ -59,7 +57,7 @@ exports.generateSummaryFlex = ({ total, unlocked, percentage, recentUnlocks, nea
             uri: getLiffUri("full", "/achievements"),
           },
           style: "primary",
-          color: "#6c5ce7",
+          color: ACCENT.main,
         },
       ],
     },
@@ -87,12 +85,12 @@ function generateHeaderSection(unlocked, total, percentage) {
             layout: "vertical",
             contents: [{ type: "filler" }],
             width: `${percentage}%`,
-            backgroundColor: "#6c5ce7",
+            backgroundColor: ACCENT.main,
             height: "6px",
             cornerRadius: "3px",
           },
         ],
-        backgroundColor: "#e0e0e0",
+        backgroundColor: SURFACE.bgMuted,
         height: "6px",
         cornerRadius: "3px",
         margin: "md",
@@ -101,7 +99,7 @@ function generateHeaderSection(unlocked, total, percentage) {
         type: "text",
         text: `${percentage}% 完成`,
         size: "xs",
-        color: "#888888",
+        color: SURFACE.textMuted,
         align: "center",
         margin: "sm",
       },
@@ -111,8 +109,7 @@ function generateHeaderSection(unlocked, total, percentage) {
 
 function generateRecentSection(recentUnlocks) {
   const items = recentUnlocks.map(achievement => {
-    const rarity = RARITY_COLORS[achievement.rarity] || RARITY_COLORS[0];
-    const rarityName = RARITY_NAMES[achievement.rarity] || "普通";
+    const rarity = RARITY_CONFIG[achievement.rarity] || RARITY_CONFIG[0];
     const timeAgo = getTimeAgo(achievement.unlocked_at);
 
     return {
@@ -126,14 +123,14 @@ function generateRecentSection(recentUnlocks) {
           flex: 6,
           contents: [
             { type: "text", text: achievement.name, size: "sm", weight: "bold" },
-            { type: "text", text: timeAgo, size: "xxs", color: "#888888" },
+            { type: "text", text: timeAgo, size: "xxs", color: SURFACE.textMuted },
           ],
         },
         {
           type: "text",
-          text: `★ ${rarityName}`,
+          text: `★ ${rarity.label}`,
           size: "xxs",
-          color: rarity.bg,
+          color: rarity.main,
           flex: 2,
           align: "end",
           gravity: "center",
@@ -151,7 +148,7 @@ function generateRecentSection(recentUnlocks) {
         type: "text",
         text: "最近解鎖",
         size: "xs",
-        color: "#888888",
+        color: SURFACE.textMuted,
         weight: "bold",
         margin: "md",
       },
@@ -188,12 +185,12 @@ function generateNearCompletionSection(nearCompletion) {
                   layout: "vertical",
                   contents: [{ type: "filler" }],
                   width: `${pct}%`,
-                  backgroundColor: "#a29bfe",
+                  backgroundColor: ACCENT.light,
                   height: "4px",
                   cornerRadius: "2px",
                 },
               ],
-              backgroundColor: "#e0e0e0",
+              backgroundColor: SURFACE.bgMuted,
               height: "4px",
               cornerRadius: "2px",
               margin: "sm",
@@ -204,7 +201,7 @@ function generateNearCompletionSection(nearCompletion) {
           type: "text",
           text: `${pct}%`,
           size: "xxs",
-          color: "#888888",
+          color: SURFACE.textMuted,
           flex: 1,
           align: "end",
           gravity: "center",
@@ -222,7 +219,7 @@ function generateNearCompletionSection(nearCompletion) {
         type: "text",
         text: "即將達成",
         size: "xs",
-        color: "#888888",
+        color: SURFACE.textMuted,
         weight: "bold",
         margin: "md",
       },
@@ -234,7 +231,7 @@ function generateNearCompletionSection(nearCompletion) {
 
 exports.generateTitlesFlex = titles => {
   const rows = titles.map(title => {
-    const rarity = RARITY_COLORS[title.rarity] || RARITY_COLORS[0];
+    const rarity = RARITY_CONFIG[title.rarity] || RARITY_CONFIG[0];
     return {
       type: "box",
       layout: "horizontal",
@@ -243,15 +240,15 @@ exports.generateTitlesFlex = titles => {
         { type: "text", text: title.name, size: "sm", flex: 5, gravity: "center" },
         {
           type: "text",
-          text: RARITY_NAMES[title.rarity] || "",
+          text: rarity.label,
           size: "xxs",
-          color: rarity.bg,
+          color: rarity.main,
           flex: 2,
           align: "end",
           gravity: "center",
         },
       ],
-      backgroundColor: `${rarity.bg}22`,
+      backgroundColor: rarity.bg,
       paddingAll: "sm",
       cornerRadius: "md",
     };
@@ -262,8 +259,10 @@ exports.generateTitlesFlex = titles => {
     header: {
       type: "box",
       layout: "vertical",
-      contents: [{ type: "text", text: "我的稱號", weight: "bold", size: "lg", color: "#ffffff" }],
-      backgroundColor: "#6c5ce7",
+      contents: [
+        { type: "text", text: "我的稱號", weight: "bold", size: "lg", color: ACCENT.contrast },
+      ],
+      backgroundColor: ACCENT.main,
       paddingAll: "lg",
     },
     body: {

--- a/app/src/templates/application/Janken.js
+++ b/app/src/templates/application/Janken.js
@@ -1,5 +1,6 @@
 const JankenRating = require("../../model/application/JankenRating");
 const { getLiffUri } = require("../common");
+const { SEMANTIC, HERO_SURFACE } = require("../common/theme");
 
 const ASSET_VERSION = Date.now();
 const jankenAsset = (baseUrl, name) => `${baseUrl}/bot-assets/janken/${name}?v=${ASSET_VERSION}`;
@@ -73,7 +74,7 @@ exports.generateDuelCard = ({
           },
         ],
         paddingAll: "md",
-        backgroundColor: "#2d2d4e",
+        backgroundColor: HERO_SURFACE.bgRaised,
         cornerRadius: "lg",
         flex: 1,
         action: genAction("rock", actionParams),
@@ -90,7 +91,7 @@ exports.generateDuelCard = ({
           },
         ],
         paddingAll: "md",
-        backgroundColor: "#2d2d4e",
+        backgroundColor: HERO_SURFACE.bgRaised,
         cornerRadius: "lg",
         flex: 1,
         action: genAction("scissors", actionParams),
@@ -107,7 +108,7 @@ exports.generateDuelCard = ({
           },
         ],
         paddingAll: "md",
-        backgroundColor: "#2d2d4e",
+        backgroundColor: HERO_SURFACE.bgRaised,
         cornerRadius: "lg",
         flex: 1,
         action: genAction("paper", actionParams),
@@ -124,14 +125,14 @@ exports.generateDuelCard = ({
         type: "text",
         align: "center",
         text: "交給命運",
-        color: "#ffffff",
+        color: HERO_SURFACE.text,
         weight: "bold",
       },
     ],
     paddingAll: "lg",
     margin: "md",
     cornerRadius: "md",
-    backgroundColor: "#3d3d6e",
+    backgroundColor: HERO_SURFACE.bgButton,
     action: genAction("random", actionParams),
   };
 
@@ -190,7 +191,7 @@ exports.generateDuelCard = ({
           type: "text",
           text: `賭注：${betAmount} 女神石`,
           align: "center",
-          color: "#FFD700",
+          color: HERO_SURFACE.textAccent,
           weight: "bold",
         },
       ],
@@ -206,7 +207,7 @@ exports.generateDuelCard = ({
       type: "text",
       text: "試試 /決鬥 @對手 金額 來下注對決！",
       align: "center",
-      color: "#888888",
+      color: HERO_SURFACE.textMuted,
       size: "xxs",
       margin: "md",
     });
@@ -217,7 +218,7 @@ exports.generateDuelCard = ({
     body: {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: bodyContents,
       paddingAll: "lg",
       spacing: "lg",
@@ -228,14 +229,14 @@ exports.generateDuelCard = ({
     bubble.header = {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: [
         {
           type: "text",
           text: title,
           align: "center",
           weight: "bold",
-          color: "#ffffff",
+          color: HERO_SURFACE.text,
           size: "lg",
         },
       ],
@@ -275,7 +276,7 @@ exports.generateArenaCard = ({ userId, groupId, iconUrl, title = "", baseUrl }) 
           },
         ],
         paddingAll: "md",
-        backgroundColor: "#2d2d4e",
+        backgroundColor: HERO_SURFACE.bgRaised,
         cornerRadius: "lg",
         flex: 1,
         action: genChallengeAction("rock", challengeParams),
@@ -292,7 +293,7 @@ exports.generateArenaCard = ({ userId, groupId, iconUrl, title = "", baseUrl }) 
           },
         ],
         paddingAll: "md",
-        backgroundColor: "#2d2d4e",
+        backgroundColor: HERO_SURFACE.bgRaised,
         cornerRadius: "lg",
         flex: 1,
         action: genChallengeAction("scissors", challengeParams),
@@ -309,7 +310,7 @@ exports.generateArenaCard = ({ userId, groupId, iconUrl, title = "", baseUrl }) 
           },
         ],
         paddingAll: "md",
-        backgroundColor: "#2d2d4e",
+        backgroundColor: HERO_SURFACE.bgRaised,
         cornerRadius: "lg",
         flex: 1,
         action: genChallengeAction("paper", challengeParams),
@@ -326,14 +327,14 @@ exports.generateArenaCard = ({ userId, groupId, iconUrl, title = "", baseUrl }) 
         type: "text",
         align: "center",
         text: "交給命運",
-        color: "#ffffff",
+        color: HERO_SURFACE.text,
         weight: "bold",
       },
     ],
     paddingAll: "lg",
     margin: "md",
     cornerRadius: "md",
-    backgroundColor: "#3d3d6e",
+    backgroundColor: HERO_SURFACE.bgButton,
     action: genChallengeAction("random", challengeParams),
   };
 
@@ -370,7 +371,7 @@ exports.generateArenaCard = ({ userId, groupId, iconUrl, title = "", baseUrl }) 
     body: {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: bodyContents,
       paddingAll: "lg",
       spacing: "lg",
@@ -381,14 +382,14 @@ exports.generateArenaCard = ({ userId, groupId, iconUrl, title = "", baseUrl }) 
     bubble.header = {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: [
         {
           type: "text",
           text: title,
           align: "center",
           weight: "bold",
-          color: "#ffffff",
+          color: HERO_SURFACE.text,
           size: "lg",
         },
       ],
@@ -430,9 +431,9 @@ exports.generateResultCard = ({
   p2NewElo,
 }) => {
   const resultColorMap = {
-    win: "#FFD700",
-    lose: "#808080",
-    draw: "#4FC3F7",
+    win: HERO_SURFACE.textAccent,
+    lose: HERO_SURFACE.textMuted,
+    draw: SEMANTIC.primary.light,
   };
 
   const p1Image = jankenAsset(baseUrl, `${p1Choice}.png`);
@@ -440,7 +441,7 @@ exports.generateResultCard = ({
   const winImage = jankenAsset(baseUrl, "win.png");
   const loseImage = jankenAsset(baseUrl, "lose.png");
   const drawImage = jankenAsset(baseUrl, "draw.png");
-  const resultColor = resultColorMap[resultType] || "#ffffff";
+  const resultColor = resultColorMap[resultType] || HERO_SURFACE.text;
 
   const winnerText = resultType === "draw" ? "平手！" : `${winnerName} 贏了！`;
 
@@ -477,7 +478,7 @@ exports.generateResultCard = ({
               type: "text",
               text: p1Name,
               align: "center",
-              color: "#ffffff",
+              color: HERO_SURFACE.text,
               size: "sm",
               weight: "bold",
             },
@@ -499,7 +500,7 @@ exports.generateResultCard = ({
                     type: "text",
                     text: JankenRating.getRankLabel(p1NewElo),
                     align: "center",
-                    color: "#B0B0B0",
+                    color: HERO_SURFACE.textMuted,
                     size: "xxs",
                   },
                 ]
@@ -513,7 +514,7 @@ exports.generateResultCard = ({
           type: "text",
           text: "VS",
           align: "center",
-          color: "#ffffff",
+          color: HERO_SURFACE.text,
           weight: "bold",
           size: "lg",
           flex: 0,
@@ -533,7 +534,7 @@ exports.generateResultCard = ({
               type: "text",
               text: p2Name,
               align: "center",
-              color: "#ffffff",
+              color: HERO_SURFACE.text,
               size: "sm",
               weight: "bold",
             },
@@ -555,7 +556,7 @@ exports.generateResultCard = ({
                     type: "text",
                     text: JankenRating.getRankLabel(p2NewElo),
                     align: "center",
-                    color: "#B0B0B0",
+                    color: HERO_SURFACE.textMuted,
                     size: "xxs",
                   },
                 ]
@@ -588,7 +589,7 @@ exports.generateResultCard = ({
       type: "text",
       text: betText,
       align: "center",
-      color: "#FFD700",
+      color: HERO_SURFACE.textAccent,
       size: "sm",
       margin: "md",
     });
@@ -599,7 +600,7 @@ exports.generateResultCard = ({
       type: "text",
       text: `${winnerName} ${winnerStreak} 連勝中！`,
       align: "center",
-      color: "#FF6B35",
+      color: SEMANTIC.warning.main,
       size: "sm",
       weight: "bold",
       margin: "md",
@@ -617,7 +618,7 @@ exports.generateResultCard = ({
           type: "text",
           text: `${p1Name}: ${p1Sign}${p1EloChange}`,
           align: "center",
-          color: p1EloChange >= 0 ? "#4CAF50" : "#F44336",
+          color: p1EloChange >= 0 ? SEMANTIC.success.main : SEMANTIC.danger.main,
           size: "xs",
           flex: 1,
         },
@@ -625,7 +626,7 @@ exports.generateResultCard = ({
           type: "text",
           text: `${p2Name}: ${p2Sign}${p2EloChange}`,
           align: "center",
-          color: p2EloChange >= 0 ? "#4CAF50" : "#F44336",
+          color: p2EloChange >= 0 ? SEMANTIC.success.main : SEMANTIC.danger.main,
           size: "xs",
           flex: 1,
         },
@@ -639,7 +640,7 @@ exports.generateResultCard = ({
     body: {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: bodyContents,
       paddingAll: "lg",
       spacing: "lg",
@@ -647,7 +648,7 @@ exports.generateResultCard = ({
     footer: {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: [
         {
           type: "button",
@@ -657,7 +658,7 @@ exports.generateResultCard = ({
             uri: getLiffUri("full", "/janken"),
           },
           style: "link",
-          color: "#4FC3F7",
+          color: SEMANTIC.primary.light,
           height: "sm",
         },
       ],
@@ -812,7 +813,7 @@ exports.generateRankCard = ({
       type: "text",
       text: rankLabel,
       align: "center",
-      color: "#FFD700",
+      color: HERO_SURFACE.textAccent,
       weight: "bold",
       size: "xl",
     },
@@ -820,10 +821,10 @@ exports.generateRankCard = ({
       type: "text",
       text: `積分：${elo}`,
       align: "center",
-      color: "#B0B0B0",
+      color: HERO_SURFACE.textMuted,
       size: "sm",
     },
-    { type: "separator", color: "#3d3d6e", margin: "lg" },
+    { type: "separator", color: HERO_SURFACE.divider, margin: "lg" },
     {
       type: "box",
       layout: "horizontal",
@@ -832,7 +833,7 @@ exports.generateRankCard = ({
           type: "text",
           text: `${winCount} 勝`,
           align: "center",
-          color: "#4CAF50",
+          color: SEMANTIC.success.main,
           size: "sm",
           flex: 1,
         },
@@ -840,7 +841,7 @@ exports.generateRankCard = ({
           type: "text",
           text: `${loseCount} 敗`,
           align: "center",
-          color: "#F44336",
+          color: SEMANTIC.danger.main,
           size: "sm",
           flex: 1,
         },
@@ -848,7 +849,7 @@ exports.generateRankCard = ({
           type: "text",
           text: `${drawCount} 平`,
           align: "center",
-          color: "#4FC3F7",
+          color: SEMANTIC.primary.light,
           size: "sm",
           flex: 1,
         },
@@ -859,7 +860,7 @@ exports.generateRankCard = ({
       type: "text",
       text: `勝率：${winRate}%`,
       align: "center",
-      color: "#ffffff",
+      color: HERO_SURFACE.text,
       size: "sm",
       margin: "sm",
     },
@@ -871,7 +872,7 @@ exports.generateRankCard = ({
           type: "text",
           text: `連勝：${streak}`,
           align: "center",
-          color: "#FF6B35",
+          color: SEMANTIC.warning.main,
           size: "sm",
           flex: 1,
         },
@@ -879,14 +880,14 @@ exports.generateRankCard = ({
           type: "text",
           text: `最高：${maxStreak}`,
           align: "center",
-          color: "#FF6B35",
+          color: SEMANTIC.warning.main,
           size: "sm",
           flex: 1,
         },
       ],
       margin: "sm",
     },
-    { type: "separator", color: "#3d3d6e", margin: "lg" },
+    { type: "separator", color: HERO_SURFACE.divider, margin: "lg" },
     {
       type: "box",
       layout: "vertical",
@@ -895,11 +896,11 @@ exports.generateRankCard = ({
           type: "box",
           layout: "horizontal",
           contents: [
-            { type: "text", text: "懸賞金", color: "#B0B0B0", size: "xs", flex: 1 },
+            { type: "text", text: "懸賞金", color: HERO_SURFACE.textMuted, size: "xs", flex: 1 },
             {
               type: "text",
               text: `${bounty} 女神石`,
-              color: "#ffffff",
+              color: HERO_SURFACE.text,
               size: "xs",
               align: "end",
               flex: 2,
@@ -910,11 +911,11 @@ exports.generateRankCard = ({
           type: "box",
           layout: "horizontal",
           contents: [
-            { type: "text", text: "最大下注", color: "#B0B0B0", size: "xs", flex: 1 },
+            { type: "text", text: "最大下注", color: HERO_SURFACE.textMuted, size: "xs", flex: 1 },
             {
               type: "text",
               text: `${maxBet} 女神石`,
-              color: "#ffffff",
+              color: HERO_SURFACE.text,
               size: "xs",
               align: "end",
               flex: 2,
@@ -927,11 +928,17 @@ exports.generateRankCard = ({
                 type: "box",
                 layout: "horizontal",
                 contents: [
-                  { type: "text", text: "全服排名", color: "#B0B0B0", size: "xs", flex: 1 },
+                  {
+                    type: "text",
+                    text: "全服排名",
+                    color: HERO_SURFACE.textMuted,
+                    size: "xs",
+                    flex: 1,
+                  },
                   {
                     type: "text",
                     text: `第 ${serverRank} 名`,
-                    color: "#ffffff",
+                    color: HERO_SURFACE.text,
                     size: "xs",
                     align: "end",
                     flex: 2,
@@ -946,11 +953,17 @@ exports.generateRankCard = ({
                 type: "box",
                 layout: "horizontal",
                 contents: [
-                  { type: "text", text: "距下一段位", color: "#B0B0B0", size: "xs", flex: 1 },
+                  {
+                    type: "text",
+                    text: "距下一段位",
+                    color: HERO_SURFACE.textMuted,
+                    size: "xs",
+                    flex: 1,
+                  },
                   {
                     type: "text",
                     text: `還差 ${eloToNext} 積分`,
-                    color: "#FFD700",
+                    color: HERO_SURFACE.textAccent,
                     size: "xs",
                     align: "end",
                     flex: 2,
@@ -970,7 +983,7 @@ exports.generateRankCard = ({
     body: {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: bodyContents,
       paddingAll: "lg",
       spacing: "sm",
@@ -978,7 +991,7 @@ exports.generateRankCard = ({
     footer: {
       type: "box",
       layout: "vertical",
-      backgroundColor: "#1a1a2e",
+      backgroundColor: HERO_SURFACE.bg,
       contents: [
         {
           type: "button",
@@ -988,7 +1001,7 @@ exports.generateRankCard = ({
             uri: getLiffUri("full", "/janken"),
           },
           style: "link",
-          color: "#4FC3F7",
+          color: SEMANTIC.primary.light,
           height: "sm",
         },
       ],

--- a/app/src/templates/common/theme.js
+++ b/app/src/templates/common/theme.js
@@ -1,0 +1,179 @@
+/**
+ * Unified color tokens for LINE Flex Message templates.
+ *
+ * Aligned with the frontend "Miyako (宮子)" theme (frontend/src/theme/index.js)
+ * so LINE flex messages and the LIFF pages share one brand identity:
+ *   - Primary: cyan (#00ACC1) — Miyako's hair
+ *   - Secondary: amber (#F59E0B) — pudding
+ *
+ * Import the named exports (SEMANTIC / RARITY / SURFACE / HERO_SURFACE /
+ * FEATURE) instead of hard-coding hex values inside individual templates:
+ *
+ *   const { SURFACE, FEATURE, RARITY } = require("../common/theme");
+ *   backgroundColor: FEATURE.gacha.main
+ *   color: RARITY.legendary.main
+ *
+ * Guideline:
+ * - Use SEMANTIC for status (success / warning / danger / info / neutral).
+ * - Use FEATURE.<name>.main as the accent color of a feature's hero/header.
+ * - Use SURFACE for light-background bubbles (achievements, info, market).
+ * - Use HERO_SURFACE for dark "stage" bubbles (janken duel, race, battle).
+ * - Use RARITY for loot / achievements / gacha results.
+ */
+
+const PALETTE = {
+  // neutrals (text/divider palette; aligned with frontend light theme)
+  gray50: "#F5F7FA",
+  gray100: "#E0E0E0",
+  gray300: "#BDBDBD",
+  gray500: "#8DA4BE",
+  gray700: "#5A6B7F",
+  gray900: "#1A2332",
+  white: "#FFFFFF",
+  black: "#000000",
+
+  // primary — Miyako cyan
+  cyan400: "#4DD0E1",
+  cyan500: "#26C6DA",
+  cyan600: "#00ACC1",
+  cyan700: "#00838F",
+
+  // secondary — pudding amber
+  amber300: "#FCD34D",
+  amber400: "#FBBF24",
+  amber500: "#F59E0B",
+  amber600: "#D97706",
+
+  // status
+  green400: "#4ADE80",
+  green500: "#22C55E",
+  green600: "#16A34A",
+  red400: "#F87171",
+  red500: "#EF4444",
+  red600: "#DC2626",
+
+  // rarity (game-standard ordering)
+  rarityCommon: "#9E9E9E",
+  rarityRare: "#3478FF",
+  rarityEpic: "#A834FF",
+  rarityLegendary: "#FF8C00",
+
+  // dark "hero" stage (aligned with frontend darkTheme bg)
+  hero900: "#0A1A2A",
+  hero800: "#12243A",
+  hero700: "#1A2E4A",
+  hero600: "#2D4068",
+  heroText: "#E8EEF4",
+  heroTextMuted: "#B0BEC5",
+};
+
+const SEMANTIC = {
+  primary: {
+    main: PALETTE.cyan600,
+    light: PALETTE.cyan500,
+    dark: PALETTE.cyan700,
+    contrast: PALETTE.white,
+  },
+  secondary: {
+    main: PALETTE.amber500,
+    light: PALETTE.amber400,
+    dark: PALETTE.amber600,
+    contrast: PALETTE.white,
+  },
+  success: {
+    main: PALETTE.green500,
+    light: PALETTE.green400,
+    dark: PALETTE.green600,
+    contrast: PALETTE.white,
+  },
+  warning: {
+    main: PALETTE.amber500,
+    light: PALETTE.amber400,
+    dark: PALETTE.amber600,
+    contrast: PALETTE.white,
+  },
+  danger: {
+    main: PALETTE.red500,
+    light: PALETTE.red400,
+    dark: PALETTE.red600,
+    contrast: PALETTE.white,
+  },
+  info: {
+    main: PALETTE.cyan600,
+    light: PALETTE.cyan500,
+    dark: PALETTE.cyan700,
+    contrast: PALETTE.white,
+  },
+  neutral: {
+    main: PALETTE.gray700,
+    light: PALETTE.gray500,
+    dark: PALETTE.gray900,
+    contrast: PALETTE.white,
+  },
+};
+
+const RARITY = {
+  common: { main: PALETTE.rarityCommon, bg: "#F5F5F5", text: PALETTE.gray700 },
+  rare: { main: PALETTE.rarityRare, bg: "#E3F2FD", text: "#0D47A1" },
+  epic: { main: PALETTE.rarityEpic, bg: "#F3E5F5", text: "#4A148C" },
+  legendary: { main: PALETTE.rarityLegendary, bg: "#FFF3E0", text: "#E65100" },
+};
+
+const SURFACE = {
+  bg: PALETTE.white,
+  bgAlt: PALETTE.gray50,
+  bgMuted: PALETTE.gray100,
+  bgInverse: PALETTE.hero900,
+
+  divider: PALETTE.gray300,
+  dividerMuted: PALETTE.gray100,
+
+  text: PALETTE.gray900,
+  textMuted: PALETTE.gray700,
+  textDisabled: PALETTE.gray500,
+  textInverse: PALETTE.white,
+};
+
+/**
+ * Dark "stage" surface for feature bubbles that read as a game scene
+ * (janken duel, horse race, guild battle). Matches the frontend darkTheme
+ * so LIFF pages feel continuous with the flex messages that launched them.
+ */
+const HERO_SURFACE = {
+  bg: PALETTE.hero900,
+  bgAlt: PALETTE.hero800,
+  bgRaised: PALETTE.hero700,
+  bgButton: PALETTE.hero600,
+
+  divider: PALETTE.hero600,
+
+  text: PALETTE.heroText,
+  textMuted: PALETTE.heroTextMuted,
+  textAccent: PALETTE.amber400,
+};
+
+/**
+ * Each feature picks a SEMANTIC color as its accent. Keep the mapping small:
+ * if a feature doesn't fit anywhere obvious, default to primary.
+ *
+ * Features with dark hero bubbles (janken / race / guildBattle) still expose
+ * an accent here so shared controls rendered inside them pick a color from
+ * the same palette.
+ */
+const FEATURE = {
+  gacha: SEMANTIC.primary,
+  achievement: SEMANTIC.primary,
+  janken: SEMANTIC.primary,
+  race: SEMANTIC.secondary,
+  guildBattle: SEMANTIC.danger,
+  worldBoss: SEMANTIC.danger,
+  subscribe: SEMANTIC.info,
+  customerOrder: SEMANTIC.neutral,
+  market: SEMANTIC.success,
+  chatLevel: SEMANTIC.info,
+  dailyQuest: SEMANTIC.success,
+  announce: SEMANTIC.neutral,
+  godStone: SEMANTIC.secondary,
+};
+
+module.exports = { PALETTE, SEMANTIC, RARITY, SURFACE, HERO_SURFACE, FEATURE };


### PR DESCRIPTION
## Summary
- New single source of truth for LINE Flex Message colors: `app/src/templates/common/theme.js`. Tokens align with the frontend's "Miyako (宮子)" theme so LIFF pages and the flex bubbles that launch them share one brand identity (cyan primary + amber secondary).
- Exports `SEMANTIC` / `SURFACE` / `HERO_SURFACE` / `RARITY` / `FEATURE`. `HERO_SURFACE` mirrors the frontend `darkTheme` for "stage" bubbles (janken duel, race, battle) so the visual language is continuous across LINE ↔ LIFF.
- Refactor two templates as first wave:
  - `Achievement.js` — header/footer/progress bar now use `FEATURE.achievement` (cyan) instead of the one-off purple `#6c5ce7`. Rarity labels use unified `RARITY` ordering.
  - `Janken.js` — duel/arena/result/rank cards now use `HERO_SURFACE` for the dark stage, and `SEMANTIC.{success,warning,danger,primary.light}` for ELO ±, streak, draw, link — replacing ~10 ad-hoc hex literals per bubble.
- Both refactored files now contain **zero hex literals**. Remaining templates (Race / WorldBoss / Subscribe / etc.) are unchanged and can adopt the theme incrementally.

## Visible changes
- Achievement bubble header & button: purple → **cyan** (matches frontend).
- Achievement rarity: legendary pink → orange, epic gold → purple (game-standard ordering).
- Janken winner / bet / bounty text: `#FFD700` → **amber `#FBBF24`**.
- Janken draw / link buttons: `#4FC3F7` → **cyan `#26C6DA`** (primary.light).
- Janken background depth stays dark navy, now aligned with frontend darkTheme `#0A1A2A`.

## Test plan
- [ ] Trigger `/我的成就` → summary bubble should show cyan header and cyan progress bar.
- [ ] Trigger `#決鬥 @target 100` → duel card dark bg, amber bet label.
- [ ] Trigger `#競技場` → arena card renders the same way.
- [ ] Play a match → result card: winner shows amber, draw shows cyan, ELO + shows green, ELO − shows red, 5 連勝 shows amber warning.
- [ ] Trigger `/段位查詢` → rank card: cyan link button, correct win/loss/streak coloring.

## Follow-ups (not in this PR)
- Frontend `Achievement/index.jsx:42-47` still uses the old rarity palette; sync once flex visuals are accepted.
- Remaining templates (Race, WorldBoss, Subscribe, Gacha, etc.) can migrate incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)