### PR TITLE
feat(achievement): per-user eligibility filter + sister achievements for tagged users

### DIFF
--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -196,7 +196,7 @@ describe("AchievementEngine", () => {
       notify_message: null,
       icon: "🫡",
       name: "管理員粉絲",
-      condition: { targetUserIds: ["Uadmin"], keywords: ["大大好"] },
+      condition: { mentionTargetUserIds: ["Uadmin"], keywords: ["大大好"] },
     };
 
     beforeEach(() => {
@@ -263,7 +263,7 @@ describe("AchievementEngine", () => {
       AchievementEngine._setCache([
         {
           ...baseAchievement,
-          condition: { targetUserIds: ["Uadmin", "Umod"], keywords: ["大大好"] },
+          condition: { mentionTargetUserIds: ["Uadmin", "Umod"], keywords: ["大大好"] },
         },
       ]);
       const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
@@ -277,7 +277,7 @@ describe("AchievementEngine", () => {
       AchievementEngine._setCache([
         {
           ...baseAchievement,
-          condition: { targetUserIds: ["Uadmin"], keywords: [] },
+          condition: { mentionTargetUserIds: ["Uadmin"], keywords: [] },
         },
       ]);
       const ctx = { mentionedUserIds: ["Uadmin"], text: "隨便打什麼都行" };
@@ -287,11 +287,11 @@ describe("AchievementEngine", () => {
       expect(result.unlocked.map(a => a.key)).toEqual(["mention_admin_hi"]);
     });
 
-    it("does not unlock when targetUserIds is empty even if keywords is also empty", async () => {
+    it("does not unlock when mentionTargetUserIds is empty even if keywords is also empty", async () => {
       AchievementEngine._setCache([
         {
           ...baseAchievement,
-          condition: { targetUserIds: [], keywords: [] },
+          condition: { mentionTargetUserIds: [], keywords: [] },
         },
       ]);
       const ctx = { mentionedUserIds: ["Uadmin"], text: "隨便" };
@@ -305,7 +305,7 @@ describe("AchievementEngine", () => {
       AchievementEngine._setCache([
         {
           ...baseAchievement,
-          condition: { targetUserIds: ["Uadmin"], keywords: ["大大好", "早安"] },
+          condition: { mentionTargetUserIds: ["Uadmin"], keywords: ["大大好", "早安"] },
         },
       ]);
       const ctx = { mentionedUserIds: ["Uadmin"], text: "大大好" };
@@ -339,6 +339,186 @@ describe("AchievementEngine", () => {
       expect(summary.categories[0].achievements).toHaveLength(2);
       expect(summary).toHaveProperty("recentUnlocks");
       expect(summary).toHaveProperty("nearCompletion");
+    });
+
+    it("excludes ineligible rows from total and category count", async () => {
+      AchievementModel.allWithCategories.mockResolvedValue([
+        { id: 1, key: "a1", name: "A1", category_key: "social", condition: null },
+        {
+          id: 2,
+          key: "a2",
+          name: "A2",
+          category_key: "social",
+          condition: { eligibility: { excludeUserIds: ["Uvip"] } },
+        },
+        {
+          id: 3,
+          key: "a3",
+          name: "A3",
+          category_key: "social",
+          condition: { eligibility: { includeUserIds: ["Uvip"] } },
+        },
+      ]);
+      CategoryModel.all.mockResolvedValue([{ id: 1, key: "social", name: "社交" }]);
+      UserAchievementModel.findByUser.mockResolvedValue([]);
+      UserProgressModel.findByUser.mockResolvedValue([]);
+      UserAchievementModel.getRecentByUser.mockResolvedValue([]);
+      UserProgressModel.getNearCompletion.mockResolvedValue([]);
+
+      const vipSummary = await AchievementEngine.getUserSummary("Uvip");
+      expect(vipSummary.total).toBe(2);
+      expect(vipSummary.categories[0].total).toBe(2);
+      expect(vipSummary.categories[0].achievements.map(a => a.key)).toEqual(["a1", "a3"]);
+
+      const plebSummary = await AchievementEngine.getUserSummary("Upleb");
+      expect(plebSummary.total).toBe(2);
+      expect(plebSummary.categories[0].achievements.map(a => a.key)).toEqual(["a1", "a2"]);
+    });
+  });
+
+  describe("isEligible", () => {
+    const { _isEligible } = AchievementEngine;
+
+    it("returns true when no eligibility block set", () => {
+      expect(_isEligible("Uany", { condition: null })).toBe(true);
+      expect(_isEligible("Uany", { condition: {} })).toBe(true);
+    });
+
+    it("rejects users in excludeUserIds", () => {
+      const a = { condition: { eligibility: { excludeUserIds: ["Ubanned"] } } };
+      expect(_isEligible("Ubanned", a)).toBe(false);
+      expect(_isEligible("Uother", a)).toBe(true);
+    });
+
+    it("admits only users in includeUserIds when set", () => {
+      const a = { condition: { eligibility: { includeUserIds: ["Uvip"] } } };
+      expect(_isEligible("Uvip", a)).toBe(true);
+      expect(_isEligible("Uother", a)).toBe(false);
+    });
+
+    it("exclude wins when user is in both", () => {
+      const a = {
+        condition: { eligibility: { includeUserIds: ["Uvip"], excludeUserIds: ["Uvip"] } },
+      };
+      expect(_isEligible("Uvip", a)).toBe(false);
+    });
+  });
+
+  describe("evaluate with eligibility filter", () => {
+    it("does not touch progress for excluded users", async () => {
+      AchievementEngine._setCache([
+        {
+          id: 50,
+          key: "mention_admin_hi",
+          target_value: 1,
+          reward_stones: 100,
+          notify_on_unlock: true,
+          condition: {
+            mentionTargetUserIds: ["Uadmin"],
+            keywords: [],
+            eligibility: { excludeUserIds: ["Uadmin"] },
+          },
+        },
+      ]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgress.mockResolvedValue(null);
+
+      // The excluded user mentions themselves (which would otherwise pass the gate).
+      const result = await AchievementEngine.evaluate("Uadmin", "mention_keyword", {
+        mentionedUserIds: ["Uadmin"],
+        text: "",
+      });
+
+      expect(result.unlocked).toEqual([]);
+      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+      expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("received_mention event", () => {
+    const sister = {
+      id: 60,
+      key: "mention_admin_hi_self",
+      target_value: 10,
+      reward_stones: 300,
+      notify_on_unlock: true,
+      notify_message: null,
+      icon: "🥞",
+      name: "鬆餅教教主",
+      condition: {
+        keywords: ["鬆餅", "祝福"],
+        eligibility: { includeUserIds: ["Uadmin"] },
+      },
+    };
+
+    beforeEach(() => {
+      AchievementEngine._setCache([sister]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.upsert.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue();
+      UserProgressModel.delete.mockResolvedValue();
+      mysql.mockImplementation(() => ({
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+        insert: jest.fn().mockResolvedValue(),
+      }));
+    });
+
+    it("increments progress for the tagged mentionee when keywords match", async () => {
+      UserProgressModel.getProgress.mockResolvedValue({ current_value: 3 });
+
+      await AchievementEngine.evaluate("Uadmin", "received_mention", {
+        mentionedByUserId: "Ufan",
+        text: "大大鬆餅祝福你",
+      });
+
+      expect(UserProgressModel.upsert).toHaveBeenCalledWith("Uadmin", 60, 4);
+      expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
+    });
+
+    it("unlocks when cumulative mentions reach target_value", async () => {
+      UserProgressModel.getProgress.mockResolvedValue({ current_value: 9 });
+
+      const result = await AchievementEngine.evaluate("Uadmin", "received_mention", {
+        mentionedByUserId: "Ufan",
+        text: "鬆餅祝福",
+      });
+
+      expect(result.unlocked.map(a => a.key)).toEqual(["mention_admin_hi_self"]);
+    });
+
+    it("does not increment when mentioned by self (self-farming block)", async () => {
+      UserProgressModel.getProgress.mockResolvedValue({ current_value: 3 });
+
+      await AchievementEngine.evaluate("Uadmin", "received_mention", {
+        mentionedByUserId: "Uadmin",
+        text: "鬆餅祝福",
+      });
+
+      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+    });
+
+    it("does not increment when keywords are missing", async () => {
+      UserProgressModel.getProgress.mockResolvedValue({ current_value: 3 });
+
+      await AchievementEngine.evaluate("Uadmin", "received_mention", {
+        mentionedByUserId: "Ufan",
+        text: "哈囉",
+      });
+
+      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+    });
+
+    it("does not fire for users outside includeUserIds (eligibility gate)", async () => {
+      UserProgressModel.getProgress.mockResolvedValue(null);
+
+      const result = await AchievementEngine.evaluate("Uother", "received_mention", {
+        mentionedByUserId: "Ufan",
+        text: "鬆餅祝福",
+      });
+
+      expect(result.unlocked).toEqual([]);
+      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/migrations/20260418184759_update_mention_achievements_add_eligibility.js
+++ b/app/migrations/20260418184759_update_mention_achievements_add_eligibility.js
@@ -1,0 +1,48 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const KEYS = ["mention_admin_hi", "mention_memory_seeker", "mention_void_gazer"];
+
+function parseCondition(raw) {
+  if (!raw) return {};
+  return typeof raw === "string" ? JSON.parse(raw) : raw;
+}
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  for (const key of KEYS) {
+    const row = await knex("achievements").where({ key }).first();
+    if (!row) continue;
+    const cond = parseCondition(row.condition);
+    const tagged = Array.isArray(cond.targetUserIds) ? cond.targetUserIds : [];
+    const next = {
+      mentionTargetUserIds: tagged,
+      keywords: Array.isArray(cond.keywords) ? cond.keywords : [],
+      eligibility: { excludeUserIds: tagged },
+    };
+    await knex("achievements")
+      .where({ key })
+      .update({ condition: JSON.stringify(next) });
+  }
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = async function (knex) {
+  for (const key of KEYS) {
+    const row = await knex("achievements").where({ key }).first();
+    if (!row) continue;
+    const cond = parseCondition(row.condition);
+    const tagged = Array.isArray(cond.mentionTargetUserIds) ? cond.mentionTargetUserIds : [];
+    const prev = {
+      targetUserIds: tagged,
+      keywords: Array.isArray(cond.keywords) ? cond.keywords : [],
+    };
+    await knex("achievements")
+      .where({ key })
+      .update({ condition: JSON.stringify(prev) });
+  }
+};

--- a/app/migrations/20260418184818_seed_mention_sister_achievements.js
+++ b/app/migrations/20260418184818_seed_mention_sister_achievements.js
@@ -1,0 +1,82 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const CATEGORY_KEY = "social";
+
+const ROWS = [
+  {
+    key: "mention_admin_hi_self",
+    name: "鬆餅教教主",
+    description: "信徒的祝福匯聚成你的光環",
+    icon: "🥞",
+    order: 120,
+    includeUserId: "U41b31c07a3279ca64355d2de43101b3d",
+    keywords: ["鬆餅", "祝福"],
+    notify_message:
+      "信徒的呼喚匯聚成祝福，你已成為鬆餅教的精神象徵。\n已解鎖隱藏成就：{icon} {name}",
+  },
+  {
+    key: "mention_memory_seeker_self",
+    name: "布丁古神的意識",
+    description: "無數旅人觸碰了你的意識",
+    icon: "🍮",
+    order: 121,
+    includeUserId: "U80ca6f24809c9a00981562b771fb6b84",
+    keywords: [],
+    notify_message: "無數旅人觸碰了你的意識，古神終於完整甦醒。\n已解鎖隱藏成就：{icon} {name}",
+  },
+  {
+    key: "mention_void_gazer_self",
+    name: "深淵本體",
+    description: "你就是虛無本身",
+    icon: "👁️",
+    order: 122,
+    includeUserId: "Uc28b2e002c86886fffdb6cabea060c6e",
+    keywords: ["sudo su"],
+    notify_message:
+      "$ cat /etc/shadow\n[INFO] you are the void now.\n無數窺探者在你的凝視下沉默。\n已解鎖隱藏成就：{icon} {name}",
+  },
+];
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  const category = await knex("achievement_categories").where({ key: CATEGORY_KEY }).first();
+  if (!category) {
+    throw new Error(`achievement_categories row with key='${CATEGORY_KEY}' not found`);
+  }
+
+  for (const r of ROWS) {
+    await knex("achievements").insert({
+      category_id: category.id,
+      key: r.key,
+      name: r.name,
+      description: r.description,
+      icon: r.icon,
+      type: "hidden",
+      rarity: 3,
+      target_value: 10,
+      reward_stones: 300,
+      order: r.order,
+      condition: JSON.stringify({
+        keywords: r.keywords,
+        eligibility: { includeUserIds: [r.includeUserId] },
+      }),
+      notify_on_unlock: true,
+      notify_message: r.notify_message,
+    });
+  }
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = async function (knex) {
+  await knex("achievements")
+    .whereIn(
+      "key",
+      ROWS.map(r => r.key)
+    )
+    .del();
+};

--- a/app/src/middleware/statistics.js
+++ b/app/src/middleware/statistics.js
@@ -22,23 +22,39 @@ const statistics = async (context, props) => {
       const mentionedUserIds = mentionees.map(m => m && m.userId).filter(Boolean);
       const text = context.event.text || "";
 
-      const tasks = [
-        AchievementEngine.evaluate(userId, "chat_message", { groupId, text }).catch(() => ({
-          unlocked: [],
-        })),
+      const unlocksByUser = { [userId]: [] };
+      const evaluations = [
+        AchievementEngine.evaluate(userId, "chat_message", { groupId, text })
+          .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
+          .catch(() => {}),
       ];
       if (mentionedUserIds.length) {
-        tasks.push(
+        evaluations.push(
           AchievementEngine.evaluate(userId, "mention_keyword", {
             mentionedUserIds,
             text,
-          }).catch(() => ({ unlocked: [] }))
+          })
+            .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
+            .catch(() => {})
         );
+        for (const mentioneeId of mentionedUserIds) {
+          unlocksByUser[mentioneeId] = unlocksByUser[mentioneeId] || [];
+          evaluations.push(
+            AchievementEngine.evaluate(mentioneeId, "received_mention", {
+              mentionedByUserId: userId,
+              text,
+              groupId,
+            })
+              .then(r => unlocksByUser[mentioneeId].push(...((r && r.unlocked) || [])))
+              .catch(() => {})
+          );
+        }
       }
 
-      const results = await Promise.all(tasks);
-      const unlocked = results.flatMap(r => (r && r.unlocked) || []);
-      await notifyUnlocks(context, userId, unlocked);
+      await Promise.all(evaluations);
+      for (const [uid, unlocked] of Object.entries(unlocksByUser)) {
+        if (unlocked.length) await notifyUnlocks(context, uid, unlocked);
+      }
     }
   }
 

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -24,6 +24,25 @@ exports._setCache = data => {
   cacheExpiry = Date.now() + CACHE_TTL_MS;
 };
 
+// Shared by evaluate() and getUserSummary() so ineligible rows are filtered
+// from both the unlock path and the collection-rate denominator.
+function isEligible(userId, achievement) {
+  const eligibility =
+    (achievement && achievement.condition && achievement.condition.eligibility) || null;
+  if (!eligibility) return true;
+  const include = Array.isArray(eligibility.includeUserIds) ? eligibility.includeUserIds : null;
+  const exclude = Array.isArray(eligibility.excludeUserIds) ? eligibility.excludeUserIds : [];
+  if (exclude.includes(userId)) return false;
+  if (include && !include.includes(userId)) return false;
+  return true;
+}
+exports._isEligible = isEligible;
+
+function matchesAllKeywords(text, keywords) {
+  if (!Array.isArray(keywords) || keywords.length === 0) return true;
+  return keywords.every(k => text.includes(k));
+}
+
 // Maps event types to achievement keys
 const EVENT_ACHIEVEMENT_MAP = {
   chat_message: ["chat_100", "chat_1000", "chat_5000", "chat_night_owl", "chat_multi_group"],
@@ -51,6 +70,11 @@ const EVENT_ACHIEVEMENT_MAP = {
   command_use: ["social_first_command", "social_all_features"],
   subscribe: ["subscribe_first", "subscribe_3", "subscribe_6", "subscribe_12"],
   mention_keyword: ["mention_admin_hi", "mention_memory_seeker", "mention_void_gazer"],
+  received_mention: [
+    "mention_admin_hi_self",
+    "mention_memory_seeker_self",
+    "mention_void_gazer_self",
+  ],
 };
 
 // --- Progress calculation strategies by achievement type ---
@@ -80,16 +104,26 @@ const STRATEGIES = {
   },
   mentionKeyword(currentValue, achievement, context) {
     const condition = achievement.condition || {};
-    const targetUserIds = Array.isArray(condition.targetUserIds) ? condition.targetUserIds : [];
-    const keywords = Array.isArray(condition.keywords) ? condition.keywords : [];
-    if (!targetUserIds.length) return currentValue;
+    const mentionTargetUserIds = Array.isArray(condition.mentionTargetUserIds)
+      ? condition.mentionTargetUserIds
+      : [];
+    if (!mentionTargetUserIds.length) return currentValue;
 
     const mentioned = Array.isArray(context.mentionedUserIds) ? context.mentionedUserIds : [];
     const text = typeof context.text === "string" ? context.text : "";
 
-    const allTagged = targetUserIds.every(id => mentioned.includes(id));
-    const allKeyword = keywords.length === 0 || keywords.every(k => text.includes(k));
-    return allTagged && allKeyword ? achievement.target_value : currentValue;
+    const allTagged = mentionTargetUserIds.every(id => mentioned.includes(id));
+    return allTagged && matchesAllKeywords(text, condition.keywords)
+      ? achievement.target_value
+      : currentValue;
+  },
+  receivedMentionKeyword(currentValue, achievement, context) {
+    const condition = achievement.condition || {};
+    const mentionedByUserId = context && context.mentionedByUserId;
+    const mentioneeId = context && context._userId;
+    if (!mentionedByUserId || mentionedByUserId === mentioneeId) return currentValue;
+    const text = typeof context.text === "string" ? context.text : "";
+    return matchesAllKeywords(text, condition.keywords) ? currentValue + 1 : currentValue;
   },
 };
 
@@ -131,6 +165,9 @@ const ACHIEVEMENT_STRATEGY = {
   mention_admin_hi: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
   mention_memory_seeker: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
   mention_void_gazer: (cv, a, ctx) => STRATEGIES.mentionKeyword(cv, a, ctx),
+  mention_admin_hi_self: (cv, a, ctx) => STRATEGIES.receivedMentionKeyword(cv, a, ctx),
+  mention_memory_seeker_self: (cv, a, ctx) => STRATEGIES.receivedMentionKeyword(cv, a, ctx),
+  mention_void_gazer_self: (cv, a, ctx) => STRATEGIES.receivedMentionKeyword(cv, a, ctx),
 };
 
 const GODDESS_STONE_ITEM_ID = 999;
@@ -148,7 +185,10 @@ exports.evaluate = async (userId, eventType, context = {}) => {
     if (!achievementKeys || achievementKeys.length === 0) return { unlocked };
 
     const cache = await getCache();
-    const achievements = achievementKeys.map(key => cache.find(a => a.key === key)).filter(Boolean);
+    const achievements = achievementKeys
+      .map(key => cache.find(a => a.key === key))
+      .filter(Boolean)
+      .filter(a => isEligible(userId, a));
     if (achievements.length === 0) return { unlocked };
 
     const unlockedIds = await UserAchievementModel.getUnlockedIds(
@@ -256,11 +296,12 @@ exports.getUserSummary = async userId => {
     progressMap[p.id] = p.current_value;
   });
 
-  const total = allAchievements.length;
+  const eligibleAchievements = allAchievements.filter(a => isEligible(userId, a));
+  const total = eligibleAchievements.length;
   const unlockedCount = unlocked.length;
 
   const categorySummary = categories.map(cat => {
-    const catAchievements = allAchievements.filter(a => a.category_key === cat.key);
+    const catAchievements = eligibleAchievements.filter(a => a.category_key === cat.key);
     const catUnlocked = catAchievements.filter(a => unlockedIds.has(a.id));
     return {
       ...cat,


### PR DESCRIPTION
## Summary

- Tag-gated mention achievements used to only reward the **mentioner**; the tagged user themselves (admin / 布丁古神 / void-gazer) had no path to earn their own themed achievement. Adding a self-unlock sibling would have created a phantom uncollectable entry in every other user's collection rate.
- Introduces `condition.eligibility = { includeUserIds, excludeUserIds }` applied to **both** `AchievementEngine.evaluate()` (unlock path) and `AchievementEngine.getUserSummary()` (collection-rate denominator + per-category count), so ineligible rows disappear from the user's view entirely.
- Adds `received_mention` event fired per mentionee from the statistics middleware, plus three hidden sister achievements (`mention_admin_hi_self` / `mention_memory_seeker_self` / `mention_void_gazer_self`; `target_value: 10`, `reward_stones: 300`) unlockable only by the corresponding tagged user via cumulative qualifying mentions. Self-mention is blocked inside the strategy to prevent farming.
- Renames `condition.targetUserIds` → `mentionTargetUserIds` (migration rewrites the existing three rows; no backward-compat read retained) to disambiguate from the new `eligibility.includeUserIds`.
- Plan doc at `.omc/plans/2026-04-18-achievement-eligibility.md` (not committed; `.omc/` is gitignored).

## Test plan

- [x] `yarn jest __tests__/service/AchievementEngine.test.js` — 27/27 pass (includes existing mention_keyword regression coverage + new `isEligible`, `evaluate with eligibility filter`, `received_mention event`, and `getUserSummary` denominator-filter describes)
- [x] `yarn lint` on touched files — clean
- [x] `yarn migrate` locally against MySQL — both migrations apply; DB query verifies `excludeUserIds` on the three existing rows and `includeUserIds` on the three new sister rows
- [ ] Manual group-chat e2e: non-tagged user mentions admin with `鬆餅祝福` → unlocks `mention_admin_hi` (existing behavior preserved)
- [ ] Manual group-chat e2e: tagged admin is mentioned 10× across separate messages with qualifying keywords from different senders → unlocks `mention_admin_hi_self` + receives group reply with their own display name
- [ ] Manual group-chat e2e: tagged user self-mentions 10× with keywords → no progress change (self-mention blocked)
- [ ] LIFF `/achievements` for the tagged user: `mention_admin_hi` does NOT appear; `mention_admin_hi_self` appears as ??? pre-unlock
- [ ] LIFF `/achievements` for a random user: `mention_admin_hi_self` does NOT appear at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)