### PR TITLE
fix(achievement): third-person sister notify_message + LINE API name fallback

### DIFF
--- a/app/__tests__/service/achievementNotifier.test.js
+++ b/app/__tests__/service/achievementNotifier.test.js
@@ -14,7 +14,7 @@ const lineUtil = require("../../src/util/line");
 const {
   notifyUnlocks,
   renderTemplate,
-  getDisplayName,
+  _getDisplayName: getDisplayName,
 } = require("../../src/service/achievementNotifier");
 
 describe("achievementNotifier", () => {
@@ -181,8 +181,6 @@ describe("achievementNotifier", () => {
   describe("getDisplayName fallback chain", () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      lineUtil.getGroupMemberProfile.mockReset();
-      getUserProfileMock.mockReset();
     });
 
     it("DB hit short-circuits LINE API calls", async () => {

--- a/app/__tests__/service/achievementNotifier.test.js
+++ b/app/__tests__/service/achievementNotifier.test.js
@@ -1,6 +1,21 @@
+const getUserProfileMock = jest.fn();
+jest.mock("bottender", () => ({
+  getClient: () => ({ getUserProfile: getUserProfileMock }),
+}));
+jest.mock("../../src/util/line", () => ({
+  getGroupMemberProfile: jest.fn(),
+}));
+jest.mock("../../src/util/Logger", () => ({
+  DefaultLogger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
 jest.mock("../../src/util/mysql");
 const mysql = require("../../src/util/mysql");
-const { notifyUnlocks, renderTemplate } = require("../../src/service/achievementNotifier");
+const lineUtil = require("../../src/util/line");
+const {
+  notifyUnlocks,
+  renderTemplate,
+  getDisplayName,
+} = require("../../src/service/achievementNotifier");
 
 describe("achievementNotifier", () => {
   describe("renderTemplate", () => {
@@ -104,12 +119,14 @@ describe("achievementNotifier", () => {
       expect(context.replyText).toHaveBeenNthCalledWith(2, "🎉 Eve 解鎖成就「🇨 C」！");
     });
 
-    it("uses fallback display name 玩家 when user row is missing", async () => {
+    it("uses fallback display name 玩家 when all lookups fail", async () => {
       mysql.mockReturnValue({
         where: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         first: jest.fn().mockResolvedValue(null),
       });
+      lineUtil.getGroupMemberProfile.mockRejectedValue(new Error("no group"));
+      getUserProfileMock.mockRejectedValue(new Error("not friends"));
       await notifyUnlocks(context, "missing-user", [
         {
           notify_on_unlock: true,
@@ -122,10 +139,31 @@ describe("achievementNotifier", () => {
       expect(context.replyText).toHaveBeenCalledWith("🎉 玩家 解鎖成就「🅉 Z」！");
     });
 
+    it("falls back to getUserProfile when DB row is missing", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      });
+      getUserProfileMock.mockResolvedValue({ displayName: "直通阿明" });
+      await notifyUnlocks(context, "U1", [
+        {
+          notify_on_unlock: true,
+          name: "Z",
+          icon: "🅉",
+          reward_stones: 0,
+          notify_message: null,
+        },
+      ]);
+      expect(context.replyText).toHaveBeenCalledWith("🎉 直通阿明 解鎖成就「🅉 Z」！");
+    });
+
     it("swallows internal errors so the middleware chain never breaks", async () => {
       mysql.mockImplementation(() => {
         throw new Error("db down");
       });
+      lineUtil.getGroupMemberProfile.mockRejectedValue(new Error("no group"));
+      getUserProfileMock.mockRejectedValue(new Error("nope"));
       await expect(
         notifyUnlocks(context, "user1", [
           {
@@ -137,7 +175,87 @@ describe("achievementNotifier", () => {
           },
         ])
       ).resolves.toBeUndefined();
-      expect(context.replyText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getDisplayName fallback chain", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      lineUtil.getGroupMemberProfile.mockReset();
+      getUserProfileMock.mockReset();
+    });
+
+    it("DB hit short-circuits LINE API calls", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue({ display_name: "DB名" }),
+      });
+      const name = await getDisplayName("U1", { event: { source: { groupId: "G1" } } });
+      expect(name).toBe("DB名");
+      expect(lineUtil.getGroupMemberProfile).not.toHaveBeenCalled();
+      expect(getUserProfileMock).not.toHaveBeenCalled();
+    });
+
+    it("DB miss + groupId → getGroupMemberProfile", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      });
+      lineUtil.getGroupMemberProfile.mockResolvedValue({ displayName: "群組名" });
+      const name = await getDisplayName("U1", { event: { source: { groupId: "G1" } } });
+      expect(name).toBe("群組名");
+      expect(lineUtil.getGroupMemberProfile).toHaveBeenCalledWith("G1", "U1");
+      expect(getUserProfileMock).not.toHaveBeenCalled();
+    });
+
+    it("DB miss + no groupId → getUserProfile", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      });
+      getUserProfileMock.mockResolvedValue({ displayName: "直通名" });
+      const name = await getDisplayName("U1", { event: { source: {} } });
+      expect(name).toBe("直通名");
+      expect(lineUtil.getGroupMemberProfile).not.toHaveBeenCalled();
+      expect(getUserProfileMock).toHaveBeenCalledWith("U1");
+    });
+
+    it("getGroupMemberProfile fails → getUserProfile", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      });
+      lineUtil.getGroupMemberProfile.mockRejectedValue(new Error("403"));
+      getUserProfileMock.mockResolvedValue({ displayName: "救援名" });
+      const name = await getDisplayName("U1", { event: { source: { groupId: "G1" } } });
+      expect(name).toBe("救援名");
+    });
+
+    it("all fail → 玩家", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockRejectedValue(new Error("db")),
+      });
+      lineUtil.getGroupMemberProfile.mockRejectedValue(new Error("403"));
+      getUserProfileMock.mockRejectedValue(new Error("404"));
+      const name = await getDisplayName("U1", { event: { source: { groupId: "G1" } } });
+      expect(name).toBe("玩家");
+    });
+
+    it("works with undefined context", async () => {
+      mysql.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      });
+      getUserProfileMock.mockResolvedValue({ displayName: "無 ctx 名" });
+      const name = await getDisplayName("U1");
+      expect(name).toBe("無 ctx 名");
     });
   });
 });

--- a/app/migrations/20260418191546_update_sister_achievements_notify_message.js
+++ b/app/migrations/20260418191546_update_sister_achievements_notify_message.js
@@ -1,0 +1,38 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const NEXT = {
+  mention_admin_hi_self:
+    "🥞 信徒的呼喚匯聚成祝福，{user} 成為了鬆餅教的精神象徵。\n已解鎖隱藏成就：{icon} {name}",
+  mention_memory_seeker_self:
+    "🍮 無數旅人觸碰了 {user} 的意識，古神終於完整甦醒。\n已解鎖隱藏成就：{icon} {name}",
+  mention_void_gazer_self:
+    "$ cat /etc/shadow\n[INFO] {user} is the void now.\n無數窺探者在 {user} 的凝視下沉默。\n已解鎖隱藏成就：{icon} {name}",
+};
+
+const PREV = {
+  mention_admin_hi_self:
+    "信徒的呼喚匯聚成祝福，你已成為鬆餅教的精神象徵。\n已解鎖隱藏成就：{icon} {name}",
+  mention_memory_seeker_self:
+    "無數旅人觸碰了你的意識，古神終於完整甦醒。\n已解鎖隱藏成就：{icon} {name}",
+  mention_void_gazer_self:
+    "$ cat /etc/shadow\n[INFO] you are the void now.\n無數窺探者在你的凝視下沉默。\n已解鎖隱藏成就：{icon} {name}",
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  for (const [key, msg] of Object.entries(NEXT)) {
+    await knex("achievements").where({ key }).update({ notify_message: msg });
+  }
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = async function (knex) {
+  for (const [key, msg] of Object.entries(PREV)) {
+    await knex("achievements").where({ key }).update({ notify_message: msg });
+  }
+};

--- a/app/src/service/achievementNotifier.js
+++ b/app/src/service/achievementNotifier.js
@@ -1,4 +1,5 @@
 const { getClient } = require("bottender");
+const { get } = require("lodash");
 const mysql = require("../util/mysql");
 const lineUtil = require("../util/line");
 const { DefaultLogger } = require("../util/Logger");
@@ -12,31 +13,21 @@ const FALLBACK_NAME = "玩家";
 // DB covers senders populated by setProfile middleware. Mentionees (sister
 // achievements) often have no user row yet — fall back to LINE profile APIs
 // so {user} renders with the real display name instead of "玩家".
-async function getDisplayName(userId, context) {
-  try {
-    const row = await mysql("user").where({ platform_id: userId }).select("display_name").first();
-    if (row && row.display_name) return row.display_name;
-  } catch (err) {
-    DefaultLogger.warn("achievementNotifier.getDisplayName db lookup failed:", err);
+async function _getDisplayName(userId, context) {
+  const lookups = [
+    async () => mysql("user").where({ platform_id: userId }).select("display_name").first(),
+    async () => {
+      const groupId = get(context, "event.source.groupId");
+      return groupId ? lineUtil.getGroupMemberProfile(groupId, userId) : null;
+    },
+    async () => LineClient.getUserProfile(userId),
+  ];
+  for (const lookup of lookups) {
+    const row = await lookup().catch(() => null);
+    const name = row && (row.display_name || row.displayName);
+    if (name) return name;
   }
-
-  const groupId = context && context.event && context.event.source && context.event.source.groupId;
-  if (groupId) {
-    try {
-      const profile = await lineUtil.getGroupMemberProfile(groupId, userId);
-      if (profile && profile.displayName) return profile.displayName;
-    } catch (err) {
-      DefaultLogger.warn("achievementNotifier.getDisplayName group-member lookup failed:", err);
-    }
-  }
-
-  try {
-    const profile = await LineClient.getUserProfile(userId);
-    if (profile && profile.displayName) return profile.displayName;
-  } catch (err) {
-    DefaultLogger.warn("achievementNotifier.getDisplayName user-profile lookup failed:", err);
-  }
-
+  DefaultLogger.warn(`achievementNotifier: no display name for ${userId}, falling back to 玩家`);
   return FALLBACK_NAME;
 }
 
@@ -55,7 +46,7 @@ async function notifyUnlocks(context, userId, achievements) {
   try {
     const toNotify = (achievements || []).filter(a => a && a.notify_on_unlock);
     if (!toNotify.length) return;
-    const userName = await getDisplayName(userId, context);
+    const userName = await _getDisplayName(userId, context);
     for (const a of toNotify) {
       await context.replyText(renderTemplate(a, userName));
     }
@@ -64,4 +55,4 @@ async function notifyUnlocks(context, userId, achievements) {
   }
 }
 
-module.exports = { notifyUnlocks, renderTemplate, getDisplayName };
+module.exports = { notifyUnlocks, renderTemplate, _getDisplayName };

--- a/app/src/service/achievementNotifier.js
+++ b/app/src/service/achievementNotifier.js
@@ -1,13 +1,43 @@
+const { getClient } = require("bottender");
 const mysql = require("../util/mysql");
+const lineUtil = require("../util/line");
 const { DefaultLogger } = require("../util/Logger");
+
+const LineClient = getClient("line");
 
 const DEFAULT_TEMPLATE_WITH_REWARD = "🎉 {user} 解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石";
 const DEFAULT_TEMPLATE_NO_REWARD = "🎉 {user} 解鎖成就「{icon} {name}」！";
 const FALLBACK_NAME = "玩家";
 
-async function getDisplayName(userId) {
-  const row = await mysql("user").where({ platform_id: userId }).select("display_name").first();
-  return (row && row.display_name) || FALLBACK_NAME;
+// DB covers senders populated by setProfile middleware. Mentionees (sister
+// achievements) often have no user row yet — fall back to LINE profile APIs
+// so {user} renders with the real display name instead of "玩家".
+async function getDisplayName(userId, context) {
+  try {
+    const row = await mysql("user").where({ platform_id: userId }).select("display_name").first();
+    if (row && row.display_name) return row.display_name;
+  } catch (err) {
+    DefaultLogger.warn("achievementNotifier.getDisplayName db lookup failed:", err);
+  }
+
+  const groupId = context && context.event && context.event.source && context.event.source.groupId;
+  if (groupId) {
+    try {
+      const profile = await lineUtil.getGroupMemberProfile(groupId, userId);
+      if (profile && profile.displayName) return profile.displayName;
+    } catch (err) {
+      DefaultLogger.warn("achievementNotifier.getDisplayName group-member lookup failed:", err);
+    }
+  }
+
+  try {
+    const profile = await LineClient.getUserProfile(userId);
+    if (profile && profile.displayName) return profile.displayName;
+  } catch (err) {
+    DefaultLogger.warn("achievementNotifier.getDisplayName user-profile lookup failed:", err);
+  }
+
+  return FALLBACK_NAME;
 }
 
 function renderTemplate(achievement, userName) {
@@ -25,7 +55,7 @@ async function notifyUnlocks(context, userId, achievements) {
   try {
     const toNotify = (achievements || []).filter(a => a && a.notify_on_unlock);
     if (!toNotify.length) return;
-    const userName = await getDisplayName(userId);
+    const userName = await getDisplayName(userId, context);
     for (const a of toNotify) {
       await context.replyText(renderTemplate(a, userName));
     }
@@ -34,4 +64,4 @@ async function notifyUnlocks(context, userId, achievements) {
   }
 }
 
-module.exports = { notifyUnlocks, renderTemplate };
+module.exports = { notifyUnlocks, renderTemplate, getDisplayName };


### PR DESCRIPTION
## Summary

Follow-up to #678. Two related fixes for the sister-achievement notification path.

### 1. Third-person `notify_message`

When a **mentioner** unlocks `mention_admin_hi` ("恭喜你加入鬆餅教…") and the **mentionee** (admin) simultaneously unlocks `mention_admin_hi_self` on the same message, bottender batches both into one group reply. The original sister template "**你**已成為鬆餅教的精神象徵" was second-person — to the mentioner reading two bubbles in a row, both looked like they were addressed to them, giving the false impression they got the admin's achievement. Rewrite the three sister templates in third person with `{user}` so the subject is unambiguous.

### 2. `{user}` fallback chain

Renaming alone is not enough: `{user}` resolves via `achievementNotifier.getDisplayName`, which only consulted the `user` table. That table is populated by `setProfile` middleware for **senders only** — mentionees with no user row would render as the "玩家" fallback, breaking the easter-egg moment.

Expand `getDisplayName(userId, context)` into a three-layer fallback:

1. DB (`user.display_name`) — fastest, covers senders
2. `lineUtil.getGroupMemberProfile(groupId, userId)` — when `context.event.source.groupId` is available (cached 1h in redis)
3. `LineClient.getUserProfile(userId)` — final LINE API call
4. "玩家" — only if everything fails

All three tagged userIds were verified live to resolve via `getUserProfile` (they've added the bot).

## Test plan

- [x] `yarn jest __tests__/service/achievementNotifier.test.js` — 16/16 pass (6 new `getDisplayName fallback chain` cases + existing renderTemplate / notifyUnlocks coverage updated for the new signature)
- [x] `yarn lint` on touched files — clean
- [x] `yarn migrate` locally — `update_sister_achievements_notify_message` applied; DB row query confirms all three `notify_message` values carry `{user}` in third person
- [ ] Manual group-chat e2e: trigger the double-unlock scenario (first-time mentioner hits admin's 10th qualifying mention) and confirm both bubbles render with the correct display names and second bubble clearly names the admin, not the mentioner

🤖 Generated with [Claude Code](https://claude.com/claude-code)