### PR TITLE
feat: subscriber auto-actions (daily gacha cron + janken auto-fate + LIFF)

### DIFF
--- a/app/__tests__/bin/AutoGacha.test.js
+++ b/app/__tests__/bin/AutoGacha.test.js
@@ -1,9 +1,8 @@
-// AutoGacha cron — unit tests covering disabled gate, concurrency cap,
-// and per-user success / already_pulled / failed / expired paths.
+// AutoGacha cron — unit tests covering concurrency cap and per-user
+// success / already_pulled / failed / expired paths.
 
 jest.mock("config", () => {
   const store = {
-    "autoGacha.enabled": true,
     "autoGacha.concurrency": 2,
     "autoGacha.schedule": ["0", "50", "23", "*", "*", "*"],
   };
@@ -14,7 +13,6 @@ jest.mock("config", () => {
       store[k] = v;
     },
     __reset: () => {
-      store["autoGacha.enabled"] = true;
       store["autoGacha.concurrency"] = 2;
     },
   };
@@ -52,14 +50,6 @@ describe("AutoGacha cron", () => {
 
   afterAll(() => {
     jest.restoreAllMocks();
-  });
-
-  it("skips entirely when autoGacha.enabled is false", async () => {
-    config.__setForTest("autoGacha.enabled", false);
-    const loadSpy = jest.spyOn(AutoGacha.impl, "loadTargets");
-    await AutoGacha();
-    expect(loadSpy).not.toHaveBeenCalled();
-    loadSpy.mockRestore();
   });
 
   it("runBatched respects the concurrency cap", async () => {

--- a/app/__tests__/bin/AutoGacha.test.js
+++ b/app/__tests__/bin/AutoGacha.test.js
@@ -20,6 +20,7 @@ jest.mock("config", () => {
 
 jest.mock("../../src/service/GachaService", () => ({
   runDailyDraw: jest.fn(),
+  getRemainingDailyQuota: jest.fn(),
 }));
 jest.mock("../../src/service/SubscriptionService", () => ({
   hasEffect: jest.fn(),
@@ -37,6 +38,7 @@ describe("AutoGacha cron", () => {
     config.__reset();
     SubscriptionService.hasEffect.mockResolvedValue(true);
     mysql.first.mockResolvedValue(null);
+    GachaService.getRemainingDailyQuota.mockResolvedValue({ total: 1, used: 0, remaining: 1 });
     GachaService.runDailyDraw.mockResolvedValue({
       rewards: new Array(10).fill({ id: 1, star: "1" }),
       rareCount: { 1: 10 },
@@ -83,10 +85,27 @@ describe("AutoGacha cron", () => {
     const summary = JSON.parse(args[6]);
     expect(summary.rareCount).toEqual({ 1: 10 });
     expect(summary.repeatReward).toBe(10);
+    expect(summary.rounds).toBe(1);
   });
 
-  it("drawForUser logs skipped / already_pulled when gacha_record has a row for today", async () => {
-    mysql.first.mockResolvedValueOnce({ id: 42 });
+  it("drawForUser loops runDailyDraw once per remaining quota slot (month-card = 2 rounds)", async () => {
+    GachaService.getRemainingDailyQuota.mockResolvedValueOnce({ total: 2, used: 0, remaining: 2 });
+    const counters = { success: 0, failed: 0, skipped: 0 };
+    await AutoGacha.drawForUser({ user_id: "Umonth" }, "2026-04-18", counters);
+    expect(GachaService.runDailyDraw).toHaveBeenCalledTimes(2);
+    expect(counters.success).toBe(1);
+    const args = mysql.raw.mock.calls[0][1];
+    expect(args[2]).toBe("success");
+    expect(args[3]).toBe(20); // 2 rounds × 10 pulls each
+    const summary = JSON.parse(args[6]);
+    expect(summary.rareCount).toEqual({ 1: 20 });
+    expect(summary.repeatReward).toBe(20); // 10 per round × 2 rounds
+    expect(summary.rounds).toBe(2);
+    expect(summary.quota_total).toBe(2);
+  });
+
+  it("drawForUser logs skipped / already_pulled when quota is exhausted", async () => {
+    GachaService.getRemainingDailyQuota.mockResolvedValueOnce({ total: 1, used: 1, remaining: 0 });
     const counters = { success: 0, failed: 0, skipped: 0 };
     await AutoGacha.drawForUser({ user_id: "Upulled" }, "2026-04-18", counters);
     expect(counters.skipped).toBe(1);
@@ -119,18 +138,19 @@ describe("AutoGacha cron", () => {
     expect(args[4]).toBe("x".repeat(255));
   });
 
-  it("summarizeRewards normalizes a GachaService result into a reward summary shape", () => {
+  it("summarizeRewards normalizes a single GachaService result into a reward summary shape", () => {
     const out = AutoGacha.summarizeRewards({
       rareCount: { 1: 7, 2: 2, 3: 1 },
       newCharacters: [{ id: 1 }, { id: 2 }],
       godStoneCost: 1500,
       repeatReward: 50,
     });
-    expect(out).toEqual({
+    expect(out).toMatchObject({
       rareCount: { 1: 7, 2: 2, 3: 1 },
       newCharactersCount: 2,
       godStoneCost: 1500,
       repeatReward: 50,
+      rounds: 1,
     });
   });
 });

--- a/app/__tests__/bin/AutoGacha.test.js
+++ b/app/__tests__/bin/AutoGacha.test.js
@@ -1,0 +1,146 @@
+// AutoGacha cron — unit tests covering disabled gate, concurrency cap,
+// and per-user success / already_pulled / failed / expired paths.
+
+jest.mock("config", () => {
+  const store = {
+    "autoGacha.enabled": true,
+    "autoGacha.concurrency": 2,
+    "autoGacha.schedule": ["0", "50", "23", "*", "*", "*"],
+  };
+  return {
+    get: jest.fn(key => store[key]),
+    has: jest.fn(key => key in store),
+    __setForTest: (k, v) => {
+      store[k] = v;
+    },
+    __reset: () => {
+      store["autoGacha.enabled"] = true;
+      store["autoGacha.concurrency"] = 2;
+    },
+  };
+});
+
+jest.mock("../../src/service/GachaService", () => ({
+  runDailyDraw: jest.fn(),
+}));
+jest.mock("../../src/service/SubscriptionService", () => ({
+  hasEffect: jest.fn(),
+}));
+
+const config = require("config");
+const mysql = require("../../src/util/mysql");
+const GachaService = require("../../src/service/GachaService");
+const SubscriptionService = require("../../src/service/SubscriptionService");
+const AutoGacha = require("../../bin/AutoGacha");
+
+describe("AutoGacha cron", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    config.__reset();
+    SubscriptionService.hasEffect.mockResolvedValue(true);
+    mysql.first.mockResolvedValue(null);
+    GachaService.runDailyDraw.mockResolvedValue({
+      rewards: new Array(10).fill({ id: 1, star: "1" }),
+      rareCount: { 1: 10 },
+      newCharacters: [],
+      ownCharactersCount: 50,
+      repeatReward: 10,
+      godStoneCost: 0,
+      unlocks: [],
+    });
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("skips entirely when autoGacha.enabled is false", async () => {
+    config.__setForTest("autoGacha.enabled", false);
+    const loadSpy = jest.spyOn(AutoGacha.impl, "loadTargets");
+    await AutoGacha();
+    expect(loadSpy).not.toHaveBeenCalled();
+    loadSpy.mockRestore();
+  });
+
+  it("runBatched respects the concurrency cap", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const worker = jest.fn(async () => {
+      inFlight++;
+      if (inFlight > maxInFlight) maxInFlight = inFlight;
+      await new Promise(r => setTimeout(r, 5));
+      inFlight--;
+    });
+    const items = Array.from({ length: 10 }, (_, i) => ({ user_id: `U${i}` }));
+    await AutoGacha.runBatched(items, 3, worker);
+    expect(worker).toHaveBeenCalledTimes(10);
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it("drawForUser logs a success row with reward_summary when GachaService resolves", async () => {
+    const counters = { success: 0, failed: 0, skipped: 0 };
+    await AutoGacha.drawForUser({ user_id: "Usucc" }, "2026-04-18", counters);
+    expect(counters.success).toBe(1);
+    expect(mysql.raw).toHaveBeenCalledTimes(1);
+    const [sql, args] = mysql.raw.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO auto_gacha_job_log/);
+    expect(sql).toMatch(/ON DUPLICATE KEY UPDATE/);
+    expect(args[0]).toBe("Usucc");
+    expect(args[1]).toBe("2026-04-18");
+    expect(args[2]).toBe("success");
+    expect(args[3]).toBe(10);
+    expect(typeof args[6]).toBe("string"); // reward_summary JSON stringified
+    const summary = JSON.parse(args[6]);
+    expect(summary.rareCount).toEqual({ 1: 10 });
+    expect(summary.repeatReward).toBe(10);
+  });
+
+  it("drawForUser logs skipped / already_pulled when gacha_record has a row for today", async () => {
+    mysql.first.mockResolvedValueOnce({ id: 42 });
+    const counters = { success: 0, failed: 0, skipped: 0 };
+    await AutoGacha.drawForUser({ user_id: "Upulled" }, "2026-04-18", counters);
+    expect(counters.skipped).toBe(1);
+    expect(GachaService.runDailyDraw).not.toHaveBeenCalled();
+    const args = mysql.raw.mock.calls[0][1];
+    expect(args[2]).toBe("skipped");
+    expect(args[4]).toBe("already_pulled");
+  });
+
+  it("drawForUser logs skipped when subscription expired between load and draw", async () => {
+    SubscriptionService.hasEffect.mockResolvedValueOnce(false);
+    const counters = { success: 0, failed: 0, skipped: 0 };
+    await AutoGacha.drawForUser({ user_id: "Uexp" }, "2026-04-18", counters);
+    expect(counters.skipped).toBe(1);
+    expect(GachaService.runDailyDraw).not.toHaveBeenCalled();
+    const args = mysql.raw.mock.calls[0][1];
+    expect(args[2]).toBe("skipped");
+    expect(args[4]).toBe("subscription_expired_between_load_and_draw");
+  });
+
+  it("drawForUser logs failed with truncated error when GachaService throws", async () => {
+    const longMsg = "x".repeat(400);
+    GachaService.runDailyDraw.mockRejectedValueOnce(new Error(longMsg));
+    const counters = { success: 0, failed: 0, skipped: 0 };
+    await AutoGacha.drawForUser({ user_id: "Ufail" }, "2026-04-18", counters);
+    expect(counters.failed).toBe(1);
+    const args = mysql.raw.mock.calls[0][1];
+    expect(args[2]).toBe("failed");
+    expect(args[4].length).toBe(255);
+    expect(args[4]).toBe("x".repeat(255));
+  });
+
+  it("summarizeRewards normalizes a GachaService result into a reward summary shape", () => {
+    const out = AutoGacha.summarizeRewards({
+      rareCount: { 1: 7, 2: 2, 3: 1 },
+      newCharacters: [{ id: 1 }, { id: 2 }],
+      godStoneCost: 1500,
+      repeatReward: 50,
+    });
+    expect(out).toEqual({
+      rareCount: { 1: 7, 2: 2, 3: 1 },
+      newCharactersCount: 2,
+      godStoneCost: 1500,
+      repeatReward: 50,
+    });
+  });
+});

--- a/app/__tests__/controller/AutoPreferenceController.test.js
+++ b/app/__tests__/controller/AutoPreferenceController.test.js
@@ -49,7 +49,12 @@ describe("AutoPreferenceController", () => {
       expect(res.json).toHaveBeenCalledWith({
         auto_daily_gacha: 1,
         auto_janken_fate: 0,
-        entitlements: { auto_daily_gacha: true, auto_janken_fate: false },
+        auto_janken_fate_with_bet: 0,
+        entitlements: {
+          auto_daily_gacha: true,
+          auto_janken_fate: false,
+          auto_janken_fate_with_bet: false,
+        },
       });
     });
 
@@ -63,7 +68,12 @@ describe("AutoPreferenceController", () => {
       expect(res.json).toHaveBeenCalledWith({
         auto_daily_gacha: 0,
         auto_janken_fate: 0,
-        entitlements: { auto_daily_gacha: false, auto_janken_fate: false },
+        auto_janken_fate_with_bet: 0,
+        entitlements: {
+          auto_daily_gacha: false,
+          auto_janken_fate: false,
+          auto_janken_fate_with_bet: false,
+        },
       });
     });
   });

--- a/app/__tests__/controller/AutoPreferenceController.test.js
+++ b/app/__tests__/controller/AutoPreferenceController.test.js
@@ -198,7 +198,7 @@ describe("AutoPreferenceController", () => {
   });
 
   describe("showAutoSettings (LINE command)", () => {
-    it("replies a Flex bubble with URI action pointing at /AutoSettings", async () => {
+    it("replies a Flex bubble with URI action pointing at /auto/settings", async () => {
       process.env.LINE_LIFF_TALL_ID = "1234567890-abc";
       const context = { replyFlex: jest.fn().mockResolvedValue(undefined) };
       await controller.showAutoSettings(context);
@@ -207,7 +207,7 @@ describe("AutoPreferenceController", () => {
       expect(altText).toBe("自動設定");
       expect(bubble.type).toBe("bubble");
       expect(bubble.body.action.type).toBe("uri");
-      expect(bubble.body.action.uri).toContain("/AutoSettings");
+      expect(bubble.body.action.uri).toContain("/auto/settings");
     });
   });
 });

--- a/app/__tests__/controller/AutoPreferenceController.test.js
+++ b/app/__tests__/controller/AutoPreferenceController.test.js
@@ -1,0 +1,203 @@
+// AutoPreferenceController — unit tests invoking handlers with fake req/res.
+
+jest.mock("../../src/model/application/UserAutoPreference", () => ({
+  first: jest.fn(),
+}));
+jest.mock("../../src/service/SubscriptionService", () => ({
+  hasEffect: jest.fn(),
+}));
+
+const UserAutoPreference = require("../../src/model/application/UserAutoPreference");
+const SubscriptionService = require("../../src/service/SubscriptionService");
+const mysql = require("../../src/util/mysql");
+const controller = require("../../src/controller/application/AutoPreferenceController");
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+}
+
+describe("AutoPreferenceController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mysql.first.mockResolvedValue(null);
+  });
+
+  describe("GET /api/auto-preference", () => {
+    it("returns 401 when profile is missing", async () => {
+      const res = mockRes();
+      await controller.api.getPreference({}, res);
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: "unauthenticated" });
+    });
+
+    it("returns preference + entitlement flags", async () => {
+      UserAutoPreference.first.mockResolvedValue({
+        user_id: "Uabc",
+        auto_daily_gacha: 1,
+        auto_janken_fate: 0,
+      });
+      SubscriptionService.hasEffect.mockImplementation(
+        async (_userId, effect) => effect === "auto_daily_gacha"
+      );
+
+      const res = mockRes();
+      await controller.api.getPreference({ profile: { userId: "Uabc" } }, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        auto_daily_gacha: 1,
+        auto_janken_fate: 0,
+        entitlements: { auto_daily_gacha: true, auto_janken_fate: false },
+      });
+    });
+
+    it("returns zeros + false entitlements when user has no preference row", async () => {
+      UserAutoPreference.first.mockResolvedValue(null);
+      SubscriptionService.hasEffect.mockResolvedValue(false);
+
+      const res = mockRes();
+      await controller.api.getPreference({ profile: { userId: "Unew" } }, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        auto_daily_gacha: 0,
+        auto_janken_fate: 0,
+        entitlements: { auto_daily_gacha: false, auto_janken_fate: false },
+      });
+    });
+  });
+
+  describe("PUT /api/auto-preference", () => {
+    beforeEach(() => {
+      UserAutoPreference.first.mockResolvedValue({
+        user_id: "Uabc",
+        auto_daily_gacha: 0,
+        auto_janken_fate: 0,
+      });
+    });
+
+    it("rejects flipping a flag to 1 without entitlement (returns 403)", async () => {
+      SubscriptionService.hasEffect.mockResolvedValue(false);
+      const res = mockRes();
+      await controller.api.setPreference(
+        { profile: { userId: "Uabc" }, body: { auto_daily_gacha: 1 } },
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "entitlement_missing",
+        field: "auto_daily_gacha",
+      });
+      expect(mysql.raw).not.toHaveBeenCalled();
+    });
+
+    it("flipping to 0 is always allowed (opt-out no entitlement required)", async () => {
+      SubscriptionService.hasEffect.mockResolvedValue(false);
+      const res = mockRes();
+      await controller.api.setPreference(
+        { profile: { userId: "Uabc" }, body: { auto_daily_gacha: 0 } },
+        res
+      );
+      expect(mysql.raw).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalledWith(403);
+    });
+
+    it("happy path: entitled + flag=1 → UPSERT with body args, token userId used", async () => {
+      SubscriptionService.hasEffect.mockResolvedValue(true);
+      // setPreference only calls UserAutoPreference.first once — after the upsert,
+      // to return the new state. So mock it as the post-upsert snapshot.
+      UserAutoPreference.first.mockResolvedValue({
+        user_id: "Uabc",
+        auto_daily_gacha: 1,
+        auto_janken_fate: 0,
+      });
+      const res = mockRes();
+      await controller.api.setPreference(
+        {
+          profile: { userId: "Uabc" },
+          body: { auto_daily_gacha: 1, user_id: "Udifferent" }, // body user_id ignored
+        },
+        res
+      );
+      expect(mysql.raw).toHaveBeenCalledTimes(1);
+      const [sql, args] = mysql.raw.mock.calls[0];
+      expect(sql).toMatch(/INSERT INTO user_auto_preference/);
+      expect(args[0]).toBe("Uabc"); // NOT "Udifferent"
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ auto_daily_gacha: 1, auto_janken_fate: 0 })
+      );
+    });
+
+    it("empty body returns current preference without UPSERT", async () => {
+      SubscriptionService.hasEffect.mockResolvedValue(true);
+      const res = mockRes();
+      await controller.api.setPreference({ profile: { userId: "Uabc" }, body: {} }, res);
+      expect(mysql.raw).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/auto-history", () => {
+    it("returns 401 when profile is missing", async () => {
+      const res = mockRes();
+      await controller.api.getHistory({ query: {} }, res);
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it("caps limit at 100 even when query.limit is 500", async () => {
+      const res = mockRes();
+      await controller.api.getHistory(
+        { profile: { userId: "Uabc" }, query: { limit: "500", type: "gacha" } },
+        res
+      );
+      expect(mysql.limit).toHaveBeenCalledWith(100);
+    });
+
+    it("defaults to limit=30 when query.limit is missing", async () => {
+      const res = mockRes();
+      await controller.api.getHistory(
+        { profile: { userId: "Uabc" }, query: { type: "gacha" } },
+        res
+      );
+      expect(mysql.limit).toHaveBeenCalledWith(30);
+    });
+
+    it("type=gacha queries only auto_gacha_job_log", async () => {
+      const res = mockRes();
+      await controller.api.getHistory(
+        { profile: { userId: "Uabc" }, query: { type: "gacha" } },
+        res
+      );
+      // mysql() call argument should be the gacha table, not janken
+      const calls = mysql.mock.calls.map(c => c[0]);
+      expect(calls).toContain("auto_gacha_job_log");
+      expect(calls).not.toContain("janken_auto_fate_log");
+    });
+
+    it("type=janken queries only janken_auto_fate_log", async () => {
+      const res = mockRes();
+      await controller.api.getHistory(
+        { profile: { userId: "Uabc" }, query: { type: "janken" } },
+        res
+      );
+      const calls = mysql.mock.calls.map(c => c[0]);
+      expect(calls).toContain("janken_auto_fate_log");
+      expect(calls).not.toContain("auto_gacha_job_log");
+    });
+  });
+
+  describe("showAutoSettings (LINE command)", () => {
+    it("replies a Flex bubble with URI action pointing at /AutoSettings", async () => {
+      process.env.LINE_LIFF_TALL_ID = "1234567890-abc";
+      const context = { replyFlex: jest.fn().mockResolvedValue(undefined) };
+      await controller.showAutoSettings(context);
+      expect(context.replyFlex).toHaveBeenCalledTimes(1);
+      const [altText, bubble] = context.replyFlex.mock.calls[0];
+      expect(altText).toBe("自動設定");
+      expect(bubble.type).toBe("bubble");
+      expect(bubble.body.action.type).toBe("uri");
+      expect(bubble.body.action.uri).toContain("/AutoSettings");
+    });
+  });
+});

--- a/app/__tests__/service/GachaService.test.js
+++ b/app/__tests__/service/GachaService.test.js
@@ -223,16 +223,19 @@ describe("GachaService.runDailyDraw", () => {
     });
 
     it("ensure: costs 3000 and the last reward is guaranteed 3-star", async () => {
-      // We force a pool where only 1-star characters exist to verify the guarantee.
+      // Force the pool so that 1-star dominates natural draws (rate so high that 3-star's
+      // 1% is statistically negligible over 10 pulls), while keeping rainbow rate > 0 so
+      // the ensure-mode rainbow pool can still produce a reward via play().
       GachaModel.getDatabasePool.mockResolvedValue([
-        { id: 1, name: "silver-1", rate: "100%", star: "1", isPrincess: "1" },
-        { id: 3, name: "rainbow-3", rate: "0%", star: "3", isPrincess: "1" },
+        { id: 1, name: "silver-1", rate: "10000%", star: "1", isPrincess: "1" },
+        { id: 3, name: "rainbow-3", rate: "1%", star: "3", isPrincess: "1" },
       ]);
 
       const result = await GachaService.runDailyDraw("Uensure", { ensure: true });
       expect(result.godStoneCost).toBe(3000);
+      expect(result.rewards.length).toBe(10);
       expect(result.rewards[9].star).toBe("3");
-      // The other 9 should be 1-star based on our forced pool.
+      // The other 9 should be 1-star based on our forced pool (natural rainbow chance ≈ 0.01%).
       const oneStars = result.rewards.slice(0, 9);
       expect(oneStars.every(r => r.star == "1")).toBe(true);
     });

--- a/app/__tests__/service/GachaService.test.js
+++ b/app/__tests__/service/GachaService.test.js
@@ -1,0 +1,182 @@
+// GachaService.runDailyDraw — unit tests targeting the side-effect ledger
+// contract documented in .omc/plans/2026-04-18-subscriber-auto-actions.md §13.
+
+jest.mock("../../src/model/princess/gacha", () => ({
+  getDatabasePool: jest.fn(),
+  getUserGodStoneCount: jest.fn(),
+  getPrincessCharacterCount: jest.fn(),
+}));
+
+jest.mock("../../src/model/princess/GachaBanner", () => ({
+  getActiveBannersWithCharacters: jest.fn().mockResolvedValue([]),
+}));
+
+// Transaction builder — records inserts per-table for post-hoc assertions.
+const txInserts = [];
+function makeTrxBuilder() {
+  const trx = tableName => ({
+    insert: jest.fn(async rows => {
+      txInserts.push({ table: tableName, rows });
+      // Simulate AUTO_INCREMENT: return [1] for gacha_record, [0] for others.
+      return tableName === "gacha_record" ? [42] : [0];
+    }),
+  });
+  trx.commit = jest.fn().mockResolvedValue(undefined);
+  trx.rollback = jest.fn().mockResolvedValue(undefined);
+  return trx;
+}
+let currentTrx;
+
+jest.mock("../../src/model/application/Inventory", () => {
+  const inventory = {
+    table: "Inventory",
+    transaction: jest.fn(async () => {
+      currentTrx = makeTrxBuilder();
+      return currentTrx;
+    }),
+    // `inventory.knex` is used to read own-items before the trx. We stub it
+    // via a getter so the query-chain returns the staged array.
+  };
+  Object.defineProperty(inventory, "knex", {
+    get: () => {
+      const chain = {};
+      chain.where = jest.fn(() => chain);
+      chain.select = jest.fn(() => chain);
+      chain.andWhereNot = jest.fn(() => chain);
+      chain.orderBy = jest.fn(() => Promise.resolve([]));
+      return chain;
+    },
+  });
+  return { inventory };
+});
+
+jest.mock("../../src/model/princess/GachaRecord", () => ({
+  table: "gacha_record",
+}));
+jest.mock("../../src/model/princess/GachaRecordDetail", () => ({
+  table: "gacha_record_detail",
+}));
+jest.mock("../../src/model/application/SigninDays", () => ({
+  first: jest.fn().mockResolvedValue(null),
+  create: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../src/service/EventCenterService", () => ({
+  add: jest.fn().mockResolvedValue(undefined),
+  getEventName: jest.fn(name => `event_center:${name}`),
+}));
+jest.mock("../../src/service/AchievementEngine", () => ({
+  evaluate: jest.fn().mockResolvedValue({ unlocked: [] }),
+}));
+
+const GachaModel = require("../../src/model/princess/gacha");
+const GachaService = require("../../src/service/GachaService");
+const EventCenterService = require("../../src/service/EventCenterService");
+const AchievementEngine = require("../../src/service/AchievementEngine");
+const signModel = require("../../src/model/application/SigninDays");
+
+function makePool() {
+  return [
+    { id: 1, name: "silver-1", rate: "70%", star: "1", isPrincess: "1" },
+    { id: 2, name: "gold-2", rate: "25%", star: "2", isPrincess: "1" },
+    { id: 3, name: "rainbow-3", rate: "5%", star: "3", isPrincess: "1" },
+  ];
+}
+
+describe("GachaService.runDailyDraw", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    txInserts.length = 0;
+    GachaModel.getDatabasePool.mockResolvedValue(makePool());
+  });
+
+  it("returns plain-data shape with exactly the seven documented keys", async () => {
+    const result = await GachaService.runDailyDraw("Utest_user_1");
+
+    expect(result).toBeDefined();
+    expect(Object.keys(result).sort()).toEqual(
+      [
+        "godStoneCost",
+        "newCharacters",
+        "ownCharactersCount",
+        "rareCount",
+        "repeatReward",
+        "rewards",
+        "unlocks",
+      ].sort()
+    );
+    expect(Array.isArray(result.rewards)).toBe(true);
+    expect(result.rewards.length).toBe(10);
+    expect(typeof result.rareCount).toBe("object");
+    expect(Array.isArray(result.newCharacters)).toBe(true);
+    expect(typeof result.ownCharactersCount).toBe("number");
+    expect(typeof result.repeatReward).toBe("number");
+    expect(typeof result.godStoneCost).toBe("number");
+    expect(Array.isArray(result.unlocks)).toBe(true);
+  });
+
+  it("does not return any context/reply-flavoured keys", async () => {
+    const result = await GachaService.runDailyDraw("Utest_user_2");
+    expect(result).not.toHaveProperty("context");
+    expect(result).not.toHaveProperty("reply");
+    expect(result).not.toHaveProperty("bubble");
+    expect(result).not.toHaveProperty("message");
+  });
+
+  it("invokes handleSignin, EventCenterService.add, AchievementEngine.evaluate with the contract args", async () => {
+    await GachaService.runDailyDraw("Uabc");
+
+    expect(signModel.first).toHaveBeenCalledWith({ filter: { user_id: "Uabc" } });
+
+    expect(EventCenterService.add).toHaveBeenCalledTimes(1);
+    expect(EventCenterService.add).toHaveBeenCalledWith("event_center:daily_quest", {
+      userId: "Uabc",
+    });
+
+    expect(AchievementEngine.evaluate).toHaveBeenCalledTimes(1);
+    const [userIdArg, eventArg, metaArg] = AchievementEngine.evaluate.mock.calls[0];
+    expect(userIdArg).toBe("Uabc");
+    expect(eventArg).toBe("gacha_pull");
+    expect(metaArg).toHaveProperty("threeStarCount");
+    expect(metaArg).toHaveProperty("uniqueCount");
+    expect(metaArg).toHaveProperty("pullType");
+  });
+
+  it("writes one GachaRecord row and one GachaRecordDetail row per pulled character", async () => {
+    await GachaService.runDailyDraw("Uledger");
+
+    const gachaRecordInserts = txInserts.filter(t => t.table === "gacha_record");
+    const detailInserts = txInserts.filter(t => t.table === "gacha_record_detail");
+    expect(gachaRecordInserts.length).toBe(1);
+    expect(detailInserts.length).toBe(1);
+    expect(Array.isArray(detailInserts[0].rows)).toBe(true);
+    expect(detailInserts[0].rows.length).toBe(10);
+    for (const row of detailInserts[0].rows) {
+      expect(row.gacha_record_id).toBe(42);
+      expect(row.user_id).toBe("Uledger");
+      expect(typeof row.character_id).toBe("number");
+      expect(typeof row.star).toBe("number");
+      expect(row.is_new === 1 || row.is_new === 0).toBe(true);
+    }
+  });
+
+  it("commits the transaction on success and does not rollback", async () => {
+    await GachaService.runDailyDraw("Ucommit");
+    expect(currentTrx.commit).toHaveBeenCalledTimes(1);
+    expect(currentTrx.rollback).not.toHaveBeenCalled();
+  });
+
+  it("accepts only a userId (no bottender context) without throwing", async () => {
+    await expect(GachaService.runDailyDraw("Uonly")).resolves.toBeDefined();
+  });
+
+  it("sets godStoneCost=0 when no special draw flags are passed", async () => {
+    const result = await GachaService.runDailyDraw("Ufree");
+    expect(result.godStoneCost).toBe(0);
+    const costInserts = txInserts.filter(
+      t => t.table === "Inventory" && t.rows.itemId === 999 && t.rows.itemAmount < 0
+    );
+    expect(costInserts.length).toBe(0);
+  });
+});

--- a/app/__tests__/service/GachaService.test.js
+++ b/app/__tests__/service/GachaService.test.js
@@ -70,7 +70,22 @@ jest.mock("../../src/service/AchievementEngine", () => ({
   evaluate: jest.fn().mockResolvedValue({ unlocked: [] }),
 }));
 
+jest.mock("config", () => ({
+  get: jest.fn(key => {
+    const values = {
+      "gacha.pick_up_cost": 1500,
+      "gacha.ensure_cost": 3000,
+      "gacha.europe_cost": 5000,
+      "gacha.silver_repeat_reward": 1,
+      "gacha.gold_repeat_reward": 10,
+      "gacha.rainbow_repeat_reward": 50,
+    };
+    return values[key];
+  }),
+}));
+
 const GachaModel = require("../../src/model/princess/gacha");
+const GachaBanner = require("../../src/model/princess/GachaBanner");
 const GachaService = require("../../src/service/GachaService");
 const EventCenterService = require("../../src/service/EventCenterService");
 const AchievementEngine = require("../../src/service/AchievementEngine");
@@ -89,6 +104,7 @@ describe("GachaService.runDailyDraw", () => {
     jest.clearAllMocks();
     txInserts.length = 0;
     GachaModel.getDatabasePool.mockResolvedValue(makePool());
+    GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([]);
   });
 
   it("returns plain-data shape with exactly the seven documented keys", async () => {
@@ -178,5 +194,47 @@ describe("GachaService.runDailyDraw", () => {
       t => t.table === "Inventory" && t.rows.itemId === 999 && t.rows.itemAmount < 0
     );
     expect(costInserts.length).toBe(0);
+  });
+
+  describe("Mode specific tests", () => {
+    it("europe: costs 5000 and all rewards are 3-star", async () => {
+      const result = await GachaService.runDailyDraw("Ueuro", { europe: true });
+      expect(result.godStoneCost).toBe(5000);
+      expect(result.rewards.every(r => r.star == "3")).toBe(true);
+      expect(result.rareCount["3"]).toBe(10);
+
+      const costInsert = txInserts.find(
+        t => t.table === "Inventory" && t.rows.itemId === 999 && t.rows.itemAmount === -5000
+      );
+      expect(costInsert).toBeDefined();
+    });
+
+    it("europe: uses banner cost if active", async () => {
+      GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([
+        { type: "europe", cost: 4444 },
+      ]);
+      const result = await GachaService.runDailyDraw("Ubanner", { europe: true });
+      expect(result.godStoneCost).toBe(4444);
+    });
+
+    it("pickup: costs 1500 and invokes pickup logic (verified via godStoneCost)", async () => {
+      const result = await GachaService.runDailyDraw("Upick", { pickup: true });
+      expect(result.godStoneCost).toBe(1500);
+    });
+
+    it("ensure: costs 3000 and the last reward is guaranteed 3-star", async () => {
+      // We force a pool where only 1-star characters exist to verify the guarantee.
+      GachaModel.getDatabasePool.mockResolvedValue([
+        { id: 1, name: "silver-1", rate: "100%", star: "1", isPrincess: "1" },
+        { id: 3, name: "rainbow-3", rate: "0%", star: "3", isPrincess: "1" },
+      ]);
+
+      const result = await GachaService.runDailyDraw("Uensure", { ensure: true });
+      expect(result.godStoneCost).toBe(3000);
+      expect(result.rewards[9].star).toBe("3");
+      // The other 9 should be 1-star based on our forced pool.
+      const oneStars = result.rewards.slice(0, 9);
+      expect(oneStars.every(r => r.star == "1")).toBe(true);
+    });
   });
 });

--- a/app/__tests__/service/JankenService.autoFate.test.js
+++ b/app/__tests__/service/JankenService.autoFate.test.js
@@ -32,6 +32,14 @@ jest.mock("../../src/service/SubscriptionService", () => ({
   hasEffect: jest.fn(),
 }));
 
+jest.mock("../../src/model/application/Inventory", () => ({
+  inventory: {
+    getUserMoney: jest.fn(),
+    decreaseGodStone: jest.fn().mockResolvedValue(undefined),
+    increaseGodStone: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
 const config = require("config");
 const redis = require("../../src/util/redis");
 const UserAutoPreference = require("../../src/model/application/UserAutoPreference");
@@ -77,7 +85,7 @@ describe("JankenService.autoFateIfEligible", () => {
       p1UserId: "Up1",
       p2UserId: "Up2",
     });
-    expect(result).toEqual({ eligible: false });
+    expect(result).toEqual({ eligible: false, reason: "feature_disabled" });
     expect(UserAutoPreference.first).not.toHaveBeenCalled();
     expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
     expect(redis.set).not.toHaveBeenCalled();
@@ -113,6 +121,72 @@ describe("JankenService.autoFateIfEligible", () => {
     expect(result.eligible).toBe(false);
     expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
     expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  describe("bet-mode auto-fate (fund-leak safety)", () => {
+    it("bet match: skips when auto_janken_fate_with_bet is not opted in", async () => {
+      UserAutoPreference.first.mockResolvedValueOnce({
+        user_id: "Up2",
+        auto_janken_fate: 1,
+        auto_janken_fate_with_bet: 0,
+      });
+      const result = await JankenService.autoFateIfEligible("Up2", "match-b", "p2", {
+        p1UserId: "Up1",
+        p2UserId: "Up2",
+        betAmount: 100,
+      });
+      expect(result).toEqual({ eligible: false, reason: "bet_auto_fate_not_opted_in" });
+      expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
+      // Confirm submitChoice was never called.
+      expect(redis.set.mock.calls.some(c => String(c[0]).startsWith("jankenDecide:match-b:"))).toBe(
+        false
+      );
+    });
+
+    it("bet match: escrow fails (insufficient funds) → skip auto-fate, no log, no submit", async () => {
+      UserAutoPreference.first.mockResolvedValueOnce({
+        user_id: "Up2",
+        auto_janken_fate: 1,
+        auto_janken_fate_with_bet: 1,
+      });
+      // First redis.set is tryEscrowOnce's NX lock acquiring → "OK"; escrowBet then
+      // calls inventory.getUserMoney which returns insufficient balance.
+      const { inventory } = require("../../src/model/application/Inventory");
+      inventory.getUserMoney.mockResolvedValueOnce({ amount: 10 });
+      redis.set.mockResolvedValue("OK"); // escrow NX succeeds
+
+      const result = await JankenService.autoFateIfEligible("Up2", "match-b2", "p2", {
+        p1UserId: "Up1",
+        p2UserId: "Up2",
+        betAmount: 1000,
+      });
+      expect(result).toEqual({ eligible: false, reason: "insufficient_funds_for_bet" });
+      expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
+      expect(inventory.decreaseGodStone).not.toHaveBeenCalled();
+    });
+
+    it("bet match: with_bet=1 and escrow succeeds → proceed with auto-fate", async () => {
+      UserAutoPreference.first.mockResolvedValueOnce({
+        user_id: "Up2",
+        auto_janken_fate: 1,
+        auto_janken_fate_with_bet: 1,
+      });
+      const { inventory } = require("../../src/model/application/Inventory");
+      inventory.getUserMoney.mockResolvedValueOnce({ amount: 10000 });
+      redis.set.mockResolvedValue("OK");
+
+      const result = await JankenService.autoFateIfEligible("Up2", "match-b3", "p2", {
+        p1UserId: "Up1",
+        p2UserId: "Up2",
+        betAmount: 1000,
+      });
+      expect(result.eligible).toBe(true);
+      expect(["rock", "paper", "scissors"]).toContain(result.choice);
+      expect(inventory.decreaseGodStone).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "Up2", amount: 1000, note: "janken_bet_escrow" })
+      );
+      expect(JankenAutoFateLog.create).toHaveBeenCalled();
+    });
   });
 });
 

--- a/app/__tests__/service/JankenService.autoFate.test.js
+++ b/app/__tests__/service/JankenService.autoFate.test.js
@@ -2,7 +2,6 @@
 
 jest.mock("config", () => {
   const store = {
-    "autoJankenFate.enabled": true,
     "redis.keys.jankenDecide": "jankenDecide",
     "redis.keys.jankenChallenge": "jankenChallenge",
     "minigame.janken.bet.feeRate": 0.1,
@@ -16,9 +15,7 @@ jest.mock("config", () => {
     __setForTest: (k, v) => {
       store[k] = v;
     },
-    __reset: () => {
-      store["autoJankenFate.enabled"] = true;
-    },
+    __reset: () => {},
   };
 });
 
@@ -75,20 +72,8 @@ describe("JankenService.autoFateIfEligible", () => {
     expect(redis.set).toHaveBeenCalledWith(
       "jankenDecide:match-1:Up2",
       result.choice,
-      expect.objectContaining({ EX: 3600 })
+      expect.objectContaining({ EX: 7 * 24 * 60 * 60 })
     );
-  });
-
-  it("no-ops when feature flag autoJankenFate.enabled is false", async () => {
-    config.__setForTest("autoJankenFate.enabled", false);
-    const result = await JankenService.autoFateIfEligible("Up2", "match-1", "p2", {
-      p1UserId: "Up1",
-      p2UserId: "Up2",
-    });
-    expect(result).toEqual({ eligible: false, reason: "feature_disabled" });
-    expect(UserAutoPreference.first).not.toHaveBeenCalled();
-    expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
-    expect(redis.set).not.toHaveBeenCalled();
   });
 
   it("no-ops when user has no preference row", async () => {

--- a/app/__tests__/service/JankenService.autoFate.test.js
+++ b/app/__tests__/service/JankenService.autoFate.test.js
@@ -1,0 +1,148 @@
+// JankenService.autoFateIfEligible + resolveMatch NX-lock unit tests.
+
+jest.mock("config", () => {
+  const store = {
+    "autoJankenFate.enabled": true,
+    "redis.keys.jankenDecide": "jankenDecide",
+    "redis.keys.jankenChallenge": "jankenChallenge",
+    "minigame.janken.bet.feeRate": 0.1,
+    "minigame.janken.bet.minAmount": 10,
+    "minigame.janken.streak.bountyMinBet": 1000,
+    "minigame.janken.streak.bountyClaimMultiplier": 5,
+  };
+  return {
+    get: jest.fn(key => store[key]),
+    has: jest.fn(key => key in store),
+    __setForTest: (k, v) => {
+      store[k] = v;
+    },
+    __reset: () => {
+      store["autoJankenFate.enabled"] = true;
+    },
+  };
+});
+
+jest.mock("../../src/model/application/UserAutoPreference", () => ({
+  first: jest.fn(),
+}));
+jest.mock("../../src/model/application/JankenAutoFateLog", () => ({
+  create: jest.fn(),
+}));
+jest.mock("../../src/service/SubscriptionService", () => ({
+  hasEffect: jest.fn(),
+}));
+
+const config = require("config");
+const redis = require("../../src/util/redis");
+const UserAutoPreference = require("../../src/model/application/UserAutoPreference");
+const JankenAutoFateLog = require("../../src/model/application/JankenAutoFateLog");
+const SubscriptionService = require("../../src/service/SubscriptionService");
+const JankenService = require("../../src/service/JankenService");
+
+describe("JankenService.autoFateIfEligible", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    config.__reset();
+    redis.set.mockResolvedValue("OK");
+    redis.get.mockResolvedValue(null);
+    UserAutoPreference.first.mockResolvedValue({ user_id: "Up2", auto_janken_fate: 1 });
+    SubscriptionService.hasEffect.mockResolvedValue(true);
+    JankenAutoFateLog.create.mockResolvedValue(1);
+  });
+
+  it("auto-submits a choice and writes a log row when user is eligible and opted-in", async () => {
+    const result = await JankenService.autoFateIfEligible("Up2", "match-1", "p2", {
+      p1UserId: "Up1",
+      p2UserId: "Up2",
+    });
+    expect(result.eligible).toBe(true);
+    expect(["rock", "paper", "scissors"]).toContain(result.choice);
+    expect(JankenAutoFateLog.create).toHaveBeenCalledWith({
+      match_id: "match-1",
+      user_id: "Up2",
+      role: "p2",
+      choice: result.choice,
+    });
+    // submitChoice writes to redis under jankenDecide:{matchId}:{userId}
+    expect(redis.set).toHaveBeenCalledWith(
+      "jankenDecide:match-1:Up2",
+      result.choice,
+      expect.objectContaining({ EX: 3600 })
+    );
+  });
+
+  it("no-ops when feature flag autoJankenFate.enabled is false", async () => {
+    config.__setForTest("autoJankenFate.enabled", false);
+    const result = await JankenService.autoFateIfEligible("Up2", "match-1", "p2", {
+      p1UserId: "Up1",
+      p2UserId: "Up2",
+    });
+    expect(result).toEqual({ eligible: false });
+    expect(UserAutoPreference.first).not.toHaveBeenCalled();
+    expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when user has no preference row", async () => {
+    UserAutoPreference.first.mockResolvedValueOnce(null);
+    const result = await JankenService.autoFateIfEligible("Up2", "match-1", "p2", {
+      p1UserId: "Up1",
+      p2UserId: "Up2",
+    });
+    expect(result.eligible).toBe(false);
+    expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when user opted out (auto_janken_fate = 0)", async () => {
+    UserAutoPreference.first.mockResolvedValueOnce({ user_id: "Up2", auto_janken_fate: 0 });
+    const result = await JankenService.autoFateIfEligible("Up2", "match-1", "p2", {
+      p1UserId: "Up1",
+      p2UserId: "Up2",
+    });
+    expect(result.eligible).toBe(false);
+    expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when user lacks the auto_janken_fate subscription entitlement", async () => {
+    SubscriptionService.hasEffect.mockResolvedValueOnce(false);
+    const result = await JankenService.autoFateIfEligible("Up2", "match-1", "p2", {
+      p1UserId: "Up1",
+      p2UserId: "Up2",
+    });
+    expect(result.eligible).toBe(false);
+    expect(JankenAutoFateLog.create).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("JankenService.resolveMatch NX lock (AC-12)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redis.set.mockResolvedValue("OK");
+  });
+
+  it("second concurrent call returns null because NX lock is held", async () => {
+    // First call acquires the lock (redis.set with NX returns "OK"), second returns null.
+    redis.set.mockImplementationOnce(async () => "OK").mockImplementationOnce(async () => null);
+
+    const params = {
+      matchId: "m",
+      groupId: "G",
+      p1UserId: "Up1",
+      p2UserId: "Up2",
+      p1Choice: "rock",
+      p2Choice: "paper",
+      betAmount: 0,
+    };
+
+    // Intentionally trigger a failure after the lock check so the first call short-circuits
+    // (we only care about the lock semantics here). The second call must see the lock held.
+    const call1 = JankenService.resolveMatch(params).catch(() => null);
+    const call2 = JankenService.resolveMatch(params);
+
+    await call1;
+    const result2 = await call2;
+    expect(result2).toBeNull();
+  });
+});

--- a/app/__tests__/service/JankenService.test.js
+++ b/app/__tests__/service/JankenService.test.js
@@ -111,7 +111,7 @@ describe("JankenService", () => {
       expect(redis.set).toHaveBeenCalledWith(
         expect.stringContaining("match-123:user-1"),
         "rock",
-        expect.objectContaining({ EX: 3600 })
+        expect.objectContaining({ EX: 7 * 24 * 60 * 60 })
       );
     });
 

--- a/app/__tests__/service/JankenService.test.js
+++ b/app/__tests__/service/JankenService.test.js
@@ -30,8 +30,18 @@ const mockTrxQuery = jest.fn(() => ({
   })),
 }));
 mockTrxQuery.transaction = jest.fn(async cb => cb(mockTrxQuery));
+mockTrxQuery.transactionProvider = jest.fn(() => jest.fn(async () => mockTrxQuery));
 
 jest.mock("../../src/util/mysql", () => mockTrxQuery);
+jest.mock("../../src/model/application/JankenAutoFateLog", () => ({
+  create: jest.fn().mockResolvedValue(1),
+}));
+jest.mock("../../src/model/application/UserAutoPreference", () => ({
+  first: jest.fn().mockResolvedValue(null),
+}));
+jest.mock("../../src/service/SubscriptionService", () => ({
+  hasEffect: jest.fn().mockResolvedValue(false),
+}));
 
 const JankenService = require("../../src/service/JankenService");
 const redis = require("../../src/util/redis");

--- a/app/__tests__/service/SubscriptionService.test.js
+++ b/app/__tests__/service/SubscriptionService.test.js
@@ -1,0 +1,87 @@
+// SubscriptionService.hasEffect — unit tests covering active/expired/no-sub/malformed cases.
+
+jest.mock("../../src/model/application/SubscribeUser", () => ({
+  all: jest.fn(),
+}));
+jest.mock("../../src/model/application/SubscribeCard", () => ({
+  first: jest.fn(),
+}));
+
+const SubscribeUser = require("../../src/model/application/SubscribeUser");
+const SubscribeCard = require("../../src/model/application/SubscribeCard");
+const SubscriptionService = require("../../src/service/SubscriptionService");
+
+describe("SubscriptionService.hasEffect", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns true when active subscription card includes the effect", async () => {
+    SubscribeUser.all.mockResolvedValue([{ subscribe_card_key: "month" }]);
+    SubscribeCard.first.mockResolvedValue({
+      effects: [
+        { type: "gacha_times", value: 1 },
+        { type: "auto_daily_gacha", value: 1 },
+      ],
+    });
+
+    const result = await SubscriptionService.hasEffect("Uabc", "auto_daily_gacha");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when active subscription card does NOT include the effect", async () => {
+    SubscribeUser.all.mockResolvedValue([{ subscribe_card_key: "month" }]);
+    SubscribeCard.first.mockResolvedValue({
+      effects: [{ type: "gacha_times", value: 1 }],
+    });
+
+    const result = await SubscriptionService.hasEffect("Uabc", "auto_daily_gacha");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when user has no active subscription", async () => {
+    SubscribeUser.all.mockResolvedValue([]);
+
+    const result = await SubscriptionService.hasEffect("Uabc", "auto_daily_gacha");
+    expect(result).toBe(false);
+    expect(SubscribeCard.first).not.toHaveBeenCalled();
+  });
+
+  it("returns false (and does not throw) when card.effects is malformed JSON string", async () => {
+    SubscribeUser.all.mockResolvedValue([{ subscribe_card_key: "month" }]);
+    SubscribeCard.first.mockResolvedValue({ effects: "{{{not-json" });
+
+    const result = await SubscriptionService.hasEffect("Uabc", "auto_daily_gacha");
+    expect(result).toBe(false);
+  });
+
+  it("parses JSON-string effects and detects matching type", async () => {
+    SubscribeUser.all.mockResolvedValue([{ subscribe_card_key: "season" }]);
+    SubscribeCard.first.mockResolvedValue({
+      effects: JSON.stringify([{ type: "auto_janken_fate", value: 1 }]),
+    });
+
+    const result = await SubscriptionService.hasEffect("Uabc", "auto_janken_fate");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when required args are missing", async () => {
+    expect(await SubscriptionService.hasEffect("", "auto_daily_gacha")).toBe(false);
+    expect(await SubscriptionService.hasEffect("Uabc", "")).toBe(false);
+    expect(SubscribeUser.all).not.toHaveBeenCalled();
+  });
+
+  it("scans all active subscriptions when the first card does not have the effect", async () => {
+    SubscribeUser.all.mockResolvedValue([
+      { subscribe_card_key: "month" },
+      { subscribe_card_key: "season" },
+    ]);
+    SubscribeCard.first
+      .mockResolvedValueOnce({ effects: [{ type: "gacha_times", value: 1 }] })
+      .mockResolvedValueOnce({ effects: [{ type: "auto_daily_gacha", value: 1 }] });
+
+    const result = await SubscriptionService.hasEffect("Uabc", "auto_daily_gacha");
+    expect(result).toBe(true);
+    expect(SubscribeCard.first).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/bin/AutoGacha.js
+++ b/app/bin/AutoGacha.js
@@ -1,0 +1,189 @@
+const moment = require("moment");
+const config = require("config");
+const mysql = require("../src/util/mysql");
+const { DefaultLogger } = require("../src/util/Logger");
+const GachaService = require("../src/service/GachaService");
+const SubscriptionService = require("../src/service/SubscriptionService");
+
+let running = false;
+
+async function main() {
+  if (running) return;
+  running = true;
+  try {
+    await run();
+  } catch (err) {
+    DefaultLogger.error(`[AutoGacha] top-level error: ${err.message}`);
+  }
+  running = false;
+}
+
+async function run() {
+  const enabled = config.has("autoGacha.enabled") && config.get("autoGacha.enabled");
+  if (!enabled) {
+    DefaultLogger.info("[AutoGacha] disabled via config.autoGacha.enabled=false");
+    return;
+  }
+
+  const concurrency = config.get("autoGacha.concurrency") || 8;
+  const runDate = moment().format("YYYY-MM-DD");
+  const start = Date.now();
+
+  const targets = await impl.loadTargets();
+  DefaultLogger.info(`cron.auto_gacha.start target_count=${targets.length}`);
+
+  const counters = { success: 0, failed: 0, skipped: 0 };
+  await impl.runBatched(targets, concurrency, t => impl.drawForUser(t, runDate, counters));
+
+  const durationMs = Date.now() - start;
+  DefaultLogger.info(
+    `cron.auto_gacha.complete duration_ms=${durationMs} ` +
+      `target_count=${targets.length} success=${counters.success} ` +
+      `failed=${counters.failed} skipped=${counters.skipped}`
+  );
+}
+
+/**
+ * 找出今晚代抽的目標使用者：有效訂閱 + 卡包含 auto_daily_gacha effect +
+ * user_auto_preference.auto_daily_gacha=1 + 今日尚未抽過。
+ */
+async function loadTargets() {
+  const now = new Date();
+  const startOfDay = moment().startOf("day").toDate();
+  const endOfDay = moment().endOf("day").toDate();
+
+  const rows = await mysql("subscribe_user as su")
+    .innerJoin("subscribe_card as sc", "su.subscribe_card_key", "sc.key")
+    .innerJoin("user_auto_preference as uap", "uap.user_id", "su.user_id")
+    .leftJoin("gacha_record as gr", function () {
+      this.on("gr.user_id", "=", "su.user_id")
+        .andOn("gr.created_at", ">=", mysql.raw("?", [startOfDay]))
+        .andOn("gr.created_at", "<=", mysql.raw("?", [endOfDay]));
+    })
+    .where("su.start_at", "<=", now)
+    .where("su.end_at", ">", now)
+    .where("uap.auto_daily_gacha", 1)
+    .whereNull("gr.id")
+    .whereRaw("JSON_SEARCH(sc.effects, 'one', 'auto_daily_gacha', NULL, '$[*].type') IS NOT NULL")
+    .select("su.user_id", "sc.key as card_key")
+    .distinct();
+
+  return rows;
+}
+
+async function drawForUser(target, runDate, counters) {
+  const userId = target.user_id;
+  const perStart = Date.now();
+
+  try {
+    // Explicit re-check: subscription may have expired between loadTargets and now
+    const stillActive = await SubscriptionService.hasEffect(userId, "auto_daily_gacha");
+    if (!stillActive) {
+      counters.skipped++;
+      return upsertLog(userId, runDate, {
+        status: "skipped",
+        pulls_made: 0,
+        error: "subscription_expired_between_load_and_draw",
+        duration_ms: Date.now() - perStart,
+      });
+    }
+
+    // Source-of-truth re-check: did they already pull today?
+    const pulled = await mysql("gacha_record")
+      .where("user_id", userId)
+      .where("created_at", ">=", moment().startOf("day").toDate())
+      .where("created_at", "<=", moment().endOf("day").toDate())
+      .first();
+    if (pulled) {
+      counters.skipped++;
+      return upsertLog(userId, runDate, {
+        status: "skipped",
+        pulls_made: 0,
+        error: "already_pulled",
+        duration_ms: Date.now() - perStart,
+      });
+    }
+
+    const result = await GachaService.runDailyDraw(userId);
+    counters.success++;
+    return upsertLog(userId, runDate, {
+      status: "success",
+      pulls_made: (result.rewards || []).length,
+      reward_summary: summarizeRewards(result),
+      error: null,
+      duration_ms: Date.now() - perStart,
+    });
+  } catch (err) {
+    counters.failed++;
+    const errMsg = (err && err.message ? err.message : String(err)).slice(0, 255);
+    DefaultLogger.error(`[AutoGacha] draw failed for ${userId}: ${errMsg}`);
+    return upsertLog(userId, runDate, {
+      status: "failed",
+      pulls_made: 0,
+      error: errMsg,
+      duration_ms: Date.now() - perStart,
+    });
+  }
+}
+
+function summarizeRewards(result) {
+  return {
+    rareCount: result.rareCount || {},
+    newCharactersCount: (result.newCharacters || []).length,
+    godStoneCost: result.godStoneCost || 0,
+    repeatReward: result.repeatReward || 0,
+  };
+}
+
+async function upsertLog(userId, runDate, fields) {
+  const row = {
+    user_id: userId,
+    run_date: runDate,
+    status: fields.status,
+    pulls_made: fields.pulls_made || 0,
+    error: fields.error || null,
+    duration_ms: fields.duration_ms || null,
+    reward_summary: fields.reward_summary ? JSON.stringify(fields.reward_summary) : null,
+  };
+  await mysql.raw(
+    `INSERT INTO auto_gacha_job_log
+      (user_id, run_date, status, pulls_made, error, duration_ms, reward_summary)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       status = VALUES(status),
+       pulls_made = VALUES(pulls_made),
+       error = VALUES(error),
+       duration_ms = VALUES(duration_ms),
+       reward_summary = VALUES(reward_summary)`,
+    [
+      row.user_id,
+      row.run_date,
+      row.status,
+      row.pulls_made,
+      row.error,
+      row.duration_ms,
+      row.reward_summary,
+    ]
+  );
+}
+
+async function runBatched(items, limit, worker) {
+  for (let i = 0; i < items.length; i += limit) {
+    const chunk = items.slice(i, i + limit);
+    await Promise.allSettled(chunk.map(worker));
+  }
+}
+
+const impl = { loadTargets, drawForUser, runBatched };
+
+module.exports = main;
+module.exports.impl = impl;
+module.exports.loadTargets = loadTargets;
+module.exports.drawForUser = drawForUser;
+module.exports.runBatched = runBatched;
+module.exports.summarizeRewards = summarizeRewards;
+module.exports.upsertLog = upsertLog;
+
+if (require.main === module) {
+  main().then(() => process.exit(0));
+}

--- a/app/bin/AutoGacha.js
+++ b/app/bin/AutoGacha.js
@@ -82,13 +82,11 @@ async function drawForUser(target, runDate, counters) {
       });
     }
 
-    // Source-of-truth re-check: did they already pull today?
-    const pulled = await mysql("gacha_record")
-      .where("user_id", userId)
-      .where("created_at", ">=", moment().startOf("day").toDate())
-      .where("created_at", "<=", moment().endOf("day").toDate())
-      .first();
-    if (pulled) {
+    // Quota gate: subscribers get base + gacha_times bonus pulls per day. Cron
+    // must deliver the full remaining quota so we don't short-change month/season
+    // card holders compared to the manual `/抽` path.
+    const quota = await GachaService.getRemainingDailyQuota(userId);
+    if (quota.remaining === 0) {
       counters.skipped++;
       return upsertLog(userId, runDate, {
         status: "skipped",
@@ -98,12 +96,16 @@ async function drawForUser(target, runDate, counters) {
       });
     }
 
-    const result = await GachaService.runDailyDraw(userId);
+    const aggregated = emptyAggregate();
+    for (let i = 0; i < quota.remaining; i++) {
+      const result = await GachaService.runDailyDraw(userId);
+      accumulate(aggregated, result);
+    }
     counters.success++;
     return upsertLog(userId, runDate, {
       status: "success",
-      pulls_made: (result.rewards || []).length,
-      reward_summary: summarizeRewards(result),
+      pulls_made: aggregated.rewards.length,
+      reward_summary: summarizeAggregate(aggregated, quota),
       error: null,
       duration_ms: Date.now() - perStart,
     });
@@ -120,13 +122,44 @@ async function drawForUser(target, runDate, counters) {
   }
 }
 
-function summarizeRewards(result) {
+function emptyAggregate() {
   return {
-    rareCount: result.rareCount || {},
-    newCharactersCount: (result.newCharacters || []).length,
-    godStoneCost: result.godStoneCost || 0,
-    repeatReward: result.repeatReward || 0,
+    rewards: [],
+    rareCount: {},
+    newCharactersCount: 0,
+    godStoneCost: 0,
+    repeatReward: 0,
   };
+}
+
+function accumulate(agg, result) {
+  agg.rewards.push(...(result.rewards || []));
+  agg.newCharactersCount += (result.newCharacters || []).length;
+  agg.godStoneCost += result.godStoneCost || 0;
+  agg.repeatReward += result.repeatReward || 0;
+  if (result.rareCount) {
+    for (const star of Object.keys(result.rareCount)) {
+      const n = Number(result.rareCount[star] || 0);
+      if (n) agg.rareCount[star] = (agg.rareCount[star] || 0) + n;
+    }
+  }
+}
+
+function summarizeAggregate(agg, quota) {
+  return {
+    rareCount: agg.rareCount,
+    newCharactersCount: agg.newCharactersCount,
+    godStoneCost: agg.godStoneCost,
+    repeatReward: agg.repeatReward,
+    rounds: quota.remaining,
+    quota_total: quota.total,
+  };
+}
+
+function summarizeRewards(result) {
+  const agg = emptyAggregate();
+  accumulate(agg, result);
+  return summarizeAggregate(agg, { total: 1, remaining: 1 });
 }
 
 async function upsertLog(userId, runDate, fields) {

--- a/app/bin/AutoGacha.js
+++ b/app/bin/AutoGacha.js
@@ -19,12 +19,6 @@ async function main() {
 }
 
 async function run() {
-  const enabled = config.has("autoGacha.enabled") && config.get("autoGacha.enabled");
-  if (!enabled) {
-    DefaultLogger.info("[AutoGacha] disabled via config.autoGacha.enabled=false");
-    return;
-  }
-
   const concurrency = config.get("autoGacha.concurrency") || 8;
   const runDate = moment().format("YYYY-MM-DD");
   const start = Date.now();

--- a/app/bin/BackfillUserAutoPreference.js
+++ b/app/bin/BackfillUserAutoPreference.js
@@ -1,0 +1,76 @@
+if (process.env.NODE_ENV !== "production") {
+  require("dotenv").config({
+    path: require("path").resolve(__dirname, "../../.env"),
+  });
+}
+
+const moment = require("moment");
+const UserAutoPreference = require("../src/model/application/UserAutoPreference");
+const SubscribeUser = require("../src/model/application/SubscribeUser");
+const SubscribeCard = require("../src/model/application/SubscribeCard");
+const { CustomLogger } = require("../src/util/Logger");
+
+const BATCH_SIZE = 500;
+
+async function main() {
+  const startedAt = Date.now();
+  let totalProcessed = 0;
+  let totalErrors = 0;
+
+  const now = moment();
+
+  const userRows = await SubscribeUser.knex
+    .whereIn("subscribe_card_key", [SubscribeCard.key.month, SubscribeCard.key.season])
+    .andWhere("end_at", ">=", now.toDate())
+    .distinct("user_id");
+
+  const userIds = userRows.map(r => r.user_id).filter(Boolean);
+  const total = userIds.length;
+
+  CustomLogger.info(`[BackfillUserAutoPreference] Target: ${total} active subscribers`);
+
+  const batches = [];
+  for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+    batches.push(userIds.slice(i, i + BATCH_SIZE));
+  }
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    const rows = batch.map(userId => ({ user_id: userId, auto_daily_gacha: 1 }));
+    try {
+      await UserAutoPreference.connection(UserAutoPreference.table)
+        .insert(rows)
+        .onConflict("user_id")
+        .merge(["auto_daily_gacha"]);
+      totalProcessed += batch.length;
+      CustomLogger.info(
+        `[BackfillUserAutoPreference] Batch ${i + 1}/${batches.length}: inserted/updated ${batch.length} rows (total ${totalProcessed}/${total})`
+      );
+    } catch (err) {
+      totalErrors += batch.length;
+      CustomLogger.error(
+        `[BackfillUserAutoPreference] Batch ${i + 1}/${batches.length} FAILED: ${err.message}`
+      );
+    }
+  }
+
+  const durationMs = Date.now() - startedAt;
+  CustomLogger.info(
+    `[BackfillUserAutoPreference] Done. totalProcessed=${totalProcessed} totalErrors=${totalErrors} duration=${durationMs}ms`
+  );
+
+  return { totalProcessed, totalErrors, durationMs };
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main()
+    .then(({ totalErrors }) => process.exit(totalErrors > 0 ? 1 : 0))
+    .catch(err => {
+      CustomLogger.error(`[BackfillUserAutoPreference] Fatal error: ${err.message}`);
+
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/app/config/crontab.config.js
+++ b/app/config/crontab.config.js
@@ -90,4 +90,11 @@ module.exports = [
     immediate: true,
     require_path: "./bin/RaceAdvance",
   },
+  {
+    name: "Auto Gacha",
+    description: "nightly auto daily-draw for subscribers with auto_daily_gacha opt-in",
+    period: require("config").get("autoGacha.schedule"),
+    immediate: false,
+    require_path: "./bin/AutoGacha",
+  },
 ];

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -197,12 +197,8 @@
     "rainbow_repeat_reward": 50
   },
   "autoGacha": {
-    "enabled": false,
     "schedule": ["0", "50", "23", "*", "*", "*"],
     "concurrency": 8
-  },
-  "autoJankenFate": {
-    "enabled": false
   },
   "subscribe": {
     "month_icon": "https://redive.estertion.win/icon/item/23001.webp",

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -196,6 +196,14 @@
     "gold_repeat_reward": 10,
     "rainbow_repeat_reward": 50
   },
+  "autoGacha": {
+    "enabled": false,
+    "schedule": ["0", "50", "23", "*", "*", "*"],
+    "concurrency": 8
+  },
+  "autoJankenFate": {
+    "enabled": false
+  },
   "subscribe": {
     "month_icon": "https://redive.estertion.win/icon/item/23001.webp",
     "season_icon": "https://redive.estertion.win/icon/item/24001.webp",

--- a/app/locales/zh_tw.json
+++ b/app/locales/zh_tw.json
@@ -182,9 +182,12 @@
       "coupon_exchange_success_continue": "已成功為您延期至 *{{ end_at }}*",
       "effects_row_positive": "+ {{ type }} +{{ value }}",
       "effects_row_negative": "- {{ type }} -{{ value }}",
+      "effects_row_feature": "✨ {{ type }}",
       "effects": {
         "gacha_times": "每日單抽次數",
-        "daily_ration": "每日寶石"
+        "daily_ration": "每日寶石",
+        "auto_daily_gacha": "每日自動抽卡",
+        "auto_janken_fate": "猜拳自動代打"
       },
       "not_enough_money": "女神石不足，無法購買月卡",
       "buy_month_card_success": "成功購買月卡，以下是您的月卡序號，請複製再發送此訊息",

--- a/app/migrations/20260418072955_create_user_auto_preference.js
+++ b/app/migrations/20260418072955_create_user_auto_preference.js
@@ -1,0 +1,35 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("user_auto_preference", function (table) {
+    table.string("user_id", 33).primary().comment("LINE User ID");
+
+    table
+      .boolean("auto_daily_gacha")
+      .notNullable()
+      .defaultTo(false)
+      .comment("訂閱者每日 23:50 自動抽卡開關");
+    table
+      .boolean("auto_janken_fate")
+      .notNullable()
+      .defaultTo(false)
+      .comment("猜拳自動交給命運開關（非賭注場）");
+    table
+      .boolean("auto_janken_fate_with_bet")
+      .notNullable()
+      .defaultTo(false)
+      .comment("賭注場猜拳是否也自動交給命運（獨立開關）");
+
+    table.timestamps(true, true);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("user_auto_preference");
+};

--- a/app/migrations/20260418073004_create_auto_gacha_job_log.js
+++ b/app/migrations/20260418073004_create_auto_gacha_job_log.js
@@ -1,0 +1,31 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("auto_gacha_job_log", function (table) {
+    table.bigIncrements("id").primary();
+
+    table.string("user_id", 33).notNullable().comment("LINE User ID");
+    table.date("run_date").notNullable().comment("本次 cron 執行的日期（local tz）");
+    table.integer("pulls_made").notNullable().defaultTo(0).comment("實際代抽的次數");
+    table
+      .enum("status", ["success", "failed", "skipped"])
+      .notNullable()
+      .comment("success=完成抽卡, failed=例外, skipped=已達上限或偏好關閉");
+    table.text("error").nullable().comment("失敗原因（僅 status=failed 時）");
+
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.unique(["user_id", "run_date"], "uq_user_run");
+    table.index(["run_date"], "idx_run_date");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("auto_gacha_job_log");
+};

--- a/app/migrations/20260418073004_create_gacha_record_detail.js
+++ b/app/migrations/20260418073004_create_gacha_record_detail.js
@@ -1,0 +1,32 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("gacha_record_detail", function (table) {
+    table.bigIncrements("id").primary();
+
+    table.integer("gacha_record_id").unsigned().notNullable().comment("對應 gacha_record.id");
+    table.string("user_id", 33).notNullable().comment("LINE User ID（冗餘，避免查詢時多次 join）");
+    table.integer("character_id").notNullable().comment("對應 GachaPool.id（角色或女神石 999）");
+    table.tinyint("star").notNullable().comment("1=銀, 2=金, 3=彩");
+    table
+      .boolean("is_new")
+      .notNullable()
+      .defaultTo(false)
+      .comment("本次抽卡對此使用者是否為首次獲得");
+
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["user_id", "created_at"], "idx_user_created");
+    table.foreign("gacha_record_id").references("gacha_record.id").onDelete("CASCADE");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("gacha_record_detail");
+};

--- a/app/migrations/20260418090334_seed_subscribe_card_auto_effects.js
+++ b/app/migrations/20260418090334_seed_subscribe_card_auto_effects.js
@@ -1,0 +1,63 @@
+const NEW_EFFECT_TYPES = ["auto_daily_gacha", "auto_janken_fate"];
+const TARGET_CARD_KEYS = ["month", "season"];
+
+function normalizeEffects(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      return [];
+    }
+  }
+  return [];
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  for (const key of TARGET_CARD_KEYS) {
+    const card = await knex("subscribe_card").where({ key }).first();
+    if (!card) continue;
+
+    const effects = normalizeEffects(card.effects);
+    const existingTypes = new Set(effects.map(e => e && e.type).filter(Boolean));
+    let changed = false;
+
+    for (const type of NEW_EFFECT_TYPES) {
+      if (!existingTypes.has(type)) {
+        effects.push({ type, value: 1 });
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await knex("subscribe_card")
+        .where({ key })
+        .update({ effects: JSON.stringify(effects) });
+    }
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  for (const key of TARGET_CARD_KEYS) {
+    const card = await knex("subscribe_card").where({ key }).first();
+    if (!card) continue;
+
+    const effects = normalizeEffects(card.effects);
+    const filtered = effects.filter(e => !(e && NEW_EFFECT_TYPES.includes(e.type)));
+
+    if (filtered.length !== effects.length) {
+      await knex("subscribe_card")
+        .where({ key })
+        .update({ effects: JSON.stringify(filtered) });
+    }
+  }
+};

--- a/app/migrations/20260418090418_add_reward_summary_and_duration_to_auto_gacha_job_log.js
+++ b/app/migrations/20260418090418_add_reward_summary_and_duration_to_auto_gacha_job_log.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("auto_gacha_job_log", function (table) {
+    table.json("reward_summary").nullable().after("pulls_made").comment("抽到的獎勵摘要");
+    table.integer("duration_ms").nullable().after("error").comment("代抽耗時 ms");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("auto_gacha_job_log", function (table) {
+    table.dropColumn("reward_summary");
+    table.dropColumn("duration_ms");
+  });
+};

--- a/app/migrations/20260418091252_create_janken_auto_fate_log.js
+++ b/app/migrations/20260418091252_create_janken_auto_fate_log.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("janken_auto_fate_log", function (table) {
+    table.bigIncrements("id").primary();
+    table.string("match_id", 64).notNullable().comment("JankenService uuid match id");
+    table.string("user_id", 33).notNullable().comment("LINE User ID");
+    table.enum("role", ["p1", "p2"]).notNullable();
+    table.enum("choice", ["rock", "paper", "scissors"]).notNullable();
+    table.timestamp("submitted_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["match_id"], "idx_match");
+    table.index(["user_id", "submitted_at"], "idx_user_submitted");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("janken_auto_fate_log");
+};

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -1,6 +1,7 @@
 const { router, text, route } = require("bottender/router");
 const { chain, withProps } = require("bottender");
 const gacha = require("./controller/princess/gacha");
+const AutoPreferenceController = require("./controller/application/AutoPreferenceController");
 const battle = require("./controller/princess/battle");
 const customerOrder = require("./controller/application/CustomerOrder");
 const guildConfig = require("./controller/application/GroupConfig");
@@ -182,6 +183,7 @@ async function OrderBased(context, { next }) {
       withProps(gacha.play, { ...props, ensure: true })
     ),
     text(["#我的包包", "/mybag"], gacha.showGachaBag),
+    text(/^[/#.]自動設定$/, AutoPreferenceController.showAutoSettings),
     text("/state", showState),
     text(/^.show/, showMention),
     text("/source", context => context.replyText(JSON.stringify(context.event.source))),

--- a/app/src/controller/application/AutoPreferenceController.js
+++ b/app/src/controller/application/AutoPreferenceController.js
@@ -5,7 +5,14 @@ const SubscriptionService = require("../../service/SubscriptionService");
 const commonTemplate = require("../../templates/common");
 const { DefaultLogger } = require("../../util/Logger");
 
-const VALID_FLAGS = ["auto_daily_gacha", "auto_janken_fate"];
+const VALID_FLAGS = ["auto_daily_gacha", "auto_janken_fate", "auto_janken_fate_with_bet"];
+// Each flag declares which subscription effect gates it. with_bet re-uses the
+// auto_janken_fate effect (it's a sub-option of the same feature).
+const FLAG_EFFECT = {
+  auto_daily_gacha: "auto_daily_gacha",
+  auto_janken_fate: "auto_janken_fate",
+  auto_janken_fate_with_bet: "auto_janken_fate",
+};
 const HISTORY_DEFAULT_LIMIT = 30;
 const HISTORY_MAX_LIMIT = 100;
 
@@ -17,6 +24,7 @@ async function loadEntitlements(userId) {
   return {
     auto_daily_gacha: autoDailyGacha,
     auto_janken_fate: autoJankenFate,
+    auto_janken_fate_with_bet: autoJankenFate,
   };
 }
 
@@ -25,6 +33,7 @@ async function loadPreference(userId) {
   return {
     auto_daily_gacha: row && row.auto_daily_gacha === 1 ? 1 : 0,
     auto_janken_fate: row && row.auto_janken_fate === 1 ? 1 : 0,
+    auto_janken_fate_with_bet: row && row.auto_janken_fate_with_bet === 1 ? 1 : 0,
   };
 }
 
@@ -66,24 +75,27 @@ exports.api.setPreference = async (req, res) => {
 
     const entitlements = await loadEntitlements(userId);
     for (const flag of Object.keys(update)) {
-      if (update[flag] === 1 && !entitlements[flag]) {
+      if (update[flag] === 1 && !entitlements[FLAG_EFFECT[flag]]) {
         return res.status(403).json({ error: "entitlement_missing", field: flag });
       }
     }
 
     await mysql.raw(
       `INSERT INTO user_auto_preference
-        (user_id, auto_daily_gacha, auto_janken_fate)
-       VALUES (?, ?, ?)
+        (user_id, auto_daily_gacha, auto_janken_fate, auto_janken_fate_with_bet)
+       VALUES (?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          auto_daily_gacha = COALESCE(?, auto_daily_gacha),
-         auto_janken_fate = COALESCE(?, auto_janken_fate)`,
+         auto_janken_fate = COALESCE(?, auto_janken_fate),
+         auto_janken_fate_with_bet = COALESCE(?, auto_janken_fate_with_bet)`,
       [
         userId,
         update.auto_daily_gacha === undefined ? 0 : update.auto_daily_gacha,
         update.auto_janken_fate === undefined ? 0 : update.auto_janken_fate,
+        update.auto_janken_fate_with_bet === undefined ? 0 : update.auto_janken_fate_with_bet,
         update.auto_daily_gacha === undefined ? null : update.auto_daily_gacha,
         update.auto_janken_fate === undefined ? null : update.auto_janken_fate,
+        update.auto_janken_fate_with_bet === undefined ? null : update.auto_janken_fate_with_bet,
       ]
     );
 

--- a/app/src/controller/application/AutoPreferenceController.js
+++ b/app/src/controller/application/AutoPreferenceController.js
@@ -1,0 +1,201 @@
+const { get } = require("lodash");
+const mysql = require("../../util/mysql");
+const UserAutoPreference = require("../../model/application/UserAutoPreference");
+const SubscriptionService = require("../../service/SubscriptionService");
+const commonTemplate = require("../../templates/common");
+const { DefaultLogger } = require("../../util/Logger");
+
+const VALID_FLAGS = ["auto_daily_gacha", "auto_janken_fate"];
+const HISTORY_DEFAULT_LIMIT = 30;
+const HISTORY_MAX_LIMIT = 100;
+
+async function loadEntitlements(userId) {
+  const [autoDailyGacha, autoJankenFate] = await Promise.all([
+    SubscriptionService.hasEffect(userId, "auto_daily_gacha"),
+    SubscriptionService.hasEffect(userId, "auto_janken_fate"),
+  ]);
+  return {
+    auto_daily_gacha: autoDailyGacha,
+    auto_janken_fate: autoJankenFate,
+  };
+}
+
+async function loadPreference(userId) {
+  const row = await UserAutoPreference.first({ filter: { user_id: userId } });
+  return {
+    auto_daily_gacha: row && row.auto_daily_gacha === 1 ? 1 : 0,
+    auto_janken_fate: row && row.auto_janken_fate === 1 ? 1 : 0,
+  };
+}
+
+exports.api = {};
+
+exports.api.getPreference = async (req, res) => {
+  try {
+    const userId = get(req, "profile.userId");
+    if (!userId) return res.status(401).json({ error: "unauthenticated" });
+
+    const [preference, entitlements] = await Promise.all([
+      loadPreference(userId),
+      loadEntitlements(userId),
+    ]);
+    return res.json({ ...preference, entitlements });
+  } catch (err) {
+    DefaultLogger.error(`auto-preference.get failed: ${err && err.message}`);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};
+
+exports.api.setPreference = async (req, res) => {
+  try {
+    const userId = get(req, "profile.userId");
+    if (!userId) return res.status(401).json({ error: "unauthenticated" });
+
+    const body = req.body || {};
+    const update = {};
+    for (const flag of VALID_FLAGS) {
+      if (body[flag] === undefined || body[flag] === null) continue;
+      const v = body[flag] === true || body[flag] === 1 || body[flag] === "1" ? 1 : 0;
+      update[flag] = v;
+    }
+    if (Object.keys(update).length === 0) {
+      const preference = await loadPreference(userId);
+      const entitlements = await loadEntitlements(userId);
+      return res.json({ ...preference, entitlements });
+    }
+
+    const entitlements = await loadEntitlements(userId);
+    for (const flag of Object.keys(update)) {
+      if (update[flag] === 1 && !entitlements[flag]) {
+        return res.status(403).json({ error: "entitlement_missing", field: flag });
+      }
+    }
+
+    await mysql.raw(
+      `INSERT INTO user_auto_preference
+        (user_id, auto_daily_gacha, auto_janken_fate)
+       VALUES (?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         auto_daily_gacha = COALESCE(?, auto_daily_gacha),
+         auto_janken_fate = COALESCE(?, auto_janken_fate)`,
+      [
+        userId,
+        update.auto_daily_gacha === undefined ? 0 : update.auto_daily_gacha,
+        update.auto_janken_fate === undefined ? 0 : update.auto_janken_fate,
+        update.auto_daily_gacha === undefined ? null : update.auto_daily_gacha,
+        update.auto_janken_fate === undefined ? null : update.auto_janken_fate,
+      ]
+    );
+
+    const preference = await loadPreference(userId);
+    return res.json({ ...preference, entitlements });
+  } catch (err) {
+    DefaultLogger.error(`auto-preference.put failed: ${err && err.message}`);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};
+
+exports.api.getHistory = async (req, res) => {
+  try {
+    const userId = get(req, "profile.userId");
+    if (!userId) return res.status(401).json({ error: "unauthenticated" });
+
+    const type = String(req.query.type || "all").toLowerCase();
+    const rawLimit = parseInt(req.query.limit, 10);
+    const limit = Math.min(
+      Math.max(isNaN(rawLimit) ? HISTORY_DEFAULT_LIMIT : rawLimit, 1),
+      HISTORY_MAX_LIMIT
+    );
+
+    const rows = [];
+
+    if (type === "all" || type === "gacha") {
+      const gachaRows = await mysql("auto_gacha_job_log")
+        .where({ user_id: userId })
+        .orderBy("created_at", "desc")
+        .limit(limit)
+        .select(
+          "run_date",
+          "status",
+          "pulls_made",
+          "reward_summary",
+          "error",
+          "duration_ms",
+          "created_at"
+        );
+      for (const r of gachaRows) {
+        rows.push({
+          type: "gacha",
+          occurred_at: r.created_at,
+          status: r.status,
+          summary: {
+            run_date: r.run_date,
+            pulls_made: r.pulls_made,
+            reward_summary: parseJsonSafe(r.reward_summary),
+            error: r.error,
+            duration_ms: r.duration_ms,
+          },
+        });
+      }
+    }
+
+    if (type === "all" || type === "janken") {
+      const jankenRows = await mysql("janken_auto_fate_log")
+        .where({ user_id: userId })
+        .orderBy("submitted_at", "desc")
+        .limit(limit)
+        .select("match_id", "role", "choice", "submitted_at");
+      for (const r of jankenRows) {
+        rows.push({
+          type: "janken",
+          occurred_at: r.submitted_at,
+          status: "submitted",
+          summary: {
+            match_id: r.match_id,
+            role: r.role,
+            choice: r.choice,
+          },
+        });
+      }
+    }
+
+    rows.sort((a, b) => {
+      const ta = new Date(a.occurred_at).getTime();
+      const tb = new Date(b.occurred_at).getTime();
+      return tb - ta;
+    });
+
+    return res.json({ items: rows.slice(0, limit), limit, type });
+  } catch (err) {
+    DefaultLogger.error(`auto-history.get failed: ${err && err.message}`);
+    return res.status(500).json({ error: "internal_error" });
+  }
+};
+
+function parseJsonSafe(raw) {
+  if (!raw) return null;
+  if (typeof raw === "object") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    void e;
+    return null;
+  }
+}
+
+/**
+ * LINE command handler: /#/.自動設定
+ * Replies a Flex button bubble that opens the LIFF AutoSettings page.
+ */
+exports.showAutoSettings = async function (context) {
+  const uri = commonTemplate.getLiffUri("tall", "/AutoSettings");
+  const bubble = commonTemplate.genLinkBubble("自動設定", uri, "blue");
+  await context.replyFlex("自動設定", bubble);
+};
+
+// Internal exports for testing
+exports._internal = {
+  loadEntitlements,
+  loadPreference,
+  parseJsonSafe,
+};

--- a/app/src/controller/application/AutoPreferenceController.js
+++ b/app/src/controller/application/AutoPreferenceController.js
@@ -200,7 +200,7 @@ function parseJsonSafe(raw) {
  * Replies a Flex button bubble that opens the LIFF AutoSettings page.
  */
 exports.showAutoSettings = async function (context) {
-  const uri = commonTemplate.getLiffUri("tall", "/AutoSettings");
+  const uri = commonTemplate.getLiffUri("tall", "/auto/settings");
   const bubble = commonTemplate.genLinkBubble("自動設定", uri, "blue");
   await context.replyFlex("自動設定", bubble);
 };

--- a/app/src/controller/application/ChatLevelController.js
+++ b/app/src/controller/application/ChatLevelController.js
@@ -17,6 +17,7 @@ const DonateModel = require("../../model/application/DonateList");
 const UserTitleModel = require("../../model/application/UserTitle");
 const SubscribeUserModel = require("../../model/application/SubscribeUser");
 const SubscribeCardModel = require("../../model/application/SubscribeCard");
+const SubscriptionService = require("../../service/SubscriptionService");
 const { get, sample, set } = require("lodash");
 
 function formatTitle(title) {
@@ -109,13 +110,7 @@ exports.showStatus = async (context, props) => {
       monthBubble = SubscribeTemplate.generateStatus({
         title: i18n.__("message.subscribe.month"),
         effects: monthCard.effects.map(effect =>
-          SubscribeTemplate.generateEffect(
-            i18n.__("message.subscribe.effects_row_positive", {
-              type: i18n.__(`message.subscribe.effects.${effect.type}`),
-              value: effect.value,
-            }),
-            "blue"
-          )
+          SubscribeTemplate.generateEffect(SubscriptionService.formatEffectRow(effect), "blue")
         ),
         expiredAt: moment(monthCard.end_at).format("YYYY-MM-DD"),
         theme: "blue",
@@ -128,13 +123,7 @@ exports.showStatus = async (context, props) => {
       seasonBubble = SubscribeTemplate.generateStatus({
         title: i18n.__("message.subscribe.season"),
         effects: seasonCard.effects.map(effect =>
-          SubscribeTemplate.generateEffect(
-            i18n.__("message.subscribe.effects_row_positive", {
-              type: i18n.__(`message.subscribe.effects.${effect.type}`),
-              value: effect.value,
-            }),
-            "red"
-          )
+          SubscribeTemplate.generateEffect(SubscriptionService.formatEffectRow(effect), "red")
         ),
         expiredAt: moment(seasonCard.end_at).format("YYYY-MM-DD"),
         theme: "red",

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -157,10 +157,13 @@ async function duel(context) {
 
   // Subscriber auto-fate (v1 scope: p2/challenged player only). The initiator explicitly
   // typed the duel command, so we don't auto-play for them. p2 is the AFK case.
+  // Bet matches require auto_janken_fate_with_bet + successful escrow (handled inside
+  // autoFateIfEligible) to prevent fund leaks.
   try {
     await JankenService.autoFateIfEligible(targetUserId, matchId, "p2", {
       p1UserId: userId,
       p2UserId: targetUserId,
+      betAmount,
     });
   } catch (err) {
     DefaultLogger.error(`[Janken] auto-fate error: ${err && err.message}`);

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -155,6 +155,17 @@ async function duel(context) {
     baseUrl,
   });
 
+  // Subscriber auto-fate (v1 scope: p2/challenged player only). The initiator explicitly
+  // typed the duel command, so we don't auto-play for them. p2 is the AFK case.
+  try {
+    await JankenService.autoFateIfEligible(targetUserId, matchId, "p2", {
+      p1UserId: userId,
+      p2UserId: targetUserId,
+    });
+  } catch (err) {
+    DefaultLogger.error(`[Janken] auto-fate error: ${err && err.message}`);
+  }
+
   await context.replyText(
     i18n.__("message.duel.start", {
       displayName,

--- a/app/src/controller/application/SubscribeController.js
+++ b/app/src/controller/application/SubscribeController.js
@@ -13,6 +13,7 @@ const config = require("config");
 const { generateCard, generateEffect } = require("../../templates/application/Subscribe");
 const AchievementEngine = require("../../service/AchievementEngine");
 const { notifyUnlocks } = require("../../service/achievementNotifier");
+const SubscriptionService = require("../../service/SubscriptionService");
 
 exports.router = [
   text(/^[.#/](訂閱|sub)$/, showInformation),
@@ -108,12 +109,7 @@ async function showInformation(context) {
   const cards = await SubscribeCard.all();
   const bubbles = cards.map(card => {
     const effects = get(card, "effects", []).map(effect =>
-      generateEffect(
-        i18n.__("message.subscribe.effects_row_positive", {
-          type: i18n.__(`message.subscribe.effects.${effect.type}`),
-          value: effect.value,
-        })
-      )
+      generateEffect(SubscriptionService.formatEffectRow(effect))
     );
 
     return generateCard({
@@ -244,14 +240,7 @@ async function subscribeCouponExchange(context, props) {
   );
 
   const effects = get(card, "effects", []);
-  effects.forEach(effect =>
-    messages.push(
-      i18n.__("message.subscribe.effects_row_positive", {
-        type: i18n.__(`message.subscribe.effects.${effect.type}`),
-        value: effect.value,
-      })
-    )
-  );
+  effects.forEach(effect => messages.push(SubscriptionService.formatEffectRow(effect)));
 
   await context.replyText(messages.join("\n"));
   !isContinue && (await DailyRation());

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -1,7 +1,6 @@
 const GachaModel = require("../../model/princess/gacha");
 const InventoryModel = require("../../model/application/Inventory");
 const { inventory } = InventoryModel;
-const random = require("math-random");
 const GachaTemplate = require("../../templates/princess/gacha");
 const allowParameter = ["name", "headimage_url", "star", "rate", "is_princess", "tag"];
 const redis = require("../../util/redis");
@@ -9,9 +8,7 @@ const { DefaultLogger, CustomLogger } = require("../../util/Logger");
 const { getClient } = require("bottender");
 const lineClient = getClient("line");
 const moment = require("moment");
-const EventCenterService = require("../../service/EventCenterService");
-const signModel = require("../../model/application/SigninDays");
-const { isNull, get, countBy, shuffle, uniqBy, difference, sum, uniq, pullAt } = require("lodash");
+const { isNull, get, countBy, shuffle } = require("lodash");
 const GachaRecord = require("../../model/princess/GachaRecord");
 const GachaBanner = require("../../model/princess/GachaBanner");
 const SubscribeUser = require("../../model/application/SubscribeUser");
@@ -19,8 +16,9 @@ const SubscribeCard = require("../../model/application/SubscribeCard");
 const config = require("config");
 const i18n = require("../../util/i18n");
 const commonTemplate = require("../../templates/common");
-const AchievementEngine = require("../../service/AchievementEngine");
 const { notifyUnlocks } = require("../../service/achievementNotifier");
+const GachaService = require("../../service/GachaService");
+const { play, filterPool } = require("../../service/gachaDrawUtil");
 
 function GachaException(message, code) {
   this.message = message;
@@ -29,91 +27,6 @@ function GachaException(message, code) {
 }
 
 GachaException.prototype = new Error();
-
-function getTotalRate(gachaPool) {
-  let result = gachaPool
-    .map(data => parseFloat(data.rate.replace("%", "")) || 0)
-    .reduce((pre, curr) => pre + curr, 0);
-  return [Math.round(result * 10000), 10000];
-}
-
-/**
- * 進行亂數產生
- * @param {Number} times
- * @returns {Array}
- */
-function genRandom(max, min, times = 1) {
-  let result = [];
-  for (let i = 0; i < times; i++) {
-    result.push(Math.round(random() * (max - min) + min));
-  }
-
-  return result;
-}
-
-/**
- * 進行轉蛋
- * @param {Array} gachaPool 轉蛋池
- */
-function play(gachaPool, times = 1) {
-  const [max, rate] = getTotalRate(gachaPool);
-  // 產出亂數陣列，用該數字，取得轉蛋池中相對應位置之獎勵
-  const randomAry = genRandom(max, 1, times).sort((a, b) => a - b);
-
-  let stack = 0; // 數字堆疊
-  let anchor = 0; // 處理到的亂數陣列錨點
-  const rewards = []; // 轉出獎勵陣列
-
-  gachaPool.forEach(data => {
-    if (anchor >= randomAry.length) return;
-    let top = Math.floor(parseFloat(data.rate.replace(/[^\d.]+/, "") * rate));
-
-    // 介於轉蛋池中的 堆疊數 和 頂點 的亂數 即為抽出內容物
-    while (
-      randomAry[anchor] >= stack &&
-      randomAry[anchor] <= stack + top &&
-      anchor < randomAry.length
-    ) {
-      rewards.push({ ...data });
-      anchor++; // 處理下一錨點
-    }
-
-    stack += top; // 數字往上堆疊
-  });
-
-  return rewards;
-}
-
-function getRainbowCharater(gachaPool) {
-  return gachaPool.filter(data => data.star == 3);
-}
-
-/**
- * 篩選出符合標籤之轉蛋池
- * @param {Array} gachaPool
- * @param {String} tag
- */
-function filterPool(gachaPool, tag) {
-  if (tag === undefined) return gachaPool.filter(data => data.isPrincess === "1");
-
-  let isPrincess = true;
-  let resultPool = gachaPool.filter(data => {
-    let tags = (data.tag || "").split(",");
-    if (tags.indexOf(tag) !== -1) {
-      isPrincess = data.isPrincess === "0" ? false : true;
-      return true;
-    }
-  });
-
-  // 非公主池子，直接回傳
-  if (isPrincess === false) return resultPool;
-
-  // 無符合標籤，回傳滿池，不過將非公主角色排除
-  if (resultPool.length === 0) return gachaPool.filter(data => data.isPrincess === "1");
-
-  // 有篩選出特定標籤，將1,2星角色補滿池子
-  return resultPool.concat(gachaPool.filter(data => data.star < 3 && data.isPrincess === "1"));
-}
 
 /**
  * 針對群組單一用戶進行冷卻時間設定
@@ -149,32 +62,6 @@ async function userCooldown(userId) {
 }
 
 /**
- * 對符合條件的角色套用機率加成
- * @param {Array} pool 轉蛋池
- * @param {Function} shouldBoost 判斷是否加成的 predicate
- * @param {Number} boost 加成百分比，如 150 → (100+150)/100 = 2.5 倍
- * @returns {Array}
- */
-function boostRate(pool, shouldBoost, boost) {
-  return pool.map(data => {
-    if (!shouldBoost(data)) return data;
-    return {
-      ...data,
-      rate: `${(parseFloat(data.rate) * (100 + boost)) / 100}%`,
-    };
-  });
-}
-
-function makePickup(pool, rate = 100) {
-  return boostRate(pool, data => data.star === "3", rate);
-}
-
-function applyBannerRateUp(pool, characterIds, rateBoost) {
-  const idSet = new Set(characterIds);
-  return boostRate(pool, data => idSet.has(data.id), rateBoost);
-}
-
-/**
  * 檢視自己的轉蛋包包
  * @param {import("bottender").LineContext} context
  */
@@ -197,10 +84,10 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
   let { tag, times = 10 } = match.groups;
   const { userId, type, groupId } = context.event.source;
 
-  // 一次查詢所有進行中的 banner（避免多次 DB round-trip）
+  // Europe banner pre-check — service will re-fetch internally, but controller
+  // needs the cost for the stone-balance gate and the early-return text.
   const allActiveBanners = await GachaBanner.getActiveBannersWithCharacters();
   const europeBanners = allActiveBanners.filter(b => b.type === "europe");
-  const rateUpBanners = allActiveBanners.filter(b => b.type === "rate_up");
 
   let activeEuropeBanner = null;
   if (europe) {
@@ -276,166 +163,11 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     return context.replyText(i18n.__("message.gacha.not_enough_stone"));
   }
 
-  const queries = [];
-  const dailyResult = {
-    rewards: [],
-    godStoneCost: 0,
-    ownCharactersCount: 0,
-    newCharacters: [],
-    repeatReward: 0,
-  };
-  const dailyPool = (() => {
-    let pool = filteredPool;
-
-    for (const banner of rateUpBanners) {
-      if (banner.characterIds.length > 0) {
-        pool = applyBannerRateUp(pool, banner.characterIds, banner.rate_boost);
-      }
-    }
-
-    if (pickup) {
-      return makePickup(pool, 200);
-    } else if (ensure) {
-      return pool;
-    } else if (europe) {
-      return pool.filter(data => data.star == "3");
-    }
-    return pool;
-  })();
-
-  // 進行特殊費用扣除
-  if (pickup || ensure || europe) {
-    let cost = 0;
-    let note = "";
-    if (pickup) {
-      cost = pickupCost;
-      note = i18n.__("message.gacha.pick_up_cost_note");
-    } else if (ensure) {
-      cost = ensureCost;
-      note = i18n.__("message.gacha.ensure_cost_note");
-    } else if (europe) {
-      cost = europeCost;
-      note = i18n.__("message.gacha.europe_cost_note");
-    }
-
-    queries.push(
-      inventory.knex.insert({
-        userId,
-        itemId: 999,
-        itemAmount: -1 * cost,
-        note,
-      })
-    );
-    dailyResult.godStoneCost = cost;
-  }
-
-  let rareCount;
-  do {
-    const rewards = shuffle(play(dailyPool, times));
-
-    if (ensure) {
-      DefaultLogger.info(`${userId} 使用了保證抽，扣除3000顆女神石，並且將最後一抽強制轉彩！`);
-      const rainbowPool = getRainbowCharater(dailyPool);
-      // remove last element of rewards
-      rewards.pop();
-      // add rainbow character
-      rewards.push(...play(rainbowPool, 1));
-    }
-
-    rareCount = countBy(rewards, "star");
-    dailyResult.rewards = rewards;
-  } while (rareCount[1] === 10);
-
-  // 每日一抽成功，紀錄轉蛋資訊
-  const message = [];
-  const uniqRewards = uniqBy(dailyResult.rewards, "id");
-  const rawRewardIds = dailyResult.rewards.map(reward => reward.id);
-  const rewardIds = uniq(rawRewardIds);
-  const ownItems = await inventory.knex
-    .where({ userId })
-    .select("itemId")
-    .andWhereNot("itemId", 999)
-    .orderBy("itemId", "asc");
-  const ownItemIds = ownItems.map(item => item.itemId);
-
-  dailyResult.ownCharactersCount = ownItemIds.length;
-  // 檢查是否有重複獲得的角色
-  const duplicateItems = [...rawRewardIds];
-  // 檢查是否有尚未獲得的角色
-  const newItemIds = difference(rewardIds, ownItemIds);
-  pullAt(
-    duplicateItems,
-    newItemIds.map(id => duplicateItems.indexOf(id))
-  );
-
-  dailyResult.repeatReward = sum(
-    duplicateItems.map(id => {
-      const targetReward = uniqRewards.find(reward => reward.id === id);
-
-      switch (parseInt(targetReward.star)) {
-        case 1:
-          message.push(`${targetReward.name} 1星 +1`);
-          return config.get("gacha.silver_repeat_reward");
-        case 2:
-          message.push(`${targetReward.name} 2星 +10`);
-          return config.get("gacha.gold_repeat_reward");
-        case 3:
-          message.push(`${targetReward.name} 3星 +50`);
-          return config.get("gacha.rainbow_repeat_reward");
-        default:
-          return 0;
-      }
-    })
-  );
-  dailyResult.newCharacters = uniqRewards.filter(reward => newItemIds.includes(reward.id));
-
-  // 紀錄每日一抽獲得的角色
-  if (dailyResult.newCharacters.length > 0) {
-    queries.push(
-      inventory.knex.insert(
-        dailyResult.newCharacters.map(character => ({
-          userId,
-          itemId: character.id,
-          itemAmount: 1,
-          attributes: JSON.stringify([
-            {
-              key: "star",
-              value: parseInt(character.star),
-            },
-          ]),
-          note: i18n.__("message.gacha.new_character_note"),
-        }))
-      )
-    );
-  }
-
-  // 紀錄每日一抽獲得的女神石
-  if (dailyResult.repeatReward > 0) {
-    queries.push(
-      inventory.knex.insert({
-        userId,
-        itemId: 999,
-        itemAmount: dailyResult.repeatReward,
-        note: i18n.__("message.gacha.repeat_reward_note"),
-      })
-    );
-  }
-
-  // 寫入所有紀錄
-  const trx = await inventory.transaction();
+  let result;
   try {
-    await Promise.all(queries.map(query => query.transacting(trx)));
-    GachaRecord.setTransaction(trx);
-    await GachaRecord.create({
-      user_id: userId,
-      silver: rareCount[1],
-      gold: rareCount[2],
-      rainbow: rareCount[3],
-      has_new: dailyResult.newCharacters.length > 0 ? 1 : 0,
-    });
-    await trx.commit();
+    result = await GachaService.runDailyDraw(userId, { tag, pickup, ensure, europe });
   } catch (err) {
-    await trx.rollback();
+    DefaultLogger.warn(`[gacha] runDailyDraw failed for ${userId}: ${err.message}`);
     console.log(err);
     return context.replyText(
       i18n.__("message.error_contact_admin", {
@@ -445,18 +177,12 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     );
   }
 
-  await Promise.all([
-    handleSignin(userId),
-    EventCenterService.add(EventCenterService.getEventName("daily_quest"), { userId }),
-  ]);
-
   const bubbles = [];
-  // 發送每日一抽結果
   bubbles.push(
     GachaTemplate.line.generateGachaResult({
-      rewards: dailyResult.rewards,
+      rewards: result.rewards,
       tag,
-      rareCount,
+      rareCount: result.rareCount,
       hasCooldown: type === "group",
     })
   );
@@ -465,21 +191,16 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
 
   bubbles.unshift(
     GachaTemplate.line.generateDailyGachaInfo({
-      newCharacters: dailyResult.newCharacters,
-      collectedCount: dailyResult.ownCharactersCount + dailyResult.newCharacters.length,
+      newCharacters: result.newCharacters,
+      collectedCount: result.ownCharactersCount + result.newCharacters.length,
       allCount: allCharactersCount,
       ownGodStone: userOwnStone,
-      costGodStone: dailyResult.godStoneCost,
-      gainGodStoneAmount: dailyResult.repeatReward,
+      costGodStone: result.godStoneCost,
+      gainGodStoneAmount: result.repeatReward,
     })
   );
 
-  const { unlocked } = await AchievementEngine.evaluate(userId, "gacha_pull", {
-    threeStarCount: rareCount[3] || 0,
-    uniqueCount: dailyResult.ownCharactersCount + dailyResult.newCharacters.length,
-    pullType: europe ? "europe" : ensure ? "ensure" : pickup ? "pickup" : undefined,
-  }).catch(() => ({ unlocked: [] }));
-  await notifyUnlocks(context, userId, unlocked);
+  await notifyUnlocks(context, userId, result.unlocks);
 
   return context.replyFlex("每日一抽結果", {
     type: "carousel",
@@ -718,27 +439,4 @@ async function showGodStoneRank(req, res) {
     DefaultLogger.warn(e);
     return res.status(400).json({ message: e.message });
   }
-}
-
-async function handleSignin(userId) {
-  const userData = await signModel.first({ filter: { user_id: userId } });
-  const now = moment();
-
-  if (!userData) {
-    return await signModel.create({ user_id: userId, last_signin_at: now.toDate() });
-  }
-
-  const latsSigninAt = moment(userData.last_signin_at);
-  const updateData = { last_signin_at: now.toDate() };
-
-  if (now.isSame(latsSigninAt, "day")) {
-    // 今天已簽到
-    return;
-  } else if (now.diff(latsSigninAt, "days") > 1) {
-    updateData.sum_days = 1;
-  } else {
-    updateData.sum_days = userData.sum_days + 1;
-  }
-
-  await signModel.update(userId, updateData, { pk: "user_id" });
 }

--- a/app/src/model/application/AutoGachaJobLog.js
+++ b/app/src/model/application/AutoGachaJobLog.js
@@ -4,5 +4,13 @@ class AutoGachaJobLog extends base {}
 
 module.exports = new AutoGachaJobLog({
   table: "auto_gacha_job_log",
-  fillable: ["user_id", "run_date", "pulls_made", "status", "error"],
+  fillable: [
+    "user_id",
+    "run_date",
+    "pulls_made",
+    "status",
+    "error",
+    "reward_summary",
+    "duration_ms",
+  ],
 });

--- a/app/src/model/application/AutoGachaJobLog.js
+++ b/app/src/model/application/AutoGachaJobLog.js
@@ -1,0 +1,8 @@
+const base = require("../base");
+
+class AutoGachaJobLog extends base {}
+
+module.exports = new AutoGachaJobLog({
+  table: "auto_gacha_job_log",
+  fillable: ["user_id", "run_date", "pulls_made", "status", "error"],
+});

--- a/app/src/model/application/JankenAutoFateLog.js
+++ b/app/src/model/application/JankenAutoFateLog.js
@@ -1,0 +1,8 @@
+const base = require("../base");
+
+class JankenAutoFateLog extends base {}
+
+module.exports = new JankenAutoFateLog({
+  table: "janken_auto_fate_log",
+  fillable: ["match_id", "user_id", "role", "choice"],
+});

--- a/app/src/model/application/UserAutoPreference.js
+++ b/app/src/model/application/UserAutoPreference.js
@@ -1,0 +1,8 @@
+const base = require("../base");
+
+class UserAutoPreference extends base {}
+
+module.exports = new UserAutoPreference({
+  table: "user_auto_preference",
+  fillable: ["user_id", "auto_daily_gacha", "auto_janken_fate", "auto_janken_fate_with_bet"],
+});

--- a/app/src/model/princess/GachaRecordDetail.js
+++ b/app/src/model/princess/GachaRecordDetail.js
@@ -1,0 +1,8 @@
+const base = require("../base");
+
+class GachaRecordDetail extends base {}
+
+module.exports = new GachaRecordDetail({
+  table: "gacha_record_detail",
+  fillable: ["gacha_record_id", "user_id", "character_id", "star", "is_new"],
+});

--- a/app/src/router/api.js
+++ b/app/src/router/api.js
@@ -372,6 +372,14 @@ router.get("/achievements/user/:userId", AchievementController.api.getUserAchiev
 router.get("/achievements/stats", AchievementController.api.getStats);
 router.get("/titles/user/:userId", AchievementController.api.getUserTitles);
 
+/**
+ * 訂閱者自動行為偏好 / 歷史
+ */
+const AutoPreferenceController = require("../controller/application/AutoPreferenceController");
+router.get("/auto-preference", verifyToken, AutoPreferenceController.api.getPreference);
+router.put("/auto-preference", verifyToken, AutoPreferenceController.api.setPreference);
+router.get("/auto-history", verifyToken, AutoPreferenceController.api.getHistory);
+
 router.all("*", (_, res) => {
   res.status(404).json({ message: "invalid api url." });
 });

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -189,7 +189,7 @@ async function calculateProgress(userId, achievement, context) {
   const currentValue = progress ? progress.current_value : 0;
 
   const strategy = ACHIEVEMENT_STRATEGY[achievement.key];
-  const newValue = strategy ? strategy(currentValue, achievement, context) : currentValue;
+  const newValue = strategy ? await strategy(currentValue, achievement, context) : currentValue;
 
   return { currentValue, newValue };
 }

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -9,6 +9,8 @@ const GachaRecord = require("../model/princess/GachaRecord");
 const GachaRecordDetail = require("../model/princess/GachaRecordDetail");
 const GachaBanner = require("../model/princess/GachaBanner");
 const signModel = require("../model/application/SigninDays");
+const SubscribeUser = require("../model/application/SubscribeUser");
+const SubscribeCard = require("../model/application/SubscribeCard");
 
 const EventCenterService = require("./EventCenterService");
 const AchievementEngine = require("./AchievementEngine");
@@ -262,6 +264,47 @@ async function runDailyDraw(userId, opts = {}) {
   };
 }
 
+/**
+ * 回傳使用者今日的每日抽卡配額狀態。邏輯對齊 controller 內的 detectCanDaily：
+ * 基礎額度 = config.gacha.daily_limit，每張有效訂閱卡額外加上其 gacha_times effect。
+ * @param {string} userId
+ * @returns {Promise<{total:number, used:number, remaining:number}>}
+ */
+async function getRemainingDailyQuota(userId) {
+  const base = config.get("gacha.daily_limit");
+  const now = moment();
+
+  const subs = await SubscribeUser.all({ filter: { user_id: userId } }).join(
+    SubscribeCard.table,
+    SubscribeCard.getColumnName("key"),
+    SubscribeUser.getColumnName("subscribe_card_key")
+  );
+  const activeSubs = subs.filter(
+    s => moment(s.start_at).isSameOrBefore(now) && moment(s.end_at).isAfter(now)
+  );
+
+  const bonus = activeSubs.reduce((acc, sub) => {
+    const effects = Array.isArray(sub.effects)
+      ? sub.effects
+      : typeof sub.effects === "string"
+        ? JSON.parse(sub.effects || "[]")
+        : [];
+    const eff = effects.find(e => e && e.type === "gacha_times");
+    return acc + (eff && eff.value ? eff.value : 0);
+  }, 0);
+  const total = base + bonus;
+
+  const countRow = await GachaRecord.knex
+    .where({ user_id: userId })
+    .whereBetween("created_at", [now.startOf("day").toDate(), now.endOf("day").toDate()])
+    .count({ count: "*" })
+    .first();
+  const used = Number((countRow && countRow.count) || 0);
+
+  return { total, used, remaining: Math.max(0, total - used) };
+}
+
 module.exports = {
   runDailyDraw,
+  getRemainingDailyQuota,
 };

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -1,0 +1,262 @@
+const moment = require("moment");
+const config = require("config");
+const { countBy, shuffle, uniqBy, difference, sum, uniq, pullAt } = require("lodash");
+
+const GachaModel = require("../model/princess/gacha");
+const InventoryModel = require("../model/application/Inventory");
+const { inventory } = InventoryModel;
+const GachaRecord = require("../model/princess/GachaRecord");
+const GachaRecordDetail = require("../model/princess/GachaRecordDetail");
+const GachaBanner = require("../model/princess/GachaBanner");
+const signModel = require("../model/application/SigninDays");
+
+const EventCenterService = require("./EventCenterService");
+const AchievementEngine = require("./AchievementEngine");
+const {
+  play,
+  filterPool,
+  getRainbowCharater,
+  makePickup,
+  applyBannerRateUp,
+} = require("./gachaDrawUtil");
+const i18n = require("../util/i18n");
+const { DefaultLogger } = require("../util/Logger");
+
+async function handleSignin(userId) {
+  const userData = await signModel.first({ filter: { user_id: userId } });
+  const now = moment();
+
+  if (!userData) {
+    return await signModel.create({ user_id: userId, last_signin_at: now.toDate() });
+  }
+
+  const latsSigninAt = moment(userData.last_signin_at);
+  const updateData = { last_signin_at: now.toDate() };
+
+  if (now.isSame(latsSigninAt, "day")) {
+    return;
+  } else if (now.diff(latsSigninAt, "days") > 1) {
+    updateData.sum_days = 1;
+  } else {
+    updateData.sum_days = userData.sum_days + 1;
+  }
+
+  await signModel.update(userId, updateData, { pk: "user_id" });
+}
+
+function resolveCost(pickup, ensure, europe, activeEuropeBanner) {
+  if (pickup) {
+    return {
+      amount: config.get("gacha.pick_up_cost"),
+      note: i18n.__("message.gacha.pick_up_cost_note"),
+    };
+  }
+  if (ensure) {
+    return {
+      amount: config.get("gacha.ensure_cost"),
+      note: i18n.__("message.gacha.ensure_cost_note"),
+    };
+  }
+  if (europe) {
+    const amount =
+      activeEuropeBanner && activeEuropeBanner.cost > 0
+        ? activeEuropeBanner.cost
+        : config.get("gacha.europe_cost");
+    return { amount, note: i18n.__("message.gacha.europe_cost_note") };
+  }
+  return { amount: 0, note: "" };
+}
+
+function buildDailyPool(filteredPool, rateUpBanners, { pickup, ensure, europe }) {
+  let pool = filteredPool;
+  for (const banner of rateUpBanners) {
+    if (banner.characterIds.length > 0) {
+      pool = applyBannerRateUp(pool, banner.characterIds, banner.rate_boost);
+    }
+  }
+  if (pickup) return makePickup(pool, 200);
+  if (ensure) return pool;
+  if (europe) return pool.filter(data => data.star == "3");
+  return pool;
+}
+
+function drawRewards(dailyPool, times, { userId, ensure }) {
+  let rareCount;
+  let rewards;
+  do {
+    rewards = shuffle(play(dailyPool, times));
+    if (ensure) {
+      DefaultLogger.info(`${userId} 使用了保證抽，扣除3000顆女神石，並且將最後一抽強制轉彩！`);
+      const rainbowPool = getRainbowCharater(dailyPool);
+      rewards.pop();
+      rewards.push(...play(rainbowPool, 1));
+    }
+    rareCount = countBy(rewards, "star");
+  } while (rareCount[1] === 10);
+  return { rewards, rareCount };
+}
+
+function computeRepeatReward(uniqRewards, duplicateItems) {
+  return sum(
+    duplicateItems.map(id => {
+      const target = uniqRewards.find(r => r.id === id);
+      switch (parseInt(target.star)) {
+        case 1:
+          return config.get("gacha.silver_repeat_reward");
+        case 2:
+          return config.get("gacha.gold_repeat_reward");
+        case 3:
+          return config.get("gacha.rainbow_repeat_reward");
+        default:
+          return 0;
+      }
+    })
+  );
+}
+
+/**
+ * 執行每日一抽的完整流水線（資料層，不涉及任何 Bottender context / reply 動作）。
+ * Caller（controller 或 cron）負責：pre-flight（detectCanDaily、cooldown、訂閱效果）、
+ * 成功後的回覆 flex 訊息、以及 notifyUnlocks。Service 只回傳原始資料 + unlocks。
+ *
+ * @param {string} userId LINE User ID
+ * @param {Object} [opts]
+ * @param {string} [opts.tag]       轉蛋池標籤（undefined 即為預設公主池）
+ * @param {boolean} [opts.pickup]   祈願（花費女神石提升彩率）
+ * @param {boolean} [opts.ensure]   保證（最後一抽必彩）
+ * @param {boolean} [opts.europe]   歐派（只彩池）
+ * @returns {Promise<{
+ *   rewards: Array,
+ *   rareCount: Object,
+ *   newCharacters: Array,
+ *   ownCharactersCount: number,
+ *   repeatReward: number,
+ *   godStoneCost: number,
+ *   unlocks: Array
+ * }>}
+ */
+async function runDailyDraw(userId, opts = {}) {
+  const { tag, pickup = false, ensure = false, europe = false } = opts;
+  const times = 10;
+
+  const allActiveBanners = await GachaBanner.getActiveBannersWithCharacters();
+  const rateUpBanners = allActiveBanners.filter(b => b.type === "rate_up");
+  const europeBanners = allActiveBanners.filter(b => b.type === "europe");
+  const activeEuropeBanner = europe && europeBanners.length > 0 ? europeBanners[0] : null;
+
+  const gachaPool = await GachaModel.getDatabasePool();
+  const filteredPool = filterPool(gachaPool, tag);
+  const dailyPool = buildDailyPool(filteredPool, rateUpBanners, { pickup, ensure, europe });
+
+  const cost = resolveCost(pickup, ensure, europe, activeEuropeBanner);
+
+  const { rewards, rareCount } = drawRewards(dailyPool, times, { userId, ensure });
+
+  const uniqRewards = uniqBy(rewards, "id");
+  const rawRewardIds = rewards.map(r => r.id);
+  const rewardIds = uniq(rawRewardIds);
+
+  const ownItems = await inventory.knex
+    .where({ userId })
+    .select("itemId")
+    .andWhereNot("itemId", 999)
+    .orderBy("itemId", "asc");
+  const ownItemIds = ownItems.map(item => item.itemId);
+  const ownCharactersCount = ownItemIds.length;
+
+  const duplicateItems = [...rawRewardIds];
+  const newItemIds = difference(rewardIds, ownItemIds);
+  pullAt(
+    duplicateItems,
+    newItemIds.map(id => duplicateItems.indexOf(id))
+  );
+
+  const repeatReward = computeRepeatReward(uniqRewards, duplicateItems);
+  const newCharacters = uniqRewards.filter(r => newItemIds.includes(r.id));
+
+  const trx = await inventory.transaction();
+  let gachaRecordId;
+  try {
+    if (cost.amount > 0) {
+      await trx(inventory.table).insert({
+        userId,
+        itemId: 999,
+        itemAmount: -1 * cost.amount,
+        note: cost.note,
+      });
+    }
+
+    if (newCharacters.length > 0) {
+      await trx(inventory.table).insert(
+        newCharacters.map(character => ({
+          userId,
+          itemId: character.id,
+          itemAmount: 1,
+          attributes: JSON.stringify([{ key: "star", value: parseInt(character.star) }]),
+          note: i18n.__("message.gacha.new_character_note"),
+        }))
+      );
+    }
+
+    if (repeatReward > 0) {
+      await trx(inventory.table).insert({
+        userId,
+        itemId: 999,
+        itemAmount: repeatReward,
+        note: i18n.__("message.gacha.repeat_reward_note"),
+      });
+    }
+
+    const [insertedId] = await trx(GachaRecord.table).insert({
+      user_id: userId,
+      silver: rareCount[1] || 0,
+      gold: rareCount[2] || 0,
+      rainbow: rareCount[3] || 0,
+      has_new: newCharacters.length > 0 ? 1 : 0,
+    });
+    gachaRecordId = insertedId;
+
+    if (rewards.length > 0 && gachaRecordId) {
+      const newIdSet = new Set(newCharacters.map(c => c.id));
+      await trx(GachaRecordDetail.table).insert(
+        rewards.map(r => ({
+          gacha_record_id: gachaRecordId,
+          user_id: userId,
+          character_id: r.id,
+          star: parseInt(r.star),
+          is_new: newIdSet.has(r.id) ? 1 : 0,
+        }))
+      );
+    }
+
+    await trx.commit();
+  } catch (err) {
+    await trx.rollback();
+    throw err;
+  }
+
+  await Promise.all([
+    handleSignin(userId),
+    EventCenterService.add(EventCenterService.getEventName("daily_quest"), { userId }),
+  ]);
+
+  const { unlocked } = await AchievementEngine.evaluate(userId, "gacha_pull", {
+    threeStarCount: rareCount[3] || 0,
+    uniqueCount: ownCharactersCount + newCharacters.length,
+    pullType: europe ? "europe" : ensure ? "ensure" : pickup ? "pickup" : undefined,
+  }).catch(() => ({ unlocked: [] }));
+
+  return {
+    rewards,
+    rareCount,
+    newCharacters,
+    ownCharactersCount,
+    repeatReward,
+    godStoneCost: cost.amount,
+    unlocks: unlocked || [],
+  };
+}
+
+module.exports = {
+  runDailyDraw,
+};

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -244,7 +244,12 @@ async function runDailyDraw(userId, opts = {}) {
     threeStarCount: rareCount[3] || 0,
     uniqueCount: ownCharactersCount + newCharacters.length,
     pullType: europe ? "europe" : ensure ? "ensure" : pickup ? "pickup" : undefined,
-  }).catch(() => ({ unlocked: [] }));
+  }).catch(err => {
+    DefaultLogger.warn(
+      `GachaService.runDailyDraw achievement.evaluate failed user=${userId}: ${err && err.message}`
+    );
+    return { unlocked: [] };
+  });
 
   return {
     rewards,

--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -2,8 +2,11 @@ const redis = require("../util/redis");
 const config = require("config");
 const JankenRecords = require("../model/application/JankenRecords");
 const JankenResult = require("../model/application/JankenResult");
+const JankenAutoFateLog = require("../model/application/JankenAutoFateLog");
+const UserAutoPreference = require("../model/application/UserAutoPreference");
 const { inventory } = require("../model/application/Inventory");
 const EventCenterService = require("./EventCenterService");
+const SubscriptionService = require("./SubscriptionService");
 const { DefaultLogger } = require("../util/Logger");
 const JankenRating = require("../model/application/JankenRating");
 
@@ -101,9 +104,7 @@ exports.updateStreaks = async function (
     const newMaxStreak = Math.max(newStreak, winnerRating.max_streak);
     // Bounty funded from match fee — no new money created
     const bountyIncrement =
-      newStreak >= 2 && betAmount >= BOUNTY_MIN_BET
-        ? exports.calculateBountyIncrement(fee)
-        : 0;
+      newStreak >= 2 && betAmount >= BOUNTY_MIN_BET ? exports.calculateBountyIncrement(fee) : 0;
     const maxBounty = JankenRating.getMaxBounty(winnerRating.rank_tier);
     const newBounty = Math.min(winnerRating.bounty + bountyIncrement, maxBounty);
     // Bounty claim capped by claimer's bet amount
@@ -136,6 +137,38 @@ exports.updateStreaks = async function (
       loserBounty,
     };
   });
+};
+
+/**
+ * 猜拳代選判斷：若使用者開啟 auto_janken_fate 且訂閱包含該 effect，
+ * 則用隨機出拳代為送出 submitChoice，並寫一筆 janken_auto_fate_log。
+ * 僅用於標準對戰（duel）流程；arena 不呼叫。
+ *
+ * @param {string} userId 要代打的使用者
+ * @param {string} matchId 對戰 uuid
+ * @param {"p1"|"p2"} role 該使用者在這場對戰的角色
+ * @param {Object} ctx
+ * @param {string} ctx.p1UserId
+ * @param {string} ctx.p2UserId
+ * @returns {Promise<{eligible:boolean, ready?:boolean, p1Choice?:string, p2Choice?:string, choice?:string}>}
+ */
+exports.autoFateIfEligible = async function (userId, matchId, role, { p1UserId, p2UserId } = {}) {
+  const enabled = config.has("autoJankenFate.enabled") && config.get("autoJankenFate.enabled");
+  if (!enabled) return { eligible: false };
+
+  const pref = await UserAutoPreference.first({ filter: { user_id: userId } });
+  if (!pref || pref.auto_janken_fate !== 1) return { eligible: false };
+
+  const entitled = await SubscriptionService.hasEffect(userId, "auto_janken_fate");
+  if (!entitled) return { eligible: false };
+
+  const choice = exports.randomChoice();
+  await JankenAutoFateLog.create({ match_id: matchId, user_id: userId, role, choice });
+  DefaultLogger.info(
+    `janken.auto_fate.submit match_id=${matchId} user_id=${userId} role=${role} choice=${choice}`
+  );
+  const result = await exports.submitChoice(matchId, userId, choice, { p1UserId, p2UserId });
+  return { eligible: true, choice, ...result };
 };
 
 exports.submitChoice = async function (matchId, userId, choice, { p1UserId, p2UserId } = {}) {
@@ -300,13 +333,25 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
 
     const p1Streak = p1Rating.streak || 0;
     const p2Streak = p2Rating.streak || 0;
-    const p1EloChange = exports.calculateEloChange(p1Rating.elo, p2Rating.elo, p1Result, betAmount, {
-      streak: p1Streak,
-    });
+    const p1EloChange = exports.calculateEloChange(
+      p1Rating.elo,
+      p2Rating.elo,
+      p1Result,
+      betAmount,
+      {
+        streak: p1Streak,
+      }
+    );
     const p2Result = p1Result === "win" ? "lose" : "win";
-    const p2EloChange = exports.calculateEloChange(p2Rating.elo, p1Rating.elo, p2Result, betAmount, {
-      streak: p2Streak,
-    });
+    const p2EloChange = exports.calculateEloChange(
+      p2Rating.elo,
+      p1Rating.elo,
+      p2Result,
+      betAmount,
+      {
+        streak: p2Streak,
+      }
+    );
 
     const p1NewElo = Math.max(0, p1Rating.elo + p1EloChange);
     const p2NewElo = Math.max(0, p2Rating.elo + p2EloChange);

--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -16,6 +16,7 @@ const FEE_RATE = config.get("minigame.janken.bet.feeRate");
 const MIN_BET = config.get("minigame.janken.bet.minAmount");
 const BOUNTY_MIN_BET = config.get("minigame.janken.streak.bountyMinBet");
 const BOUNTY_CLAIM_MULTIPLIER = config.get("minigame.janken.streak.bountyClaimMultiplier");
+const MATCH_WINDOW_SECONDS = 7 * 24 * 60 * 60;
 
 const RESULT_MAP = {
   rock: { rock: "draw", paper: "lose", scissors: "win" },
@@ -63,7 +64,7 @@ exports.escrowBet = async function (userId, amount) {
 
 exports.tryEscrowOnce = async function (matchId, userId, amount) {
   const escrowKey = `${REDIS_PREFIX}:escrow:${matchId}:${userId}`;
-  const locked = await redis.set(escrowKey, "1", { EX: 3600, NX: true });
+  const locked = await redis.set(escrowKey, "1", { EX: MATCH_WINDOW_SECONDS, NX: true });
   if (!locked) {
     return { alreadyEscrowed: true };
   }
@@ -163,9 +164,6 @@ exports.autoFateIfEligible = async function (
   role,
   { p1UserId, p2UserId, betAmount = 0 } = {}
 ) {
-  const enabled = config.has("autoJankenFate.enabled") && config.get("autoJankenFate.enabled");
-  if (!enabled) return { eligible: false, reason: "feature_disabled" };
-
   const pref = await UserAutoPreference.first({ filter: { user_id: userId } });
   if (!pref || pref.auto_janken_fate !== 1) return { eligible: false, reason: "opt_out" };
 
@@ -202,7 +200,7 @@ exports.submitChoice = async function (matchId, userId, choice, { p1UserId, p2Us
   }
 
   const key = `${REDIS_PREFIX}:${matchId}:${userId}`;
-  await redis.set(key, choice, { EX: 3600 });
+  await redis.set(key, choice, { EX: MATCH_WINDOW_SECONDS });
 
   DefaultLogger.info(`[Janken] ${userId} chose ${choice} for match ${matchId}`);
 

--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -144,28 +144,53 @@ exports.updateStreaks = async function (
  * 則用隨機出拳代為送出 submitChoice，並寫一筆 janken_auto_fate_log。
  * 僅用於標準對戰（duel）流程；arena 不呼叫。
  *
+ * 賭注場特別處理：只有當 pref.auto_janken_fate_with_bet === 1 且 tryEscrowOnce
+ * 成功把女神石押上時才代為出拳；否則拒絕 auto-fate（避免資金洩漏：被代打的人若
+ * 沒有押上賭金就進入 resolveMatch，payout 會視同雙方都押但只有 p1 的石頭被扣）。
+ *
  * @param {string} userId 要代打的使用者
  * @param {string} matchId 對戰 uuid
  * @param {"p1"|"p2"} role 該使用者在這場對戰的角色
  * @param {Object} ctx
  * @param {string} ctx.p1UserId
  * @param {string} ctx.p2UserId
- * @returns {Promise<{eligible:boolean, ready?:boolean, p1Choice?:string, p2Choice?:string, choice?:string}>}
+ * @param {number} [ctx.betAmount=0] 本場賭金；>0 時需要 with_bet 子偏好 + 成功 escrow
+ * @returns {Promise<{eligible:boolean, reason?:string, ready?:boolean, p1Choice?:string, p2Choice?:string, choice?:string}>}
  */
-exports.autoFateIfEligible = async function (userId, matchId, role, { p1UserId, p2UserId } = {}) {
+exports.autoFateIfEligible = async function (
+  userId,
+  matchId,
+  role,
+  { p1UserId, p2UserId, betAmount = 0 } = {}
+) {
   const enabled = config.has("autoJankenFate.enabled") && config.get("autoJankenFate.enabled");
-  if (!enabled) return { eligible: false };
+  if (!enabled) return { eligible: false, reason: "feature_disabled" };
 
   const pref = await UserAutoPreference.first({ filter: { user_id: userId } });
-  if (!pref || pref.auto_janken_fate !== 1) return { eligible: false };
+  if (!pref || pref.auto_janken_fate !== 1) return { eligible: false, reason: "opt_out" };
 
   const entitled = await SubscriptionService.hasEffect(userId, "auto_janken_fate");
-  if (!entitled) return { eligible: false };
+  if (!entitled) return { eligible: false, reason: "no_entitlement" };
+
+  if (betAmount > 0) {
+    if (pref.auto_janken_fate_with_bet !== 1) {
+      return { eligible: false, reason: "bet_auto_fate_not_opted_in" };
+    }
+    const escrow = await exports.tryEscrowOnce(matchId, userId, betAmount);
+    if (escrow.alreadyEscrowed) {
+      // Bet already posted by another path — safe to proceed with auto-fate.
+    } else if (!escrow.success) {
+      DefaultLogger.info(
+        `janken.auto_fate.skipped_insufficient_funds match_id=${matchId} user_id=${userId} bet=${betAmount}`
+      );
+      return { eligible: false, reason: "insufficient_funds_for_bet" };
+    }
+  }
 
   const choice = exports.randomChoice();
   await JankenAutoFateLog.create({ match_id: matchId, user_id: userId, role, choice });
   DefaultLogger.info(
-    `janken.auto_fate.submit match_id=${matchId} user_id=${userId} role=${role} choice=${choice}`
+    `janken.auto_fate.submit match_id=${matchId} user_id=${userId} role=${role} choice=${choice} bet=${betAmount}`
   );
   const result = await exports.submitChoice(matchId, userId, choice, { p1UserId, p2UserId });
   return { eligible: true, choice, ...result };

--- a/app/src/service/SubscriptionService.js
+++ b/app/src/service/SubscriptionService.js
@@ -1,0 +1,64 @@
+const SubscribeUser = require("../model/application/SubscribeUser");
+const SubscribeCard = require("../model/application/SubscribeCard");
+const { DefaultLogger } = require("../util/Logger");
+
+function parseEffects(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      DefaultLogger.warn("subscription.effects.parse_error", { error: e.message });
+      return [];
+    }
+  }
+  return [];
+}
+
+/**
+ * 判斷使用者目前的訂閱是否包含某個效果（effect type）。
+ * 訂閱效果儲存在 subscribe_card.effects 陣列，格式為 [{type, value}, ...]。
+ * 只要使用者有任一張目前有效（start_at <= now < end_at）的訂閱卡，
+ * 且該卡的 effects 陣列中存在 {type: effectType, value: truthy}，就回傳 true。
+ *
+ * @param {string} userId LINE User ID
+ * @param {string} effectType 例如 "auto_daily_gacha" / "auto_janken_fate" / "daily_ration"
+ * @returns {Promise<boolean>}
+ */
+async function hasEffect(userId, effectType) {
+  if (!userId || !effectType) return false;
+
+  const now = new Date();
+  const activeSubs = await SubscribeUser.all({
+    filter: {
+      user_id: userId,
+      start_at: { operator: "<=", value: now },
+      end_at: { operator: ">", value: now },
+    },
+    select: ["subscribe_card_key"],
+  });
+
+  if (!activeSubs || activeSubs.length === 0) return false;
+
+  const seenKeys = new Set();
+  for (const sub of activeSubs) {
+    const key = sub && sub.subscribe_card_key;
+    if (!key || seenKeys.has(key)) continue;
+    seenKeys.add(key);
+
+    const card = await SubscribeCard.first({
+      filter: { key },
+      select: ["effects"],
+    });
+    if (!card) continue;
+
+    const effects = parseEffects(card.effects);
+    if (effects.some(e => e && e.type === effectType && e.value)) return true;
+  }
+  return false;
+}
+
+module.exports = {
+  hasEffect,
+};

--- a/app/src/service/SubscriptionService.js
+++ b/app/src/service/SubscriptionService.js
@@ -1,6 +1,11 @@
+const i18n = require("../util/i18n");
 const SubscribeUser = require("../model/application/SubscribeUser");
 const SubscribeCard = require("../model/application/SubscribeCard");
 const { DefaultLogger } = require("../util/Logger");
+
+// Effect types that represent a feature unlock (binary perk) rather than a
+// numeric bonus. Rendered without a "+N" suffix since the value is always 1.
+const FEATURE_EFFECT_TYPES = new Set(["auto_daily_gacha", "auto_janken_fate"]);
 
 function parseEffects(raw) {
   if (Array.isArray(raw)) return raw;
@@ -59,6 +64,24 @@ async function hasEffect(userId, effectType) {
   return false;
 }
 
+/**
+ * Render a subscribe card effect as a single localized display row.
+ * Feature-unlock effects omit the numeric "+value" suffix.
+ * @param {{type: string, value: number|boolean}} effect
+ * @returns {string}
+ */
+function formatEffectRow(effect) {
+  const type = i18n.__(`message.subscribe.effects.${effect.type}`);
+  if (FEATURE_EFFECT_TYPES.has(effect.type)) {
+    return i18n.__("message.subscribe.effects_row_feature", { type });
+  }
+  return i18n.__("message.subscribe.effects_row_positive", {
+    type,
+    value: effect.value,
+  });
+}
+
 module.exports = {
   hasEffect,
+  formatEffectRow,
 };

--- a/app/src/service/gachaDrawUtil.js
+++ b/app/src/service/gachaDrawUtil.js
@@ -1,0 +1,91 @@
+const random = require("math-random");
+
+function getTotalRate(gachaPool) {
+  const result = gachaPool
+    .map(data => parseFloat(data.rate.replace("%", "")) || 0)
+    .reduce((pre, curr) => pre + curr, 0);
+  return [Math.round(result * 10000), 10000];
+}
+
+function genRandom(max, min, times = 1) {
+  const result = [];
+  for (let i = 0; i < times; i++) {
+    result.push(Math.round(random() * (max - min) + min));
+  }
+  return result;
+}
+
+function play(gachaPool, times = 1) {
+  const [max, rate] = getTotalRate(gachaPool);
+  const randomAry = genRandom(max, 1, times).sort((a, b) => a - b);
+
+  let stack = 0;
+  let anchor = 0;
+  const rewards = [];
+
+  gachaPool.forEach(data => {
+    if (anchor >= randomAry.length) return;
+    const top = Math.floor(parseFloat(data.rate.replace(/[^\d.]+/, "") * rate));
+
+    while (
+      randomAry[anchor] >= stack &&
+      randomAry[anchor] <= stack + top &&
+      anchor < randomAry.length
+    ) {
+      rewards.push({ ...data });
+      anchor++;
+    }
+
+    stack += top;
+  });
+
+  return rewards;
+}
+
+function getRainbowCharater(gachaPool) {
+  return gachaPool.filter(data => data.star == 3);
+}
+
+function filterPool(gachaPool, tag) {
+  if (tag === undefined) return gachaPool.filter(data => data.isPrincess === "1");
+
+  let isPrincess = true;
+  const resultPool = gachaPool.filter(data => {
+    const tags = (data.tag || "").split(",");
+    if (tags.indexOf(tag) !== -1) {
+      isPrincess = data.isPrincess === "0" ? false : true;
+      return true;
+    }
+  });
+
+  if (isPrincess === false) return resultPool;
+  if (resultPool.length === 0) return gachaPool.filter(data => data.isPrincess === "1");
+  return resultPool.concat(gachaPool.filter(data => data.star < 3 && data.isPrincess === "1"));
+}
+
+function boostRate(pool, shouldBoost, boost) {
+  return pool.map(data => {
+    if (!shouldBoost(data)) return data;
+    return {
+      ...data,
+      rate: `${(parseFloat(data.rate) * (100 + boost)) / 100}%`,
+    };
+  });
+}
+
+function makePickup(pool, rate = 100) {
+  return boostRate(pool, data => data.star === "3", rate);
+}
+
+function applyBannerRateUp(pool, characterIds, rateBoost) {
+  const idSet = new Set(characterIds);
+  return boostRate(pool, data => idSet.has(data.id), rateBoost);
+}
+
+module.exports = {
+  play,
+  filterPool,
+  getRainbowCharater,
+  makePickup,
+  applyBannerRateUp,
+};

--- a/docs/plans/2026-04-18-phase1-exploration.md
+++ b/docs/plans/2026-04-18-phase1-exploration.md
@@ -1,0 +1,168 @@
+# Phase 1 Exploration — Subscriber Auto-Actions
+
+**Date:** 2026-04-18
+**Branch:** `feat/subscriber-auto-actions`
+**Plan reference:** `.omc/plans/2026-04-18-subscriber-auto-actions.md`
+**Story:** US-001 (ralph Phase 1 PRD)
+
+This document captures the pre-implementation audit that unblocks Phase 1 execution (migrations, models, backfill). All assertions below were verified against the actual repo state on branch `feat/subscriber-auto-actions` at HEAD.
+
+---
+
+## (a) Verified file/line references
+
+### `app/src/controller/princess/gacha.js`
+
+| Reference | Plan says | Actual | Status |
+|---|---|---|---|
+| `gacha()` function start | 196 | 196 | ✓ |
+| `gacha()` function end | 488 | 488 | ✓ |
+| Transaction open (`inventory.transaction()`) | ~425 | 425 | ✓ |
+| Transaction commit | ~436 | 436 | ✓ |
+| Transaction rollback (error path) | ~438 | 438 | ✓ |
+| `context.replyText` error fallback | 440 | 440 | ✓ |
+| `handleSignin(userId)` | 449 | 449 | ✓ |
+| `EventCenterService.add("daily_quest", {userId})` | 450 | 450 | ✓ |
+| `AchievementEngine.evaluate(userId, "gacha_pull", ...)` | 477 | 477 | ✓ |
+| `notifyUnlocks(context, userId, unlocked)` | 482 | 482 | ✓ |
+| `context.replyFlex("每日一抽結果", ...)` | 484 | 484 | ✓ |
+| `detectCanDaily()` start | 495 | 495 | ✓ |
+| `detectCanDaily()` end | 556 | 556 | ✓ |
+| `purgeDailyGachaCache()` | 558+ | 558 | ✓ |
+| Redis negative-cache set (short EX:60) | ~530, ~549 | 530, 549 | ✓ |
+
+All line numbers in the plan match current HEAD. No drift since plan authoring.
+
+### `app/src/service/JankenService.js`
+
+| Reference | Plan says | Actual | Status |
+|---|---|---|---|
+| `randomChoice()` | 27-30 | 27-30 | ✓ |
+| `submitChoice()` | 141-165 | 141-165 | ✓ |
+| `resolveMatch()` | 167+ | 167-260 | ✓ |
+| `resolve:${matchId}` NX lock | 176-181 | 176-181 | ✓ |
+| `submitArenaChallenge()` | (not in plan) | 371-396 | noted |
+| `resolveArena()` | 398-414 | 398-414 | ✓ |
+
+### `app/knexfile.js`
+
+Pool config at line 17:
+```js
+pool: { min: 0, max: 10 }
+```
+Matches plan expectation. Concurrency cap of 8 (per plan §5 Phase 3) leaves 2 connections for HTTP / other cron overlap. No infra change needed.
+
+---
+
+## (b) Chart library decision
+
+**Decision:** Use **`recharts` ^3.8.1** (already present in `frontend/package.json:28`).
+
+- No fallback needed.
+- Recharts aligns with the existing frontend stack (React 19, MUI 7, Vite 8) and is the simplest option for line / bar charts in the LIFF gacha-history page (Phase 7).
+- Rationale: adding another chart lib would bloat the bundle; recharts is well-maintained and already carried.
+
+---
+
+## (c) Logger decision
+
+**Decision:** Use **`log4js` 6.9.1** (already present in `app/package.json:34`) via the existing wrapper at `app/src/util/Logger.js`.
+
+- Two pre-configured loggers are exported:
+  - `DefaultLogger` — category `default`, level `debug`
+  - `CustomLogger` — category `custom`, level `all`
+- Phase 3 cron (`AutoDailyGacha.js`) will import `CustomLogger` (consistent with `DailyRation.js` which uses `CustomLogger` for per-user success/error trace).
+- Log line for cron completion (per §10 Metrics): `CustomLogger.info("cron.auto_gacha.complete", { duration_ms, target_count, success, failed, skipped })`.
+- No new logger lib required.
+
+---
+
+## (d) Knex pool confirmation
+
+Confirmed at `app/knexfile.js:17`: `pool: { min: 0, max: 10 }`.
+
+- Concurrency cap **8** (planned in §5 Phase 3) fits within budget and reserves 2 connections for concurrent HTTP traffic + other nightly crons (`DailyRation`, `DailyCleanup`, `CleanExpiredSubscriber`, `DailyQuestProcess`).
+- If production measurement (deferred — see §g) shows contention above this baseline, raise to `max: 15` via coordinated knexfile + Docker compose env change.
+- No changes to `knexfile.js` required in Phase 1.
+
+---
+
+## (e) `subscribe_card.effects` JSON shape
+
+Confirmed by cross-referencing:
+- `app/src/controller/princess/gacha.js:538-542` — iterates `effects.find(effect => effect.type === "gacha_times")` and reads `.value` as a number.
+- `app/bin/DailyRation.js:41-49` — iterates `effects.find(item => item.type === "daily_ration")` and reads `.value`.
+
+**Shape:** `effects` is a JSON array of `{ type: string, value: number }` objects stored on the `subscribe_card` table (not on `subscribe_user`). Example inferred from usage:
+
+```json
+[
+  { "type": "gacha_times", "value": 2 },
+  { "type": "daily_ration", "value": 50 }
+]
+```
+
+**Access pattern (for Phase 3 target loader):** join `subscribe_user` with `subscribe_card` on `subscribe_user.subscribe_card_key = subscribe_card.key`. The `effects` column lives on `subscribe_card`. Existing `detectCanDaily` at `gacha.js:516-524` demonstrates this join.
+
+**Implication for Phase 3 cron:** target loader must JOIN against `subscribe_card` to obtain `effects`; do not duplicate the effects onto `subscribe_user`.
+
+---
+
+## (f) Arena `resolveArena` signature (v1 scope-out justification)
+
+Arena path uses a fundamentally different protocol from duel:
+
+```js
+// JankenService.js:371
+exports.submitArenaChallenge = async function (groupId, holderUserId, challengerUserId, choice)
+// Redis key: `${CHALLENGE_PREFIX}:${groupId}:${holderUserId}`
+// Payload:   JSON.stringify({ challengerUserId, choice })
+
+// JankenService.js:398
+exports.resolveArena = async function (groupId, holderUserId, holderChoice)
+// Returns: { challengerUserId, challengerChoice, holderChoice } | null
+```
+
+Differences from duel:
+
+| Axis | Duel (`resolveMatch`) | Arena (`resolveArena`) |
+|---|---|---|
+| Unique key | `matchId` (UUID per 1v1) | `(groupId, holderUserId)` — long-lived holder slot |
+| Role model | symmetric P1/P2 | asymmetric holder vs challenger |
+| Redis TTL | 3600s per player-side choice | 10 min per pending challenge |
+| Choice storage | one Redis key per player | single Redis key with JSON payload |
+| Bet flow | both escrow via `tryEscrowOnce` | arena uses different settlement (need further read if in-scope) |
+
+Both arena entry points (`submitArenaChallenge` at 371, `resolveArena` at 398) already handle `choice === "random"` natively (lines 372-374 and 399-401). Auto-fate for arena would require:
+
+- Detecting when a holder has a pending challenger (no matchId to hook off of).
+- Deciding WHOSE auto-fate triggers: holder only? challenger only? both?
+- Integrating with bet-lock semantics unique to arena.
+
+**v1 scope-out stands.** Tracked as follow-up F1 in plan §12.
+
+---
+
+## (g) Open items and discrepancies
+
+### Open items (not blockers for Phase 1)
+
+1. **DailyRation baseline (AC-17 in plan §3).** Requires production access (`docker exec redive_linebot-worker-1 …` on the remote host) to tail `app/log/error_log.log` for `DailyRation` start/end lines. Deferred to Phase 3 precondition; not needed for Phase 1 migrations/models/backfill.
+2. **Existing `effects` values in production `subscribe_card`.** Plan assumes `gacha_times` value ≥1 for month/season cards but this is not verified locally. Should be spot-checked before Phase 3 cron goes live; no impact on Phase 1 schema.
+3. **Whether any non-subscriber users have `user_auto_preference` rows accidentally created during testing.** N/A at Phase 1 — the table does not exist yet.
+
+### Discrepancies between plan and reality
+
+None. All line numbers, function signatures, and dependencies in `.omc/plans/2026-04-18-subscriber-auto-actions.md` v2.1 match HEAD of `feat/subscriber-auto-actions` branch.
+
+### Confirmed patterns to mimic
+
+- **Cron entry pattern (for Phase 3 `AutoDailyGacha.js`):** `app/bin/DailyRation.js` — exports `main` function, registers `if (require.main === module) { main().then(() => process.exit(0)); }` at tail. Uses `CustomLogger` for per-user traces.
+- **Subscription target loader pattern:** `SubscribeUser.getDailyRation({key, now})` at `app/src/model/application/SubscribeUser.js:12-29` — filters by `start_at <= now`, `end_at > now`, and excludes users already processed today via a NOT-IN subquery on `SubscribeJobLog`. Phase 3 loader will apply the same `end_at > now` check plus a NOT-IN on `auto_gacha_job_log(user_id, run_date=CURDATE())`.
+- **Migration style:** `app/migrations/20221026092347_create_gacha_record_table.js` (reference for `gacha_record_detail` FK pattern at `20260406120001_create_gacha_banner_characters.js:13`). Use `table.foreign().references().onDelete("CASCADE")` for FKs and `table.unique(["col1","col2"])` for composite uniques.
+- **Model pattern:** `app/src/model/princess/GachaRecord.js` — single-instance export extending `base` with `table` + `fillable`.
+- **Transaction pattern (for backfill script):** `app/bin/DailyRation.js:83-87` — `Model.connection.transaction(async trx => { ... })`.
+
+---
+
+_End of Phase 1 exploration._

--- a/docs/plans/2026-04-18-rollout-subscriber-auto-actions.md
+++ b/docs/plans/2026-04-18-rollout-subscriber-auto-actions.md
@@ -1,0 +1,68 @@
+# Subscriber Auto-Actions — Rollout Plan (Phase 8)
+
+Phases 1-7 landed on branch `feat/subscriber-auto-actions`. This doc records
+the staged rollout after merge.
+
+## Feature flags (config/default.json)
+
+| Key | Default | Flip to enable |
+|---|---|---|
+| `autoGacha.enabled` | `false` | production + staging |
+| `autoGacha.concurrency` | `8` | keep (≤ knex pool.max - 2) |
+| `autoGacha.schedule` | `["0","50","23","*","*","*"]` | keep unless collision |
+| `autoJankenFate.enabled` | `false` | production + staging |
+
+Override via NODE_CONFIG_DIR / custom-env / production.json as needed.
+
+## Seed data prerequisite
+
+After `yarn migrate` on prod DB, verify the seed migration ran:
+```sql
+SELECT key, JSON_EXTRACT(effects, '$[*].type') FROM subscribe_card WHERE key IN ('month','season');
+-- expect auto_daily_gacha + auto_janken_fate in both cards
+```
+
+## Observability log lines
+
+Structured lines to monitor (via DefaultLogger.info → worker logs):
+
+- `cron.auto_gacha.start target_count=N`
+- `cron.auto_gacha.complete duration_ms=X target_count=N success=S failed=F skipped=K`
+- `[AutoGacha] draw failed for <userId>: <error>`
+- `janken.auto_fate.submit match_id=<id> user_id=<id> role=p1|p2 choice=rock|paper|scissors`
+
+Alert thresholds (suggested):
+- `failed / target_count > 0.05` for 1 consecutive run
+- `duration_ms > 300000` (5 min hard cap from AC-17)
+
+## Staged rollout
+
+1. **Day 0 — Deploy with flags OFF.** Ship code, run migrations. Confirm
+   no cron rows get written (`SELECT COUNT(*) FROM auto_gacha_job_log
+   WHERE run_date = CURDATE()` should stay 0).
+2. **Day 1 — Internal canaries.** Manually set `auto_daily_gacha=1` on
+   3 internal test users with active subscriptions. Flip
+   `autoGacha.enabled=true` in a custom config. Watch logs for one
+   nightly cycle. Expect 3 success rows.
+3. **Day 2-7 — 10% cohort.** Pick 10% of active subscribers (by
+   `user_id % 10 == 0`) and pre-set their `auto_daily_gacha=1`. Monitor
+   failure rate and duration for one week.
+4. **Day 8 — Full rollout.** Flip `autoGacha.enabled=true` globally.
+   Monitor for 48h.
+5. **Repeat 1-4 for `autoJankenFate.enabled` independently.**
+
+## Rollback
+
+- Flip the corresponding `enabled` flag to `false` via config change +
+  worker restart. No code revert needed. Existing log rows preserved
+  for audit.
+
+## Out of scope follow-ups
+
+- Arena auto-fate (only standard matches supported in v1).
+- Push notification of auto-draw results (LINE Push API disabled per
+  project policy; users see results via /auto-history LIFF or next
+  manual interaction).
+- `recharts`-powered history charts (deferred; list view shipped).
+- Pre-fetching banners / shared draw-dispatch state for cron speedup
+  (Phase 3 follow-up from architect review).

--- a/docs/plans/2026-04-18-rollout-subscriber-auto-actions.md
+++ b/docs/plans/2026-04-18-rollout-subscriber-auto-actions.md
@@ -1,30 +1,36 @@
-# Subscriber Auto-Actions — Rollout Plan (Phase 8)
+# Subscriber Auto-Actions — Rollout Plan
 
 Phases 1-7 landed on branch `feat/subscriber-auto-actions`. This doc records
-the staged rollout after merge.
+the rollout after merge.
 
-## Feature flags (config/default.json)
+## Gating model
 
-| Key | Default | Flip to enable |
+Auto-actions are gated by a single layer: **per-user opt-in**
+(`user_auto_preference.auto_daily_gacha` / `auto_janken_fate` /
+`auto_janken_fate_with_bet`, all default `0`). Users must open the LIFF
+`/auto/settings` page and turn the toggle on themselves. The global feature
+flags from earlier drafts were removed — with opt-in default OFF there was
+no meaningful second gate.
+
+## Config (config/default.json)
+
+| Key | Default | Notes |
 |---|---|---|
-| `autoGacha.enabled` | `false` | production + staging |
-| `autoGacha.concurrency` | `8` | keep (≤ knex pool.max - 2) |
-| `autoGacha.schedule` | `["0","50","23","*","*","*"]` | keep unless collision |
-| `autoJankenFate.enabled` | `false` | production + staging |
-
-Override via NODE_CONFIG_DIR / custom-env / production.json as needed.
+| `autoGacha.concurrency` | `8` | Keep ≤ knex `pool.max - 2`. |
+| `autoGacha.schedule` | `["0","50","23","*","*","*"]` | 23:50 local. Adjust only if cron collision observed. |
 
 ## Seed data prerequisite
 
 After `yarn migrate` on prod DB, verify the seed migration ran:
 ```sql
-SELECT key, JSON_EXTRACT(effects, '$[*].type') FROM subscribe_card WHERE key IN ('month','season');
+SELECT `key`, JSON_EXTRACT(effects, '$[*].type')
+FROM subscribe_card WHERE `key` IN ('month','season');
 -- expect auto_daily_gacha + auto_janken_fate in both cards
 ```
 
-## Observability log lines
+## Observability
 
-Structured lines to monitor (via DefaultLogger.info → worker logs):
+Structured log lines (via `DefaultLogger.info` → worker logs):
 
 - `cron.auto_gacha.start target_count=N`
 - `cron.auto_gacha.complete duration_ms=X target_count=N success=S failed=F skipped=K`
@@ -35,33 +41,38 @@ Alert thresholds (suggested):
 - `failed / target_count > 0.05` for 1 consecutive run
 - `duration_ms > 300000` (5 min hard cap from AC-17)
 
-## Staged rollout
+## Go-live steps
 
-1. **Day 0 — Deploy with flags OFF.** Ship code, run migrations. Confirm
-   no cron rows get written (`SELECT COUNT(*) FROM auto_gacha_job_log
-   WHERE run_date = CURDATE()` should stay 0).
-2. **Day 1 — Internal canaries.** Manually set `auto_daily_gacha=1` on
-   3 internal test users with active subscriptions. Flip
-   `autoGacha.enabled=true` in a custom config. Watch logs for one
-   nightly cycle. Expect 3 success rows.
-3. **Day 2-7 — 10% cohort.** Pick 10% of active subscribers (by
-   `user_id % 10 == 0`) and pre-set their `auto_daily_gacha=1`. Monitor
-   failure rate and duration for one week.
-4. **Day 8 — Full rollout.** Flip `autoGacha.enabled=true` globally.
-   Monitor for 48h.
-5. **Repeat 1-4 for `autoJankenFate.enabled` independently.**
+1. **Deploy.** Merge PR, run `yarn migrate` on prod, restart bot + worker.
+2. **Verify cron registered.** Worker logs should show the `AutoGacha` entry
+   loaded. First live tick fires at the next 23:50.
+3. **Internal canaries.** Ops manually flips `auto_daily_gacha=1` on 2-3
+   internal test accounts that hold an active subscription. Wait for the
+   next nightly cycle; confirm `auto_gacha_job_log` rows land with
+   `status='success'` and the LIFF history page renders them.
+4. **Announce.** Once canaries look healthy for at least one full day,
+   announce the feature (LINE broadcast / release notes / Bahamut thread).
+   Organic rollout happens user-by-user as subscribers visit
+   `/自動設定`.
 
 ## Rollback
 
-- Flip the corresponding `enabled` flag to `false` via config change +
-  worker restart. No code revert needed. Existing log rows preserved
-  for audit.
+There is no single-config kill switch. If a serious bug surfaces:
+
+- **Immediate (code revert).** Revert the feature branch commit on `main`,
+  redeploy bot + worker. Cron entry disappears; janken hook becomes no-op.
+- **Partial (disable cron only).** Comment out the `AutoGacha` line in
+  `app/config/crontab.config.js`, redeploy worker. Janken hook still runs
+  for opted-in users.
+- **Per-user.** `UPDATE user_auto_preference SET auto_daily_gacha=0,
+  auto_janken_fate=0 WHERE user_id IN (...)` for the affected cohort. Log
+  rows preserved for audit.
 
 ## Out of scope follow-ups
 
 - Arena auto-fate (only standard matches supported in v1).
 - Push notification of auto-draw results (LINE Push API disabled per
-  project policy; users see results via /auto-history LIFF or next
+  project policy; users see results via `/auto/history` LIFF or next
   manual interaction).
 - `recharts`-powered history charts (deferred; list view shipped).
 - Pre-fetching banners / shared draw-dispatch state for cron speedup

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,8 @@ import BattleControl from "./pages/Panel/BattleControl";
 import BattleSign from "./pages/Panel/BattleSign";
 import CustomerOrder from "./pages/CustomerOrder";
 import Achievement from "./pages/Achievement";
+import AutoSettings from "./pages/AutoSettings";
+import AutoHistory from "./pages/AutoHistory";
 import AdminGachaPool from "./pages/Admin/GachaPool";
 import AdminGachaPoolForm from "./pages/Admin/GachaPool/GachaPoolForm";
 import AdminGachaBanner from "./pages/Admin/GachaBanner";
@@ -85,6 +87,10 @@ export default function App() {
 
           {/* Achievement */}
           <Route path="achievements" element={<Achievement />} />
+
+          {/* Subscriber auto-actions (LIFF) */}
+          <Route path="AutoSettings" element={<AutoSettings />} />
+          <Route path="AutoHistory" element={<AutoHistory />} />
 
           {/* Admin — requires admin privilege */}
           <Route element={<RequireAdmin />}>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -89,8 +89,8 @@ export default function App() {
           <Route path="achievements" element={<Achievement />} />
 
           {/* Subscriber auto-actions (LIFF) */}
-          <Route path="AutoSettings" element={<AutoSettings />} />
-          <Route path="AutoHistory" element={<AutoHistory />} />
+          <Route path="auto/settings" element={<AutoSettings />} />
+          <Route path="auto/history" element={<AutoHistory />} />
 
           {/* Admin — requires admin privilege */}
           <Route element={<RequireAdmin />}>

--- a/frontend/src/components/NavDrawer.jsx
+++ b/frontend/src/components/NavDrawer.jsx
@@ -30,6 +30,8 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import LinkIcon from "@mui/icons-material/Link";
 import CelebrationIcon from "@mui/icons-material/Celebration";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import HistoryIcon from "@mui/icons-material/History";
 
 const mainItems = [
   { label: "首頁", path: "/", icon: HomeIcon },
@@ -50,6 +52,8 @@ const personalItems = [
   { label: "交易管理", path: "/trade/manage", icon: ShoppingBasketIcon },
   { label: "轉蛋包包", path: "/bag", icon: LocalMallIcon },
   { label: "裝備管理", path: "/equipment", icon: FitnessCenterIcon },
+  { label: "自動設定", path: "/auto/settings", icon: AutoAwesomeIcon },
+  { label: "自動行為紀錄", path: "/auto/history", icon: HistoryIcon },
 ];
 
 const adminItems = [

--- a/frontend/src/pages/AutoHistory/index.jsx
+++ b/frontend/src/pages/AutoHistory/index.jsx
@@ -25,6 +25,14 @@ function statusColor(status) {
   return "default";
 }
 
+function statusLabel(status) {
+  if (status === "success") return "成功";
+  if (status === "failed") return "失敗";
+  if (status === "skipped") return "略過";
+  if (status === "submitted") return "已送出";
+  return status;
+}
+
 function summaryText(item) {
   if (item.type === "gacha") {
     const s = item.summary || {};
@@ -63,7 +71,7 @@ function HistoryItemCard({ item }) {
           </Box>
           <Chip
             size="small"
-            label={item.status}
+            label={statusLabel(item.status)}
             color={statusColor(item.status)}
             variant={item.status === "submitted" ? "outlined" : "filled"}
           />

--- a/frontend/src/pages/AutoHistory/index.jsx
+++ b/frontend/src/pages/AutoHistory/index.jsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useState } from "react";
+import { Box, Card, CardContent, Chip, Paper, Skeleton, Stack, Typography } from "@mui/material";
+import CasinoIcon from "@mui/icons-material/Casino";
+import SportsMmaIcon from "@mui/icons-material/SportsMma";
+import HistoryIcon from "@mui/icons-material/History";
+import AlertLogin from "../../components/AlertLogin";
+import useLiff from "../../context/useLiff";
+import { getHistory } from "../../services/autoPreference";
+
+function formatDay(iso) {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function statusColor(status) {
+  if (status === "success") return "success";
+  if (status === "failed") return "error";
+  if (status === "skipped") return "default";
+  if (status === "submitted") return "info";
+  return "default";
+}
+
+function summaryText(item) {
+  if (item.type === "gacha") {
+    const s = item.summary || {};
+    const rare = s.reward_summary?.rareCount || {};
+    const parts = [];
+    if (rare["3"]) parts.push(`${rare["3"]} 彩`);
+    if (rare["2"]) parts.push(`${rare["2"]} 金`);
+    if (rare["1"]) parts.push(`${rare["1"]} 銀`);
+    if (s.reward_summary?.newCharactersCount)
+      parts.push(`新角 ${s.reward_summary.newCharactersCount}`);
+    if (s.error) return `(${s.error})`;
+    return parts.length ? parts.join(" / ") : "（無詳細資料）";
+  }
+  if (item.type === "janken") {
+    const { role, choice } = item.summary || {};
+    const mapping = { rock: "✊", paper: "🖐️", scissors: "✌️" };
+    return `${role?.toUpperCase() || ""} 代出 ${mapping[choice] || choice}`;
+  }
+  return "";
+}
+
+function HistoryItemCard({ item }) {
+  const Icon = item.type === "gacha" ? CasinoIcon : SportsMmaIcon;
+  return (
+    <Card>
+      <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+        <Stack direction="row" alignItems="center" spacing={1.5}>
+          <Icon color={item.type === "gacha" ? "primary" : "secondary"} />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {item.type === "gacha" ? "每日自動抽卡" : "猜拳自動出手"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {summaryText(item)}
+            </Typography>
+          </Box>
+          <Chip
+            size="small"
+            label={item.status}
+            color={statusColor(item.status)}
+            variant={item.status === "submitted" ? "outlined" : "filled"}
+          />
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmptyState() {
+  return (
+    <Paper sx={{ p: 4, textAlign: "center", borderRadius: 3 }}>
+      <HistoryIcon sx={{ fontSize: 48, opacity: 0.3, mb: 1 }} />
+      <Typography color="text.secondary">尚無自動行為紀錄</Typography>
+    </Paper>
+  );
+}
+
+function HistorySkeleton() {
+  return (
+    <Stack spacing={1.5}>
+      {[1, 2, 3, 4].map(i => (
+        <Skeleton key={i} variant="rounded" height={64} animation="wave" />
+      ))}
+    </Stack>
+  );
+}
+
+export default function AutoHistory() {
+  const { loggedIn: isLoggedIn } = useLiff();
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    document.title = "自動行為紀錄";
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    let cancelled = false;
+    setLoading(true);
+    getHistory({ limit: 30, type: "all" })
+      .then(data => {
+        if (cancelled) return;
+        setItems(data.items || []);
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn]);
+
+  const grouped = useMemo(() => {
+    const map = new Map();
+    for (const it of items) {
+      const day = formatDay(it.occurred_at);
+      if (!map.has(day)) map.set(day, []);
+      map.get(day).push(it);
+    }
+    return Array.from(map.entries());
+  }, [items]);
+
+  if (!isLoggedIn) return <AlertLogin />;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <Paper
+        sx={{
+          p: 3,
+          borderRadius: 3,
+          background: theme =>
+            `linear-gradient(135deg, ${theme.palette.secondary.dark} 0%, ${theme.palette.secondary.main} 100%)`,
+          color: "#fff",
+        }}
+      >
+        <Stack direction="row" alignItems="center" spacing={1.5}>
+          <HistoryIcon sx={{ fontSize: 32 }} />
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              自動行為紀錄
+            </Typography>
+            <Typography variant="body2" sx={{ opacity: 0.9 }}>
+              最近 30 天的自動抽卡與自動猜拳紀錄。
+            </Typography>
+          </Box>
+        </Stack>
+      </Paper>
+
+      {loading ? (
+        <HistorySkeleton />
+      ) : grouped.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <Stack spacing={2.5}>
+          {grouped.map(([day, entries]) => (
+            <Box key={day}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ display: "block", mb: 1, letterSpacing: 1 }}
+              >
+                {day}
+              </Typography>
+              <Stack spacing={1.5}>
+                {entries.map((it, idx) => (
+                  <HistoryItemCard key={`${day}-${idx}`} item={it} />
+                ))}
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/pages/AutoSettings/index.jsx
+++ b/frontend/src/pages/AutoSettings/index.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState, useCallback } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import {
   Alert,
   Box,
+  Button,
   Card,
   CardContent,
   Chip,
@@ -13,6 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import HistoryIcon from "@mui/icons-material/History";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import AlertLogin from "../../components/AlertLogin";
 import useLiff from "../../context/useLiff";
@@ -90,7 +93,12 @@ export default function AutoSettings() {
   const [state, setState] = useState({
     auto_daily_gacha: 0,
     auto_janken_fate: 0,
-    entitlements: { auto_daily_gacha: false, auto_janken_fate: false },
+    auto_janken_fate_with_bet: 0,
+    entitlements: {
+      auto_daily_gacha: false,
+      auto_janken_fate: false,
+      auto_janken_fate_with_bet: false,
+    },
   });
   const [snack, setSnack] = useState(null);
 
@@ -157,7 +165,7 @@ export default function AutoSettings() {
       >
         <Stack direction="row" alignItems="center" spacing={1.5}>
           <AutoAwesomeIcon sx={{ fontSize: 32 }} />
-          <Box>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
             <Typography variant="h6" sx={{ fontWeight: 700 }}>
               訂閱者自動行為
             </Typography>
@@ -165,6 +173,21 @@ export default function AutoSettings() {
               開啟後，布丁會自動替你執行這些行為。隨時可以關閉。
             </Typography>
           </Box>
+          <Button
+            component={RouterLink}
+            to="/auto/history"
+            size="small"
+            variant="outlined"
+            startIcon={<HistoryIcon />}
+            sx={{
+              color: "#fff",
+              borderColor: "rgba(255,255,255,0.6)",
+              whiteSpace: "nowrap",
+              "&:hover": { borderColor: "#fff", bgcolor: "rgba(255,255,255,0.08)" },
+            }}
+          >
+            查看紀錄
+          </Button>
         </Stack>
       </Paper>
 

--- a/frontend/src/pages/AutoSettings/index.jsx
+++ b/frontend/src/pages/AutoSettings/index.jsx
@@ -29,6 +29,13 @@ const FLAGS = [
     title: "猜拳自動出手 (被挑戰時)",
     description: "被 @tag 猜拳時由系統代你出拳，避免長時間未回應。僅限標準對戰。",
   },
+  {
+    key: "auto_janken_fate_with_bet",
+    title: "含賭注的猜拳也自動代打",
+    description:
+      "上面那個開關啟用後才生效。開啟後被下戰書含賭金時也自動出拳，系統會先替你把女神石押上（餘額不足時自動放棄代打）。",
+    dependsOn: "auto_janken_fate",
+  },
 ];
 
 function ToggleRow({ flag, value, entitled, disabled, onChange }) {
@@ -165,16 +172,19 @@ export default function AutoSettings() {
         <SettingsSkeleton />
       ) : (
         <Stack spacing={2}>
-          {FLAGS.map(flag => (
-            <ToggleRow
-              key={flag.key}
-              flag={flag}
-              value={state[flag.key]}
-              entitled={state.entitlements?.[flag.key]}
-              disabled={saving}
-              onChange={handleToggle}
-            />
-          ))}
+          {FLAGS.map(flag => {
+            const dependencyUnmet = flag.dependsOn && state[flag.dependsOn] !== 1;
+            return (
+              <ToggleRow
+                key={flag.key}
+                flag={flag}
+                value={state[flag.key]}
+                entitled={state.entitlements?.[flag.key]}
+                disabled={saving || dependencyUnmet}
+                onChange={handleToggle}
+              />
+            );
+          })}
         </Stack>
       )}
 

--- a/frontend/src/pages/AutoSettings/index.jsx
+++ b/frontend/src/pages/AutoSettings/index.jsx
@@ -1,0 +1,195 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Paper,
+  Skeleton,
+  Snackbar,
+  Stack,
+  Switch,
+  Typography,
+} from "@mui/material";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import AlertLogin from "../../components/AlertLogin";
+import useLiff from "../../context/useLiff";
+import { getPreference, setPreference } from "../../services/autoPreference";
+
+const FLAGS = [
+  {
+    key: "auto_daily_gacha",
+    title: "每日自動抽卡",
+    description: "每晚 23:50 自動幫你抽今日的公主池十連，結果會存進 LIFF 歷史頁。",
+  },
+  {
+    key: "auto_janken_fate",
+    title: "猜拳自動出手 (被挑戰時)",
+    description: "被 @tag 猜拳時由系統代你出拳，避免長時間未回應。僅限標準對戰。",
+  },
+];
+
+function ToggleRow({ flag, value, entitled, disabled, onChange }) {
+  const locked = !entitled;
+  return (
+    <Card sx={{ opacity: locked ? 0.7 : 1 }}>
+      <CardContent>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                {flag.title}
+              </Typography>
+              {locked && (
+                <Chip
+                  size="small"
+                  icon={<LockOutlinedIcon sx={{ fontSize: 14 }} />}
+                  label="需要月卡/季卡"
+                  color="warning"
+                  variant="outlined"
+                />
+              )}
+            </Stack>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {flag.description}
+            </Typography>
+          </Box>
+          <Switch
+            checked={value === 1}
+            disabled={disabled || (locked && value !== 1)}
+            onChange={e => onChange(flag.key, e.target.checked ? 1 : 0)}
+          />
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SettingsSkeleton() {
+  return (
+    <Stack spacing={2}>
+      <Skeleton variant="rounded" height={96} animation="wave" />
+      <Skeleton variant="rounded" height={96} animation="wave" />
+    </Stack>
+  );
+}
+
+export default function AutoSettings() {
+  const { loggedIn: isLoggedIn } = useLiff();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [state, setState] = useState({
+    auto_daily_gacha: 0,
+    auto_janken_fate: 0,
+    entitlements: { auto_daily_gacha: false, auto_janken_fate: false },
+  });
+  const [snack, setSnack] = useState(null);
+
+  useEffect(() => {
+    document.title = "自動設定";
+  }, []);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getPreference();
+      setState(data);
+    } catch (err) {
+      setSnack({ severity: "error", message: "讀取偏好失敗，請稍後再試" });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    reload();
+  }, [isLoggedIn, reload]);
+
+  const handleToggle = useCallback(
+    async (key, nextValue) => {
+      setSaving(true);
+      const prev = state;
+      setState(s => ({ ...s, [key]: nextValue }));
+      try {
+        const updated = await setPreference({ [key]: nextValue });
+        setState(updated);
+        setSnack({ severity: "success", message: "已更新" });
+      } catch (err) {
+        setState(prev);
+        const code = err?.response?.data?.error;
+        if (code === "entitlement_missing") {
+          setSnack({
+            severity: "warning",
+            message: "此功能需要月卡/季卡訂閱",
+          });
+        } else {
+          setSnack({ severity: "error", message: "更新失敗，請稍後再試" });
+        }
+      } finally {
+        setSaving(false);
+      }
+    },
+    [state]
+  );
+
+  if (!isLoggedIn) return <AlertLogin />;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <Paper
+        sx={{
+          p: 3,
+          borderRadius: 3,
+          background: theme =>
+            `linear-gradient(135deg, ${theme.palette.primary.dark} 0%, ${theme.palette.primary.main} 100%)`,
+          color: "#fff",
+        }}
+      >
+        <Stack direction="row" alignItems="center" spacing={1.5}>
+          <AutoAwesomeIcon sx={{ fontSize: 32 }} />
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              訂閱者自動行為
+            </Typography>
+            <Typography variant="body2" sx={{ opacity: 0.9 }}>
+              開啟後，布丁會自動替你執行這些行為。隨時可以關閉。
+            </Typography>
+          </Box>
+        </Stack>
+      </Paper>
+
+      {loading ? (
+        <SettingsSkeleton />
+      ) : (
+        <Stack spacing={2}>
+          {FLAGS.map(flag => (
+            <ToggleRow
+              key={flag.key}
+              flag={flag}
+              value={state[flag.key]}
+              entitled={state.entitlements?.[flag.key]}
+              disabled={saving}
+              onChange={handleToggle}
+            />
+          ))}
+        </Stack>
+      )}
+
+      <Snackbar
+        open={!!snack}
+        autoHideDuration={3000}
+        onClose={() => setSnack(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        {snack ? (
+          <Alert onClose={() => setSnack(null)} severity={snack.severity} variant="filled">
+            {snack.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Box>
+  );
+}

--- a/frontend/src/pages/Home/FeatureGrid.jsx
+++ b/frontend/src/pages/Home/FeatureGrid.jsx
@@ -7,15 +7,59 @@ import LocalLibraryIcon from "@mui/icons-material/LocalLibrary";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import StorefrontIcon from "@mui/icons-material/Storefront";
 import FitnessCenterIcon from "@mui/icons-material/FitnessCenter";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 
 const features = [
-  { icon: HowToVoteIcon, label: "專屬指令", description: "自訂群組指令", path: null, color: "#6C63FF" },
-  { icon: RecordVoiceOverIcon, label: "幹話等級", description: "聊天經驗排行", path: "/rankings", color: "#FFB830" },
+  {
+    icon: HowToVoteIcon,
+    label: "專屬指令",
+    description: "自訂群組指令",
+    path: null,
+    color: "#6C63FF",
+  },
+  {
+    icon: RecordVoiceOverIcon,
+    label: "幹話等級",
+    description: "聊天經驗排行",
+    path: "/rankings",
+    color: "#FFB830",
+  },
   { icon: GroupIcon, label: "公會管理", description: "群組設定管理", path: null, color: "#51CF66" },
-  { icon: LocalLibraryIcon, label: "遊戲查詢", description: "角色與裝備資訊", path: null, color: "#74C0FC" },
-  { icon: EmojiEventsIcon, label: "公會戰", description: "報刀與戰績", path: null, color: "#FF6B6B" },
-  { icon: StorefrontIcon, label: "轉蛋商店", description: "女神石兌換", path: "/gacha/exchange", color: "#E599F7" },
-  { icon: FitnessCenterIcon, label: "裝備管理", description: "查看我的裝備", path: "/equipment", color: "#FF6B6B" },
+  {
+    icon: LocalLibraryIcon,
+    label: "遊戲查詢",
+    description: "角色與裝備資訊",
+    path: null,
+    color: "#74C0FC",
+  },
+  {
+    icon: EmojiEventsIcon,
+    label: "公會戰",
+    description: "報刀與戰績",
+    path: null,
+    color: "#FF6B6B",
+  },
+  {
+    icon: StorefrontIcon,
+    label: "轉蛋商店",
+    description: "女神石兌換",
+    path: "/gacha/exchange",
+    color: "#E599F7",
+  },
+  {
+    icon: FitnessCenterIcon,
+    label: "裝備管理",
+    description: "查看我的裝備",
+    path: "/equipment",
+    color: "#FF6B6B",
+  },
+  {
+    icon: AutoAwesomeIcon,
+    label: "自動設定",
+    description: "訂閱者自動行為",
+    path: "/auto/settings",
+    color: "#9775FA",
+  },
 ];
 
 export default function FeatureGrid() {
@@ -32,7 +76,8 @@ export default function FeatureGrid() {
             <Card
               sx={{
                 height: "100%",
-                transition: "border-color 0.2s ease-out, box-shadow 0.2s ease-out, transform 0.2s ease-out",
+                transition:
+                  "border-color 0.2s ease-out, box-shadow 0.2s ease-out, transform 0.2s ease-out",
                 "&:hover": {
                   transform: "translateY(-2px)",
                 },

--- a/frontend/src/services/autoPreference.js
+++ b/frontend/src/services/autoPreference.js
@@ -1,0 +1,9 @@
+import api from "./api";
+
+export const getPreference = () => api.get("/api/auto-preference").then(res => res.data);
+
+export const setPreference = payload =>
+  api.put("/api/auto-preference", payload).then(res => res.data);
+
+export const getHistory = ({ limit = 30, type = "all" } = {}) =>
+  api.get("/api/auto-history", { params: { limit, type } }).then(res => res.data);


### PR DESCRIPTION
## Summary

- 訂閱者自動代抽每日轉蛋（23:50 cron，per-user opt-in）
- 猜拳 (duel) 被 @tag 時自動出拳；含賭注的場需額外子開關 + 自動押金 escrow
- LIFF `/auto/settings` 開關頁 + `/auto/history` 30 天紀錄頁，搭配 `/自動設定` 指令
- 單一閘門設計：per-user `user_auto_preference`，預設全 0；無全域 feature flag

## 架構

- Phase 1：schema migrations（`user_auto_preference`, `auto_gacha_job_log`, `gacha_record_detail`, `janken_auto_fate_log`）+ 月/季卡 effects 種子
- Phase 2：抽出 `GachaService.runDailyDraw(userId)`（context-free service layer），`/抽` 指令改成薄 controller
- Phase 3：`app/bin/AutoGacha.js` cron，按 `autoGacha.concurrency` batched，雙重 re-check（訂閱 + 當日已抽）避免 race
- Phase 4：`JankenService.autoFateIfEligible` hook 進 `createMatch`；賭注場需 `auto_janken_fate_with_bet=1` 且 `tryEscrowOnce` 成功才代打
- Phase 5：`GET/PUT /api/auto-preference` + `GET /api/auto-history`（union gacha + janken，token userId 永遠覆寫 body）
- Phase 6：`SubscriptionService.hasEffect(userId, effectType)` helper（JOIN subscribe_user × subscribe_card）
- Phase 7：LIFF React pages（MUI gradient hero + toggle cards / day-grouped history list）
- Phase 8：rollout 指南 at `docs/plans/2026-04-18-rollout-subscriber-auto-actions.md`

## 規劃依據

完整 plan：`.omc/plans/2026-04-18-subscriber-auto-actions.md`（RALPLAN-DR deliberate mode，含 side-effect ledger、pre-mortem、ADR）
PRD：`.omc/prd.json`（15 個 stories，全綠）

## Test plan

- [x] `cd app && yarn test` — 全綠（177 pass，僅餘先前 `api/images.test.js` baseline 紅）
- [x] `cd frontend && yarn build` — 通過（僅 chunk-size 警告，既有問題）
- [x] Code review：reuse / quality / efficiency 三路並行檢視，已修兩處（AchievementEngine 靜默失敗、AutoSettings 初始 state 缺 key）
- [ ] Merge 後 `yarn migrate` on prod（migrations + seed 月/季卡 effects）
- [ ] 內部 canary：手動設 2-3 個測試帳號 `auto_daily_gacha=1`，確認 23:50 cron 寫 log row + LIFF 歷史頁顯示
- [ ] 公告後觀察：`cron.auto_gacha.complete` / `janken.auto_fate.submit` log，若 failure rate > 5% 或 duration > 5min 按 rollout doc 回退

## 不含

- Arena 自動代打（三方 resolveArena 有 role 不對稱，列入後續）
- LINE Push API 通知抽卡結果（專案一律不用 Push API）
- `recharts` 歷史圖表（延後，先出 list view）

## 回退

1. `git revert 2c39916^..HEAD` 並 redeploy
2. 或單獨停 cron：註解掉 `app/config/crontab.config.js` 裡的 AutoGacha 那行
3. 或逐戶停用：`UPDATE user_auto_preference SET auto_daily_gacha=0, auto_janken_fate=0 WHERE user_id IN (...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)