### PR TITLE
feat(auto-gacha): user-selectable daily mode + fix achievement reward leak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,107 +4,155 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Princess Connect Re:Dive LINE chatbot — a production LINE messaging bot built on the [Bottender](https://bottender.js.org/) framework with a React admin frontend. The bot provides game features (gacha simulation, character lookup, guild battle coordination), group management (leveling, custom commands, rankings), and AI-powered conversation via Google Gemini.
+Princess Connect Re:Dive LINE chatbot — a production LINE messaging bot built on the [Bottender](https://bottender.js.org/) framework with a React admin frontend. Provides game features (gacha simulation, character lookup, guild battle coordination, raid boss, janken arena, trade market), group management (levels, rankings, custom commands), and AI conversation via Google Gemini.
 
-## Architecture
+## Repository Layout
 
-Three services run in Docker Compose:
+Yarn workspaces root; two packages plus shared dev tooling:
 
-- **app/** — Main bot + Express API server (port 5000). Entry: `app/server.js` → `app/src/app.js`
-- **frontend/** — React 17 admin dashboard (port 3000). Entry: `frontend/src/App.js`
-- **job/** — Cron-based background tasks. Entry: `job/index.js`
+- **app/** — Bottender bot + Express API + Socket.IO + cron worker. All backend code lives here.
+- **frontend/** — React 19 + MUI 7 + Vite admin dashboard, embedded as LINE LIFF.
+- **migration/** — MySQL init scripts (mounted into the mysql container on first boot).
+- **docs/** — Design specs (e.g. `docs/superpowers/specs/`).
 
-Supporting infrastructure: MySQL (database `Princess`), Redis (session/cache), nginx (reverse proxy), ngrok (dev tunneling).
+There is no `job/` package — cron is `yarn worker` inside `app/` (see below).
 
-### Backend (app/) Request Flow
+## Runtime Architecture
 
-`app/src/app.js` defines the Bottender middleware chain for LINE webhook messages:
+### Local development (the normal workflow)
 
-1. `setProfile` → `statistics` → `recordLatestGroupUser` → `lineEvent` (LINE events like join/leave)
-2. `config` → `transfer` (Discord webhook) → `HandlePostback` (postback routing)
-3. `rateLimit` → `alias` (command aliasing)
-4. `GlobalOrderBase` → `OrderBased` (feature routing) → `CustomerOrderBased` (user-defined commands)
-5. `interactWithBot` (Gemini AI fallback) → `recordSession` → `Nothing`
+- `make infra` runs **only** MySQL + Redis + phpMyAdmin in Docker (`docker-compose.yml`).
+- `app/` and `frontend/` run on the host via `yarn dev`, **not** in containers.
+- The bot listens on `PORT=9527` (fallback default in `app/server.js`); frontend on `3000`.
+- Vite proxies `/api`, `/webhooks`, `/socket.io` from `3000` → `9527` (`frontend/vite.config.js`), so the frontend talks to the bot directly without nginx.
+- ngrok is launched manually on the host (`ngrok http 9527 --region ap`), then `make tunnel` syncs the public URL into LINE's webhook + LIFF endpoint.
+- Root `.env` is the single env file — loaded by `app/server.js`, `app/tasks.js`, and `app/knexfile.js` via `dotenv` pointing at `../.env`.
 
-Express API routes are at `/api/*` (defined in `app/src/router/api.js`), with token-based auth middleware in `app/src/middleware/validation.js`.
+### Production
 
-### Backend Layers
+- Defined in `docker-compose.traefik.yml` (referenced but deployed via Portainer stacks — see memory).
+- Three services: **bot** (`yarn start`), **frontend** (pre-built static), **worker** (`yarn worker`).
+- Traefik terminates TLS and routes `/api`, `/webhooks`, `/bot-assets`, `/socket.io` → bot; everything else → frontend.
 
-- **Controllers** (`app/src/controller/`) — Route handlers split into `princess/` (game features) and `application/` (group/system features)
-- **Models** (`app/src/model/`) — Extend `app/src/model/base.js`, a Knex-based CRUD base class with `table`, `fillable`, transaction support, and methods: `all()`, `first()`, `find()`, `create()`, `update()`, `delete()`
-- **Services** (`app/src/service/`) — Business logic layer
-- **Templates** (`app/src/templates/`) — LINE Flex Message builders
-- **Middleware** (`app/src/middleware/`) — Bottender chain middleware + Express middleware
-- **Router** (`app/src/router/`) — Express API route definitions
+### Bot process vs worker process
 
-### Data Layer
+Both run from `app/`, sharing the same codebase and `.env`:
 
-- MySQL via Knex query builder (`app/knexfile.js`). Database: `Princess`
-- Redis for Bottender session storage and caching (`app/src/util/redis.js`)
-- SQLite for game asset data (`app/assets/`)
-- Migrations in `app/migrations/` (Knex)
+- **bot** (`yarn dev` / `yarn start` → `server.js`): Bottender + Express + Socket.IO on port 9527. Handles LINE webhooks, REST API under `/api`, static assets at `/bot-assets`.
+- **worker** (`yarn worker` → `tasks.js`): cron scheduler that reads `app/config/crontab.config.js` and executes scripts in `app/bin/` (auto-gacha, chat-exp aggregation, daily cleanup, achievement evaluation, race lifecycle, etc.). Never starts the HTTP server.
 
-### Frontend (frontend/)
+## Backend (app/) Internals
 
-React 17 with Material-UI v4/v5, react-router-dom v5, axios for API calls, Socket.IO for real-time updates.
+### Bottender middleware chain (`app/src/app.js#App`)
+
+Order matters — this is the actual chain:
+
+1. `setProfile` → `statistics` → `recordLatestGroupUser` → `lineEvent`
+2. `config` (loads per-group `guildConfig` into `context.state`) → `transfer` (Discord mirror) → `HandlePostback`
+3. `rateLimit` → `alias` → `umamiTrack`
+4. `GlobalOrderBase` → `OrderBased` (main command router) → `CustomerOrderBased` (user-defined commands)
+5. `interactWithBot` (mention-triggered Gemini fallback) → `OpenaiController.recordSession` → `Nothing`
+
+Command routing in `OrderBased` composes routers from every domain controller (gacha, battle, worldboss, janken, achievement, market, coupon, race, subscribe, character, job, etc.) plus top-level `text(...)` matchers. Adding a new command almost always means appending to `OrderBased` or exposing a `.router` array from a controller.
+
+### Layers
+
+- **Controllers** (`app/src/controller/`): split into `princess/` (game features: gacha, battle, character, god-stone shop) and `application/` (group/system: chat level, worldboss, janken, achievements, market, race, subscribe, admin, customer orders).
+- **Services** (`app/src/service/`): business logic reused across controllers (`AchievementEngine`, `GachaService`, `EquipmentService`, `JankenService`, `RaceService`, `SubscriptionService`, `WorldBossEvent*Service`, `EventCenterService`, etc.).
+- **Models** (`app/src/model/`): Knex-based CRUD, split into `application/` and `princess/`. All extend `app/src/model/base.js` — supply `{ table, fillable }`; get `all()`, `first()`, `find()`, `create()`, `update()`, `delete()`, plus `transaction()` / `setTransaction(trx)` for trx propagation.
+- **Templates** (`app/src/templates/`): LINE Flex Message builders, mirroring the controller split.
+- **Middleware** (`app/src/middleware/`): Bottender-chain middleware (`profile`, `statistics`, `config`, `alias`, `rateLimit`, `dcWebhook`, `umamiTrack`) and Express auth (`validation.js` for `/api` tokens).
+- **Router** (`app/src/router/api.js`): Express REST API; `socket.js` wires Socket.IO events on the shared HTTP server.
+
+### Data layer
+
+- **MySQL** via Knex (`app/knexfile.js`) — database is hardcoded `Princess`. Host-run migrations read the root `.env` (`DB_HOST=mysql` maps to the docker-exposed port 3306 on localhost).
+- **Redis** — Bottender session store + general cache (`app/src/util/redis.js`). Session TTL 60 min, state TTL 15 min (`app/bottender.config.js`).
+- **SQLite** — read-only game data (`app/assets/redive_tw.db`) and a local task log (`app/assets/task.db`); accessed via `better-sqlite3` through `app/src/model/princess/GameSqlite.js`.
+- **Migrations** — `app/migrations/`. Create new ones with `cd app && yarn knex migrate:make <name>` — never hand-write.
+
+### Socket.IO
+
+`app/src/util/connection.js` constructs the shared Express `server`, wraps it in `http`, and attaches `io` to the same port. Frontend connects through the Vite proxy in dev, through Traefik in prod.
+
+## Frontend (frontend/) Internals
+
+- React 19, MUI 7 (`@mui/material`, `@mui/x-data-grid` v8), Emotion, `react-router-dom` v7, Framer Motion, Recharts, Socket.IO client.
+- Bundler: **Vite 8** (not CRA). Dev: `yarn dev`. Build: `yarn build`. No test runner currently configured.
+- Entry: `frontend/src/main.jsx` → `App.jsx`. Pages under `src/pages/` (Achievement, Admin, Auto{History,Settings}, Bag, CustomerOrder, Equipment, Gacha, Group, Home, Janken, Panel, Race, Rankings, Tools, Trade).
+- Auth uses LINE LIFF (`@line/liff`) — pages assume a LIFF context, and LIFF endpoint URLs are kept in sync by `make tunnel` in dev.
+- Progressive redesign toward MUI card layouts is in progress; see memory for which pages are done.
 
 ## Common Commands
 
-### Docker (primary workflow)
+Root (yarn workspaces glue):
 
 ```bash
-make build-images      # Build Docker images
-make build-project     # Install dependencies in all services
-make build             # Full setup: pull + build + install
-make run               # Start all containers (docker compose up -d)
-make logs              # Tail all container logs
-make bash              # Shell into bot container
-make bash-redis        # Open Redis CLI
+yarn dev              # runs app + frontend concurrently
+yarn test:app         # jest in app/
+yarn lint:app         # eslint in app/
+yarn lint:frontend    # eslint in frontend/
+yarn build:frontend   # production build
+yarn migrate          # proxies to app/yarn migrate
 ```
 
-### Backend (app/)
+Makefile (infra + LINE plumbing):
 
 ```bash
-yarn dev               # Dev server with nodemon hot-reload
-yarn start             # Production server
-yarn test              # Jest tests
-yarn lint              # ESLint
-yarn migrate           # Run Knex migrations
-yarn debug             # Verbose Bottender debug logging
+make infra            # docker compose up -d mysql redis (+ phpmyadmin)
+make infra-stop       # docker compose down
+make migrate          # cd app && yarn migrate
+make logs             # tail infra logs
+make bash-redis       # redis-cli into the redis container
+make ngrok-url        # fetch the current ngrok public URL from localhost:4040
+make tunnel           # push ngrok URL → LINE webhook + LIFF endpoint
+make get-webhook      # print current LINE webhook endpoint
+make get-liff         # print LIFF app config
+make help             # list all targets
 ```
 
-### Frontend (frontend/)
+app/ scripts:
 
 ```bash
-yarn start             # React dev server (port 3000)
-yarn build             # Production build
-yarn test              # React Testing Library tests
+yarn dev              # nodemon server.js (port 9527)
+yarn start            # production bot
+yarn worker           # cron scheduler (tasks.js + app/bin/*)
+yarn test             # jest
+yarn test -- path/to/file.test.js   # single test file
+yarn lint             # eslint .
+yarn migrate          # knex migrate:latest
+yarn debug            # DEBUG=bottender:action node server.js
 ```
 
-### Job (job/)
+frontend/ scripts:
 
 ```bash
-yarn dev               # Dev with nodemon
-yarn start             # Production cron runner
+yarn dev              # vite dev server (port 3000)
+yarn build            # production build
+yarn preview          # serve the built dist
+yarn lint             # eslint .
 ```
+
+Tests currently live only in `app/` (Jest, `__tests__/` dirs alongside services/controllers/bin). There is no frontend test runner.
+
+## LINE Webhook Flow
+
+LINE channel is the only enabled webhook (`app/bottender.config.js`): `POST /webhooks/line`. Messenger / WhatsApp / Telegram / Slack / Viber blocks exist but are disabled. To update LINE after starting a new ngrok session: `make tunnel`.
 
 ## Code Style
 
-- ESLint + Prettier: double quotes, trailing commas (es5), 100 char print width
-- CommonJS modules (`require`/`module.exports`) throughout backend
-- Config in `app/.eslintrc.js` and `app/.prettierrc`
+- ESLint 10 + Prettier 3: double quotes, trailing commas (`es5`), 100-char print width (`app/.eslintrc.js`, `app/.prettierrc`). Husky + lint-staged format on commit via `app/node_modules/.bin/prettier` (monorepo-wide).
+- CommonJS throughout the backend (`require` / `module.exports`). Frontend is ESM (`"type": "module"`).
 
 ## Environment
 
-Copy `.env.example` to `.env`. Required variables: `LINE_ACCESS_TOKEN`, `LINE_CHANNEL_SECRET`, `DB_PASSWORD`, `DB_USER`, `DB_USER_PASSWORD`, `REDIS_PASSWORD`, `ADMIN_EMAIL`. See `.env.example` for optional variables and infrastructure defaults.
-
-## LINE Webhook
-
-Webhook URL: `https://{domain}/webhooks/line` — configured in `app/bottender.config.js`. Only the LINE channel is enabled.
+Copy `.env.example` to root `.env`. Required: `LINE_ACCESS_TOKEN`, `LINE_CHANNEL_SECRET`, `DB_PASSWORD`, `DB_USER`, `DB_USER_PASSWORD`, `REDIS_PASSWORD`. Optional but commonly used: `LINE_LIFF_ID` + variants, `LINE_LOGIN_CHANNEL_ID/SECRET` (for `make tunnel`'s LIFF update), `GEMINI_API_KEY`, `PICTSHARE_URL` + `PICTSHARE_UPLOAD_CODE`, `UMAMI_URL` + `UMAMI_WEBSITE_ID`.
 
 ## Key Config Files
 
-- `app/bottender.config.js` — Bottender session (Redis), LINE channel config, initial state
-- `app/knexfile.js` — MySQL connection config
-- `app/config/default.json` — Game logic settings, API endpoints, color codes
-- `docker-compose.yml` — Service definitions (infra only; bot/frontend/crontab defined in override files)
+- `app/bottender.config.js` — session store (Redis), channel enablement, initial `context.state`.
+- `app/knexfile.js` — single MySQL connection config for app + worker + migrations.
+- `app/config/default.json` — game logic constants, external link URLs, color palette; read via `config` package (`require("config").get(...)`).
+- `app/config/crontab.config.js` — cron schedule → `app/bin/<Script>.js` mapping (edit here when adding background jobs).
+- `docker-compose.yml` — infra only (mysql, redis, phpmyadmin). Dev reality; bot/frontend run on the host.
+- `docker-compose.traefik.yml` — production service + Traefik routing labels. Not used locally.

--- a/app/__tests__/bin/AutoGacha.test.js
+++ b/app/__tests__/bin/AutoGacha.test.js
@@ -1,10 +1,14 @@
-// AutoGacha cron — unit tests covering concurrency cap and per-user
-// success / already_pulled / failed / expired paths.
+// AutoGacha cron — unit tests covering concurrency cap, per-user success /
+// already_pulled / failed / expired paths, and per-mode draw selection with
+// best-effort stone fallback.
 
 jest.mock("config", () => {
   const store = {
     "autoGacha.concurrency": 2,
     "autoGacha.schedule": ["0", "50", "23", "*", "*", "*"],
+    "gacha.pick_up_cost": 1500,
+    "gacha.ensure_cost": 3000,
+    "gacha.europe_cost": 10000,
   };
   return {
     get: jest.fn(key => store[key]),
@@ -25,12 +29,33 @@ jest.mock("../../src/service/GachaService", () => ({
 jest.mock("../../src/service/SubscriptionService", () => ({
   hasEffect: jest.fn(),
 }));
+jest.mock("../../src/model/princess/gacha", () => ({
+  getUserGodStoneCount: jest.fn(),
+}));
+jest.mock("../../src/model/princess/GachaBanner", () => ({
+  getActiveBannersWithCharacters: jest.fn(),
+}));
 
 const config = require("config");
 const mysql = require("../../src/util/mysql");
 const GachaService = require("../../src/service/GachaService");
 const SubscriptionService = require("../../src/service/SubscriptionService");
+const GachaModel = require("../../src/model/princess/gacha");
+const GachaBanner = require("../../src/model/princess/GachaBanner");
 const AutoGacha = require("../../bin/AutoGacha");
+
+function makeResult(overrides = {}) {
+  return {
+    rewards: new Array(10).fill({ id: 1, star: "1" }),
+    rareCount: { 1: 10 },
+    newCharacters: [],
+    ownCharactersCount: 50,
+    repeatReward: 10,
+    godStoneCost: 0,
+    unlocks: [],
+    ...overrides,
+  };
+}
 
 describe("AutoGacha cron", () => {
   beforeEach(() => {
@@ -39,15 +64,9 @@ describe("AutoGacha cron", () => {
     SubscriptionService.hasEffect.mockResolvedValue(true);
     mysql.first.mockResolvedValue(null);
     GachaService.getRemainingDailyQuota.mockResolvedValue({ total: 1, used: 0, remaining: 1 });
-    GachaService.runDailyDraw.mockResolvedValue({
-      rewards: new Array(10).fill({ id: 1, star: "1" }),
-      rareCount: { 1: 10 },
-      newCharacters: [],
-      ownCharactersCount: 50,
-      repeatReward: 10,
-      godStoneCost: 0,
-      unlocks: [],
-    });
+    GachaService.runDailyDraw.mockResolvedValue(makeResult());
+    GachaModel.getUserGodStoneCount.mockResolvedValue(100000);
+    GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([]);
   });
 
   afterAll(() => {
@@ -81,7 +100,7 @@ describe("AutoGacha cron", () => {
     expect(args[1]).toBe("2026-04-18");
     expect(args[2]).toBe("success");
     expect(args[3]).toBe(10);
-    expect(typeof args[6]).toBe("string"); // reward_summary JSON stringified
+    expect(typeof args[6]).toBe("string");
     const summary = JSON.parse(args[6]);
     expect(summary.rareCount).toEqual({ 1: 10 });
     expect(summary.repeatReward).toBe(10);
@@ -96,10 +115,10 @@ describe("AutoGacha cron", () => {
     expect(counters.success).toBe(1);
     const args = mysql.raw.mock.calls[0][1];
     expect(args[2]).toBe("success");
-    expect(args[3]).toBe(20); // 2 rounds × 10 pulls each
+    expect(args[3]).toBe(20);
     const summary = JSON.parse(args[6]);
     expect(summary.rareCount).toEqual({ 1: 20 });
-    expect(summary.repeatReward).toBe(20); // 10 per round × 2 rounds
+    expect(summary.repeatReward).toBe(20);
     expect(summary.rounds).toBe(2);
     expect(summary.quota_total).toBe(2);
   });
@@ -151,6 +170,157 @@ describe("AutoGacha cron", () => {
       godStoneCost: 1500,
       repeatReward: 50,
       rounds: 1,
+    });
+  });
+
+  describe("mode selection", () => {
+    it("mode=normal does not read stone balance and calls runDailyDraw with empty opts", async () => {
+      const counters = { success: 0, failed: 0, skipped: 0 };
+      await AutoGacha.drawForUser(
+        { user_id: "Unorm", auto_daily_gacha_mode: "normal" },
+        "2026-04-18",
+        counters
+      );
+      expect(GachaModel.getUserGodStoneCount).not.toHaveBeenCalled();
+      expect(GachaService.runDailyDraw).toHaveBeenCalledTimes(1);
+      expect(GachaService.runDailyDraw).toHaveBeenCalledWith("Unorm", {});
+      const summary = JSON.parse(mysql.raw.mock.calls[0][1][6]);
+      expect(summary.mode_requested).toBe("normal");
+      expect(summary.mode_breakdown).toEqual({ normal: 1, pickup: 0, ensure: 0, europe: 0 });
+      expect(summary.fallback_reason).toBeNull();
+    });
+
+    it("mode=ensure with abundant stones runs every round in ensure mode", async () => {
+      GachaService.getRemainingDailyQuota.mockResolvedValueOnce({
+        total: 2,
+        used: 0,
+        remaining: 2,
+      });
+      GachaModel.getUserGodStoneCount.mockResolvedValue(10000);
+      const counters = { success: 0, failed: 0, skipped: 0 };
+      await AutoGacha.drawForUser(
+        { user_id: "Uens", auto_daily_gacha_mode: "ensure" },
+        "2026-04-18",
+        counters
+      );
+      expect(GachaService.runDailyDraw).toHaveBeenCalledTimes(2);
+      expect(GachaService.runDailyDraw).toHaveBeenNthCalledWith(1, "Uens", { ensure: true });
+      expect(GachaService.runDailyDraw).toHaveBeenNthCalledWith(2, "Uens", { ensure: true });
+      const summary = JSON.parse(mysql.raw.mock.calls[0][1][6]);
+      expect(summary.mode_requested).toBe("ensure");
+      expect(summary.mode_breakdown).toEqual({ normal: 0, pickup: 0, ensure: 2, europe: 0 });
+      expect(summary.fallback_reason).toBeNull();
+    });
+
+    it("mode=ensure degrades round 2 to normal when stones drop below the ensure cost", async () => {
+      GachaService.getRemainingDailyQuota.mockResolvedValueOnce({
+        total: 2,
+        used: 0,
+        remaining: 2,
+      });
+      // Round 1: 3000 stones (covers one ensure). Round 2: 0 stones (forces normal fallback).
+      GachaModel.getUserGodStoneCount.mockResolvedValueOnce(3000).mockResolvedValueOnce(0);
+      const counters = { success: 0, failed: 0, skipped: 0 };
+      await AutoGacha.drawForUser(
+        { user_id: "Umix", auto_daily_gacha_mode: "ensure" },
+        "2026-04-18",
+        counters
+      );
+      expect(GachaService.runDailyDraw).toHaveBeenCalledTimes(2);
+      expect(GachaService.runDailyDraw).toHaveBeenNthCalledWith(1, "Umix", { ensure: true });
+      expect(GachaService.runDailyDraw).toHaveBeenNthCalledWith(2, "Umix", {});
+      expect(GachaModel.getUserGodStoneCount).toHaveBeenCalledTimes(2);
+      const summary = JSON.parse(mysql.raw.mock.calls[0][1][6]);
+      expect(summary.mode_breakdown).toEqual({ normal: 1, pickup: 0, ensure: 1, europe: 0 });
+      expect(summary.fallback_reason).toBe("insufficient_stone");
+    });
+
+    it("mode=europe with no active europe banner falls back to normal for the whole day", async () => {
+      GachaService.getRemainingDailyQuota.mockResolvedValueOnce({
+        total: 2,
+        used: 0,
+        remaining: 2,
+      });
+      const counters = { success: 0, failed: 0, skipped: 0 };
+      await AutoGacha.drawForUser(
+        { user_id: "Ueuro", auto_daily_gacha_mode: "europe" },
+        "2026-04-18",
+        counters,
+        { activeEuropeBanner: null }
+      );
+      // All rounds in normal → no stone reads at all
+      expect(GachaModel.getUserGodStoneCount).not.toHaveBeenCalled();
+      expect(GachaService.runDailyDraw).toHaveBeenCalledTimes(2);
+      expect(GachaService.runDailyDraw).toHaveBeenNthCalledWith(1, "Ueuro", {});
+      expect(GachaService.runDailyDraw).toHaveBeenNthCalledWith(2, "Ueuro", {});
+      const summary = JSON.parse(mysql.raw.mock.calls[0][1][6]);
+      expect(summary.mode_requested).toBe("europe");
+      expect(summary.mode_breakdown).toEqual({ normal: 2, pickup: 0, ensure: 0, europe: 0 });
+      expect(summary.fallback_reason).toBe("europe_unavailable");
+    });
+
+    it("mode=europe with active banner uses banner.cost for the stone check", async () => {
+      GachaService.getRemainingDailyQuota.mockResolvedValueOnce({
+        total: 1,
+        used: 0,
+        remaining: 1,
+      });
+      // banner.cost=5000 takes precedence over the 10000 config default.
+      GachaModel.getUserGodStoneCount.mockResolvedValue(5000);
+      const counters = { success: 0, failed: 0, skipped: 0 };
+      await AutoGacha.drawForUser(
+        { user_id: "Ubanner", auto_daily_gacha_mode: "europe" },
+        "2026-04-18",
+        counters,
+        { activeEuropeBanner: { id: 1, type: "europe", cost: 5000 } }
+      );
+      expect(GachaService.runDailyDraw).toHaveBeenCalledWith("Ubanner", { europe: true });
+      const summary = JSON.parse(mysql.raw.mock.calls[0][1][6]);
+      expect(summary.mode_breakdown.europe).toBe(1);
+      expect(summary.fallback_reason).toBeNull();
+    });
+
+    it("mode=europe with active banner but insufficient stones falls back per round with insufficient_stone", async () => {
+      GachaService.getRemainingDailyQuota.mockResolvedValueOnce({
+        total: 1,
+        used: 0,
+        remaining: 1,
+      });
+      GachaModel.getUserGodStoneCount.mockResolvedValue(1000);
+      const counters = { success: 0, failed: 0, skipped: 0 };
+      await AutoGacha.drawForUser(
+        { user_id: "Upoor", auto_daily_gacha_mode: "europe" },
+        "2026-04-18",
+        counters,
+        { activeEuropeBanner: { id: 1, type: "europe", cost: 5000 } }
+      );
+      expect(GachaService.runDailyDraw).toHaveBeenCalledWith("Upoor", {});
+      const summary = JSON.parse(mysql.raw.mock.calls[0][1][6]);
+      expect(summary.mode_requested).toBe("europe");
+      expect(summary.mode_breakdown.europe).toBe(0);
+      expect(summary.mode_breakdown.normal).toBe(1);
+      expect(summary.fallback_reason).toBe("insufficient_stone");
+    });
+
+    it("unknown / missing stored mode is coerced to 'normal'", async () => {
+      const counters = { success: 0, failed: 0, skipped: 0 };
+      await AutoGacha.drawForUser(
+        { user_id: "Ugarbage", auto_daily_gacha_mode: "legendary" },
+        "2026-04-18",
+        counters
+      );
+      expect(GachaService.runDailyDraw).toHaveBeenCalledWith("Ugarbage", {});
+      const summary = JSON.parse(mysql.raw.mock.calls[0][1][6]);
+      expect(summary.mode_requested).toBe("normal");
+    });
+
+    it("costForMode honours banner.cost precedence over config default", () => {
+      expect(AutoGacha.costForMode("normal", null)).toBe(0);
+      expect(AutoGacha.costForMode("pickup", null)).toBe(1500);
+      expect(AutoGacha.costForMode("ensure", null)).toBe(3000);
+      expect(AutoGacha.costForMode("europe", null)).toBe(10000);
+      expect(AutoGacha.costForMode("europe", { cost: 0 })).toBe(10000);
+      expect(AutoGacha.costForMode("europe", { cost: 7777 })).toBe(7777);
     });
   });
 });

--- a/app/__tests__/bin/AutoGacha.test.js
+++ b/app/__tests__/bin/AutoGacha.test.js
@@ -25,6 +25,12 @@ jest.mock("config", () => {
 jest.mock("../../src/service/GachaService", () => ({
   runDailyDraw: jest.fn(),
   getRemainingDailyQuota: jest.fn(),
+  resolveCost: jest.fn((pickup, ensure, europe, banner) => {
+    if (pickup) return { amount: 1500, note: "" };
+    if (ensure) return { amount: 3000, note: "" };
+    if (europe) return { amount: banner && banner.cost > 0 ? banner.cost : 10000, note: "" };
+    return { amount: 0, note: "" };
+  }),
 }));
 jest.mock("../../src/service/SubscriptionService", () => ({
   hasEffect: jest.fn(),

--- a/app/__tests__/controller/AutoPreferenceController.test.js
+++ b/app/__tests__/controller/AutoPreferenceController.test.js
@@ -8,6 +8,12 @@ jest.mock("../../src/service/SubscriptionService", () => ({
 }));
 jest.mock("../../src/service/GachaService", () => ({
   getRemainingDailyQuota: jest.fn(),
+  resolveCost: jest.fn((pickup, ensure, europe, banner) => {
+    if (pickup) return { amount: 1500, note: "" };
+    if (ensure) return { amount: 3000, note: "" };
+    if (europe) return { amount: banner && banner.cost > 0 ? banner.cost : 10000, note: "" };
+    return { amount: 0, note: "" };
+  }),
 }));
 jest.mock("../../src/model/princess/gacha", () => ({
   getUserGodStoneCount: jest.fn(),

--- a/app/__tests__/controller/AutoPreferenceController.test.js
+++ b/app/__tests__/controller/AutoPreferenceController.test.js
@@ -6,9 +6,21 @@ jest.mock("../../src/model/application/UserAutoPreference", () => ({
 jest.mock("../../src/service/SubscriptionService", () => ({
   hasEffect: jest.fn(),
 }));
+jest.mock("../../src/service/GachaService", () => ({
+  getRemainingDailyQuota: jest.fn(),
+}));
+jest.mock("../../src/model/princess/gacha", () => ({
+  getUserGodStoneCount: jest.fn(),
+}));
+jest.mock("../../src/model/princess/GachaBanner", () => ({
+  getActiveBannersWithCharacters: jest.fn(),
+}));
 
 const UserAutoPreference = require("../../src/model/application/UserAutoPreference");
 const SubscriptionService = require("../../src/service/SubscriptionService");
+const GachaService = require("../../src/service/GachaService");
+const GachaModel = require("../../src/model/princess/gacha");
+const GachaBanner = require("../../src/model/princess/GachaBanner");
 const mysql = require("../../src/util/mysql");
 const controller = require("../../src/controller/application/AutoPreferenceController");
 
@@ -23,6 +35,10 @@ describe("AutoPreferenceController", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mysql.first.mockResolvedValue(null);
+    // Defaults for the newly-added gacha_context lookup — each test may override.
+    GachaService.getRemainingDailyQuota.mockResolvedValue({ total: 2, used: 0, remaining: 2 });
+    GachaModel.getUserGodStoneCount.mockResolvedValue(5000);
+    GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([]);
   });
 
   describe("GET /api/auto-preference", () => {
@@ -33,10 +49,11 @@ describe("AutoPreferenceController", () => {
       expect(res.json).toHaveBeenCalledWith({ error: "unauthenticated" });
     });
 
-    it("returns preference + entitlement flags", async () => {
+    it("returns preference + entitlement flags + gacha_context", async () => {
       UserAutoPreference.first.mockResolvedValue({
         user_id: "Uabc",
         auto_daily_gacha: 1,
+        auto_daily_gacha_mode: "ensure",
         auto_janken_fate: 0,
       });
       SubscriptionService.hasEffect.mockImplementation(
@@ -48,6 +65,7 @@ describe("AutoPreferenceController", () => {
 
       expect(res.json).toHaveBeenCalledWith({
         auto_daily_gacha: 1,
+        auto_daily_gacha_mode: "ensure",
         auto_janken_fate: 0,
         auto_janken_fate_with_bet: 0,
         entitlements: {
@@ -55,26 +73,81 @@ describe("AutoPreferenceController", () => {
           auto_janken_fate: false,
           auto_janken_fate_with_bet: false,
         },
+        gacha_context: {
+          stone_balance: 5000,
+          daily_quota: { total: 2, used: 0, remaining: 2 },
+          costs: { normal: 0, pickup: 1500, ensure: 3000, europe: 10000 },
+          europe_banner_active: false,
+        },
       });
     });
 
-    it("returns zeros + false entitlements when user has no preference row", async () => {
+    it("returns zeros + mode='normal' + false entitlements when user has no preference row", async () => {
       UserAutoPreference.first.mockResolvedValue(null);
       SubscriptionService.hasEffect.mockResolvedValue(false);
 
       const res = mockRes();
       await controller.api.getPreference({ profile: { userId: "Unew" } }, res);
 
-      expect(res.json).toHaveBeenCalledWith({
-        auto_daily_gacha: 0,
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          auto_daily_gacha: 0,
+          auto_daily_gacha_mode: "normal",
+          auto_janken_fate: 0,
+          auto_janken_fate_with_bet: 0,
+          entitlements: {
+            auto_daily_gacha: false,
+            auto_janken_fate: false,
+            auto_janken_fate_with_bet: false,
+          },
+        })
+      );
+    });
+
+    it("reports europe_banner_active=true and uses banner.cost when active europe banner has cost > 0", async () => {
+      UserAutoPreference.first.mockResolvedValue(null);
+      SubscriptionService.hasEffect.mockResolvedValue(false);
+      GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([
+        { id: 1, type: "europe", cost: 7777, characterIds: [] },
+      ]);
+
+      const res = mockRes();
+      await controller.api.getPreference({ profile: { userId: "Uabc" } }, res);
+
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.gacha_context.europe_banner_active).toBe(true);
+      expect(payload.gacha_context.costs.europe).toBe(7777);
+    });
+
+    it("falls back to config europe_cost when banner cost is 0/missing", async () => {
+      UserAutoPreference.first.mockResolvedValue(null);
+      SubscriptionService.hasEffect.mockResolvedValue(false);
+      GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([
+        { id: 1, type: "europe", cost: 0, characterIds: [] },
+      ]);
+
+      const res = mockRes();
+      await controller.api.getPreference({ profile: { userId: "Uabc" } }, res);
+
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.gacha_context.europe_banner_active).toBe(true);
+      expect(payload.gacha_context.costs.europe).toBe(10000);
+    });
+
+    it("coerces invalid stored mode value back to 'normal'", async () => {
+      UserAutoPreference.first.mockResolvedValue({
+        user_id: "Uabc",
+        auto_daily_gacha: 1,
+        auto_daily_gacha_mode: "garbage",
         auto_janken_fate: 0,
-        auto_janken_fate_with_bet: 0,
-        entitlements: {
-          auto_daily_gacha: false,
-          auto_janken_fate: false,
-          auto_janken_fate_with_bet: false,
-        },
       });
+      SubscriptionService.hasEffect.mockResolvedValue(true);
+
+      const res = mockRes();
+      await controller.api.getPreference({ profile: { userId: "Uabc" } }, res);
+
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.auto_daily_gacha_mode).toBe("normal");
     });
   });
 
@@ -83,6 +156,7 @@ describe("AutoPreferenceController", () => {
       UserAutoPreference.first.mockResolvedValue({
         user_id: "Uabc",
         auto_daily_gacha: 0,
+        auto_daily_gacha_mode: "normal",
         auto_janken_fate: 0,
       });
     });
@@ -115,11 +189,10 @@ describe("AutoPreferenceController", () => {
 
     it("happy path: entitled + flag=1 → UPSERT with body args, token userId used", async () => {
       SubscriptionService.hasEffect.mockResolvedValue(true);
-      // setPreference only calls UserAutoPreference.first once — after the upsert,
-      // to return the new state. So mock it as the post-upsert snapshot.
       UserAutoPreference.first.mockResolvedValue({
         user_id: "Uabc",
         auto_daily_gacha: 1,
+        auto_daily_gacha_mode: "normal",
         auto_janken_fate: 0,
       });
       const res = mockRes();
@@ -145,6 +218,74 @@ describe("AutoPreferenceController", () => {
       await controller.api.setPreference({ profile: { userId: "Uabc" }, body: {} }, res);
       expect(mysql.raw).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalled();
+    });
+
+    it("accepts valid auto_daily_gacha_mode and persists it via UPSERT", async () => {
+      SubscriptionService.hasEffect.mockResolvedValue(true);
+      UserAutoPreference.first.mockResolvedValue({
+        user_id: "Uabc",
+        auto_daily_gacha: 0,
+        auto_daily_gacha_mode: "ensure",
+        auto_janken_fate: 0,
+      });
+      const res = mockRes();
+      await controller.api.setPreference(
+        { profile: { userId: "Uabc" }, body: { auto_daily_gacha_mode: "ensure" } },
+        res
+      );
+      expect(mysql.raw).toHaveBeenCalledTimes(1);
+      const [sql, args] = mysql.raw.mock.calls[0];
+      // Column order in INSERT is fixed: user_id, auto_daily_gacha, mode, janken, with_bet
+      expect(sql).toMatch(/auto_daily_gacha_mode/);
+      expect(args[2]).toBe("ensure");
+      // COALESCE slot for mode should also carry the new value (not null)
+      expect(args[6]).toBe("ensure");
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.auto_daily_gacha_mode).toBe("ensure");
+    });
+
+    it("rejects unknown mode with 400 invalid_mode", async () => {
+      SubscriptionService.hasEffect.mockResolvedValue(true);
+      const res = mockRes();
+      await controller.api.setPreference(
+        { profile: { userId: "Uabc" }, body: { auto_daily_gacha_mode: "legendary" } },
+        res
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "invalid_mode",
+        field: "auto_daily_gacha_mode",
+      });
+      expect(mysql.raw).not.toHaveBeenCalled();
+    });
+
+    it("mode change does NOT require auto_daily_gacha entitlement (toggle gate already covers it)", async () => {
+      // User dropped their subscription but still sends a mode change while the toggle is 0.
+      SubscriptionService.hasEffect.mockResolvedValue(false);
+      const res = mockRes();
+      await controller.api.setPreference(
+        { profile: { userId: "Uabc" }, body: { auto_daily_gacha_mode: "pickup" } },
+        res
+      );
+      expect(res.status).not.toHaveBeenCalledWith(403);
+      expect(mysql.raw).toHaveBeenCalledTimes(1);
+    });
+
+    it("sending only mode (no flags) still triggers UPSERT and keeps other flags via COALESCE null", async () => {
+      SubscriptionService.hasEffect.mockResolvedValue(true);
+      const res = mockRes();
+      await controller.api.setPreference(
+        { profile: { userId: "Uabc" }, body: { auto_daily_gacha_mode: "europe" } },
+        res
+      );
+      const args = mysql.raw.mock.calls[0][1];
+      // COALESCE null for flags → keep existing values
+      expect(args[5]).toBeNull(); // auto_daily_gacha COALESCE slot
+      expect(args[7]).toBeNull(); // auto_janken_fate COALESCE slot
+      expect(args[8]).toBeNull(); // auto_janken_fate_with_bet COALESCE slot
+      // Mode COALESCE slot must carry the new value
+      expect(args[6]).toBe("europe");
+      void res;
     });
   });
 

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -166,6 +166,44 @@ describe("AchievementEngine", () => {
       expect(result.unlocked[0].key).toBe("chat_100");
     });
 
+    it("credits reward_stones via a single INSERT row (never UPDATE across existing rows)", async () => {
+      const achievement = {
+        id: 2,
+        key: "chat_100",
+        target_value: 100,
+        reward_stones: 50,
+        notify_on_unlock: false,
+        notify_message: null,
+        condition: null,
+      };
+      AchievementEngine._setCache([achievement]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgress.mockResolvedValue({ current_value: 99 });
+      UserProgressModel.upsert.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue();
+      UserProgressModel.delete.mockResolvedValue();
+      const insert = jest.fn().mockResolvedValue();
+      const update = jest.fn().mockResolvedValue(99);
+      mysql.mockImplementationOnce(() => ({
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue({ ID: 42, itemAmount: 1000 }),
+        insert,
+        update,
+      }));
+
+      await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      expect(insert).toHaveBeenCalledTimes(1);
+      expect(insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user1",
+          itemId: 999,
+          itemAmount: 50,
+        })
+      );
+      expect(update).not.toHaveBeenCalled();
+    });
+
     it("returns { unlocked: [] } when inner error is swallowed", async () => {
       AchievementEngine._setCache([
         {

--- a/app/bin/AutoGacha.js
+++ b/app/bin/AutoGacha.js
@@ -4,6 +4,10 @@ const mysql = require("../src/util/mysql");
 const { DefaultLogger } = require("../src/util/Logger");
 const GachaService = require("../src/service/GachaService");
 const SubscriptionService = require("../src/service/SubscriptionService");
+const GachaModel = require("../src/model/princess/gacha");
+const GachaBanner = require("../src/model/princess/GachaBanner");
+
+const VALID_MODES = ["normal", "pickup", "ensure", "europe"];
 
 let running = false;
 
@@ -26,8 +30,14 @@ async function run() {
   const targets = await impl.loadTargets();
   DefaultLogger.info(`cron.auto_gacha.start target_count=${targets.length}`);
 
+  // Fetch the active europe banner once per batch. A single query beats
+  // re-fetching per user; banner state is stable across a run.
+  const europeBanners = await GachaBanner.getActiveBannersWithCharacters({ type: "europe" });
+  const activeEuropeBanner = europeBanners && europeBanners.length > 0 ? europeBanners[0] : null;
+  const context = { activeEuropeBanner };
+
   const counters = { success: 0, failed: 0, skipped: 0 };
-  await impl.runBatched(targets, concurrency, t => impl.drawForUser(t, runDate, counters));
+  await impl.runBatched(targets, concurrency, t => impl.drawForUser(t, runDate, counters, context));
 
   const durationMs = Date.now() - start;
   DefaultLogger.info(
@@ -40,6 +50,7 @@ async function run() {
 /**
  * 找出今晚代抽的目標使用者：有效訂閱 + 卡包含 auto_daily_gacha effect +
  * user_auto_preference.auto_daily_gacha=1 + 今日尚未抽過。
+ * 一併帶出 auto_daily_gacha_mode 供 drawForUser 使用。
  */
 async function loadTargets() {
   const now = new Date();
@@ -59,18 +70,67 @@ async function loadTargets() {
     .where("uap.auto_daily_gacha", 1)
     .whereNull("gr.id")
     .whereRaw("JSON_SEARCH(sc.effects, 'one', 'auto_daily_gacha', NULL, '$[*].type') IS NOT NULL")
-    .select("su.user_id", "sc.key as card_key")
+    .select("su.user_id", "sc.key as card_key", "uap.auto_daily_gacha_mode")
     .distinct();
 
   return rows;
 }
 
-async function drawForUser(target, runDate, counters) {
+/**
+ * Cost per 10-pull for the selected mode. Europe mirrors the
+ * GachaService.resolveCost precedence: use banner.cost when > 0, otherwise
+ * the config default.
+ */
+function costForMode(mode, activeEuropeBanner) {
+  switch (mode) {
+    case "pickup":
+      return config.get("gacha.pick_up_cost");
+    case "ensure":
+      return config.get("gacha.ensure_cost");
+    case "europe":
+      return activeEuropeBanner && activeEuropeBanner.cost > 0
+        ? activeEuropeBanner.cost
+        : config.get("gacha.europe_cost");
+    case "normal":
+    default:
+      return 0;
+  }
+}
+
+function optsForMode(mode) {
+  switch (mode) {
+    case "pickup":
+      return { pickup: true };
+    case "ensure":
+      return { ensure: true };
+    case "europe":
+      return { europe: true };
+    case "normal":
+    default:
+      return {};
+  }
+}
+
+function normalizeMode(raw) {
+  return VALID_MODES.includes(raw) ? raw : "normal";
+}
+
+async function drawForUser(target, runDate, counters, context = {}) {
   const userId = target.user_id;
   const perStart = Date.now();
+  const activeEuropeBanner = context.activeEuropeBanner || null;
+  const requestedMode = normalizeMode(target.auto_daily_gacha_mode);
+
+  // europe is period-limited: without an active europe banner, degrade the
+  // whole day to normal (matches controller-level behaviour for /抽 歐派).
+  let workingMode = requestedMode;
+  let fallbackReason = null;
+  if (requestedMode === "europe" && !activeEuropeBanner) {
+    workingMode = "normal";
+    fallbackReason = "europe_unavailable";
+  }
 
   try {
-    // Explicit re-check: subscription may have expired between loadTargets and now
     const stillActive = await SubscriptionService.hasEffect(userId, "auto_daily_gacha");
     if (!stillActive) {
       counters.skipped++;
@@ -82,9 +142,6 @@ async function drawForUser(target, runDate, counters) {
       });
     }
 
-    // Quota gate: subscribers get base + gacha_times bonus pulls per day. Cron
-    // must deliver the full remaining quota so we don't short-change month/season
-    // card holders compared to the manual `/抽` path.
     const quota = await GachaService.getRemainingDailyQuota(userId);
     if (quota.remaining === 0) {
       counters.skipped++;
@@ -97,15 +154,36 @@ async function drawForUser(target, runDate, counters) {
     }
 
     const aggregated = emptyAggregate();
+    const breakdown = { normal: 0, pickup: 0, ensure: 0, europe: 0 };
+    const modeCost = costForMode(workingMode, activeEuropeBanner);
+
     for (let i = 0; i < quota.remaining; i++) {
-      const result = await GachaService.runDailyDraw(userId);
+      let roundMode = workingMode;
+      if (modeCost > 0) {
+        // Re-read balance before each round — prior rounds (and any concurrent
+        // manual /抽) will have updated the stone count.
+        const stoneRaw = await GachaModel.getUserGodStoneCount(userId);
+        const stone = parseInt(stoneRaw) || 0;
+        if (stone < modeCost) {
+          roundMode = "normal";
+          if (!fallbackReason) fallbackReason = "insufficient_stone";
+        }
+      }
+
+      const result = await GachaService.runDailyDraw(userId, optsForMode(roundMode));
       accumulate(aggregated, result);
+      breakdown[roundMode]++;
     }
+
     counters.success++;
     return upsertLog(userId, runDate, {
       status: "success",
       pulls_made: aggregated.rewards.length,
-      reward_summary: summarizeAggregate(aggregated, quota),
+      reward_summary: summarizeAggregate(aggregated, quota, {
+        modeRequested: requestedMode,
+        breakdown,
+        fallbackReason,
+      }),
       error: null,
       duration_ms: Date.now() - perStart,
     });
@@ -145,8 +223,8 @@ function accumulate(agg, result) {
   }
 }
 
-function summarizeAggregate(agg, quota) {
-  return {
+function summarizeAggregate(agg, quota, modeMeta = {}) {
+  const summary = {
     rareCount: agg.rareCount,
     newCharactersCount: agg.newCharactersCount,
     godStoneCost: agg.godStoneCost,
@@ -154,6 +232,16 @@ function summarizeAggregate(agg, quota) {
     rounds: quota.remaining,
     quota_total: quota.total,
   };
+  if (modeMeta.modeRequested !== undefined) {
+    summary.mode_requested = modeMeta.modeRequested;
+  }
+  if (modeMeta.breakdown) {
+    summary.mode_breakdown = modeMeta.breakdown;
+  }
+  if (modeMeta.fallbackReason !== undefined) {
+    summary.fallback_reason = modeMeta.fallbackReason;
+  }
+  return summary;
 }
 
 function summarizeRewards(result) {
@@ -210,6 +298,8 @@ module.exports.drawForUser = drawForUser;
 module.exports.runBatched = runBatched;
 module.exports.summarizeRewards = summarizeRewards;
 module.exports.upsertLog = upsertLog;
+module.exports.costForMode = costForMode;
+module.exports.optsForMode = optsForMode;
 
 if (require.main === module) {
   main().then(() => process.exit(0));

--- a/app/bin/AutoGacha.js
+++ b/app/bin/AutoGacha.js
@@ -30,8 +30,8 @@ async function run() {
   const targets = await impl.loadTargets();
   DefaultLogger.info(`cron.auto_gacha.start target_count=${targets.length}`);
 
-  // Fetch the active europe banner once per batch. A single query beats
-  // re-fetching per user; banner state is stable across a run.
+  // Fetch once per batch — banner state is stable across a run, so per-user
+  // re-fetches would be pure overhead.
   const europeBanners = await GachaBanner.getActiveBannersWithCharacters({ type: "europe" });
   const activeEuropeBanner = europeBanners && europeBanners.length > 0 ? europeBanners[0] : null;
   const context = { activeEuropeBanner };
@@ -76,25 +76,13 @@ async function loadTargets() {
   return rows;
 }
 
-/**
- * Cost per 10-pull for the selected mode. Europe mirrors the
- * GachaService.resolveCost precedence: use banner.cost when > 0, otherwise
- * the config default.
- */
 function costForMode(mode, activeEuropeBanner) {
-  switch (mode) {
-    case "pickup":
-      return config.get("gacha.pick_up_cost");
-    case "ensure":
-      return config.get("gacha.ensure_cost");
-    case "europe":
-      return activeEuropeBanner && activeEuropeBanner.cost > 0
-        ? activeEuropeBanner.cost
-        : config.get("gacha.europe_cost");
-    case "normal":
-    default:
-      return 0;
-  }
+  return GachaService.resolveCost(
+    mode === "pickup",
+    mode === "ensure",
+    mode === "europe",
+    activeEuropeBanner
+  ).amount;
 }
 
 function optsForMode(mode) {
@@ -122,7 +110,7 @@ async function drawForUser(target, runDate, counters, context = {}) {
   const requestedMode = normalizeMode(target.auto_daily_gacha_mode);
 
   // europe is period-limited: without an active europe banner, degrade the
-  // whole day to normal (matches controller-level behaviour for /抽 歐派).
+  // whole day to normal (matches controller-level behaviour for /歐洲抽).
   let workingMode = requestedMode;
   let fallbackReason = null;
   if (requestedMode === "europe" && !activeEuropeBanner) {

--- a/app/migrations/20260419110722_add_auto_daily_gacha_mode.js
+++ b/app/migrations/20260419110722_add_auto_daily_gacha_mode.js
@@ -1,0 +1,26 @@
+/**
+ * 為 user_auto_preference 新增自動抽卡的模式選擇。
+ * 現行 auto_daily_gacha 仍是總開關；mode 決定開關打開時實際執行哪種抽卡路徑。
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("user_auto_preference", function (table) {
+    table
+      .enum("auto_daily_gacha_mode", ["normal", "pickup", "ensure", "europe"])
+      .notNullable()
+      .defaultTo("normal")
+      .comment("自動抽卡模式：normal 普通 / pickup 機率調升 / ensure 保證 / europe 歐派");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("user_auto_preference", function (table) {
+    table.dropColumn("auto_daily_gacha_mode");
+  });
+};

--- a/app/src/controller/application/AutoPreferenceController.js
+++ b/app/src/controller/application/AutoPreferenceController.js
@@ -1,7 +1,11 @@
 const { get } = require("lodash");
+const config = require("config");
 const mysql = require("../../util/mysql");
 const UserAutoPreference = require("../../model/application/UserAutoPreference");
 const SubscriptionService = require("../../service/SubscriptionService");
+const GachaService = require("../../service/GachaService");
+const GachaModel = require("../../model/princess/gacha");
+const GachaBanner = require("../../model/princess/GachaBanner");
 const commonTemplate = require("../../templates/common");
 const { DefaultLogger } = require("../../util/Logger");
 
@@ -13,6 +17,7 @@ const FLAG_EFFECT = {
   auto_janken_fate: "auto_janken_fate",
   auto_janken_fate_with_bet: "auto_janken_fate",
 };
+const VALID_MODES = ["normal", "pickup", "ensure", "europe"];
 const HISTORY_DEFAULT_LIMIT = 30;
 const HISTORY_MAX_LIMIT = 100;
 
@@ -30,10 +35,41 @@ async function loadEntitlements(userId) {
 
 async function loadPreference(userId) {
   const row = await UserAutoPreference.first({ filter: { user_id: userId } });
+  const mode =
+    row && VALID_MODES.includes(row.auto_daily_gacha_mode) ? row.auto_daily_gacha_mode : "normal";
   return {
     auto_daily_gacha: row && row.auto_daily_gacha === 1 ? 1 : 0,
+    auto_daily_gacha_mode: mode,
     auto_janken_fate: row && row.auto_janken_fate === 1 ? 1 : 0,
     auto_janken_fate_with_bet: row && row.auto_janken_fate_with_bet === 1 ? 1 : 0,
+  };
+}
+
+/**
+ * 前端 AutoSettings 需要用來估算「依目前模式與配額，今晚大概會花多少女神石」。
+ * 一併回傳歐派活動是否進行中 — 無活動時前端要把 europe 選項灰階。
+ */
+async function loadGachaContext(userId) {
+  const [stoneRaw, quota, europeBanners] = await Promise.all([
+    GachaModel.getUserGodStoneCount(userId),
+    GachaService.getRemainingDailyQuota(userId),
+    GachaBanner.getActiveBannersWithCharacters({ type: "europe" }),
+  ]);
+  const activeEuropeBanner = europeBanners && europeBanners.length > 0 ? europeBanners[0] : null;
+  const europeCost =
+    activeEuropeBanner && activeEuropeBanner.cost > 0
+      ? activeEuropeBanner.cost
+      : config.get("gacha.europe_cost");
+  return {
+    stone_balance: parseInt(stoneRaw) || 0,
+    daily_quota: quota,
+    costs: {
+      normal: 0,
+      pickup: config.get("gacha.pick_up_cost"),
+      ensure: config.get("gacha.ensure_cost"),
+      europe: europeCost,
+    },
+    europe_banner_active: Boolean(activeEuropeBanner),
   };
 }
 
@@ -44,11 +80,12 @@ exports.api.getPreference = async (req, res) => {
     const userId = get(req, "profile.userId");
     if (!userId) return res.status(401).json({ error: "unauthenticated" });
 
-    const [preference, entitlements] = await Promise.all([
+    const [preference, entitlements, gachaContext] = await Promise.all([
       loadPreference(userId),
       loadEntitlements(userId),
+      loadGachaContext(userId),
     ]);
-    return res.json({ ...preference, entitlements });
+    return res.json({ ...preference, entitlements, gacha_context: gachaContext });
   } catch (err) {
     DefaultLogger.error(`auto-preference.get failed: ${err && err.message}`);
     return res.status(500).json({ error: "internal_error" });
@@ -67,10 +104,20 @@ exports.api.setPreference = async (req, res) => {
       const v = body[flag] === true || body[flag] === 1 || body[flag] === "1" ? 1 : 0;
       update[flag] = v;
     }
-    if (Object.keys(update).length === 0) {
-      const preference = await loadPreference(userId);
-      const entitlements = await loadEntitlements(userId);
-      return res.json({ ...preference, entitlements });
+    let modeUpdate;
+    if (body.auto_daily_gacha_mode !== undefined && body.auto_daily_gacha_mode !== null) {
+      if (!VALID_MODES.includes(body.auto_daily_gacha_mode)) {
+        return res.status(400).json({ error: "invalid_mode", field: "auto_daily_gacha_mode" });
+      }
+      modeUpdate = body.auto_daily_gacha_mode;
+    }
+    if (Object.keys(update).length === 0 && modeUpdate === undefined) {
+      const [preference, entitlements, gachaContext] = await Promise.all([
+        loadPreference(userId),
+        loadEntitlements(userId),
+        loadGachaContext(userId),
+      ]);
+      return res.json({ ...preference, entitlements, gacha_context: gachaContext });
     }
 
     const entitlements = await loadEntitlements(userId);
@@ -82,25 +129,31 @@ exports.api.setPreference = async (req, res) => {
 
     await mysql.raw(
       `INSERT INTO user_auto_preference
-        (user_id, auto_daily_gacha, auto_janken_fate, auto_janken_fate_with_bet)
-       VALUES (?, ?, ?, ?)
+        (user_id, auto_daily_gacha, auto_daily_gacha_mode, auto_janken_fate, auto_janken_fate_with_bet)
+       VALUES (?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          auto_daily_gacha = COALESCE(?, auto_daily_gacha),
+         auto_daily_gacha_mode = COALESCE(?, auto_daily_gacha_mode),
          auto_janken_fate = COALESCE(?, auto_janken_fate),
          auto_janken_fate_with_bet = COALESCE(?, auto_janken_fate_with_bet)`,
       [
         userId,
         update.auto_daily_gacha === undefined ? 0 : update.auto_daily_gacha,
+        modeUpdate === undefined ? "normal" : modeUpdate,
         update.auto_janken_fate === undefined ? 0 : update.auto_janken_fate,
         update.auto_janken_fate_with_bet === undefined ? 0 : update.auto_janken_fate_with_bet,
         update.auto_daily_gacha === undefined ? null : update.auto_daily_gacha,
+        modeUpdate === undefined ? null : modeUpdate,
         update.auto_janken_fate === undefined ? null : update.auto_janken_fate,
         update.auto_janken_fate_with_bet === undefined ? null : update.auto_janken_fate_with_bet,
       ]
     );
 
-    const preference = await loadPreference(userId);
-    return res.json({ ...preference, entitlements });
+    const [preference, gachaContext] = await Promise.all([
+      loadPreference(userId),
+      loadGachaContext(userId),
+    ]);
+    return res.json({ ...preference, entitlements, gacha_context: gachaContext });
   } catch (err) {
     DefaultLogger.error(`auto-preference.put failed: ${err && err.message}`);
     return res.status(500).json({ error: "internal_error" });
@@ -209,5 +262,7 @@ exports.showAutoSettings = async function (context) {
 exports._internal = {
   loadEntitlements,
   loadPreference,
+  loadGachaContext,
   parseJsonSafe,
+  VALID_MODES,
 };

--- a/app/src/controller/application/AutoPreferenceController.js
+++ b/app/src/controller/application/AutoPreferenceController.js
@@ -1,5 +1,4 @@
 const { get } = require("lodash");
-const config = require("config");
 const mysql = require("../../util/mysql");
 const UserAutoPreference = require("../../model/application/UserAutoPreference");
 const SubscriptionService = require("../../service/SubscriptionService");
@@ -47,7 +46,7 @@ async function loadPreference(userId) {
 
 /**
  * 前端 AutoSettings 需要用來估算「依目前模式與配額，今晚大概會花多少女神石」。
- * 一併回傳歐派活動是否進行中 — 無活動時前端要把 europe 選項灰階。
+ * 一併回傳歐洲活動是否進行中 — 無活動時前端要把 europe 選項灰階。
  */
 async function loadGachaContext(userId) {
   const [stoneRaw, quota, europeBanners] = await Promise.all([
@@ -56,18 +55,14 @@ async function loadGachaContext(userId) {
     GachaBanner.getActiveBannersWithCharacters({ type: "europe" }),
   ]);
   const activeEuropeBanner = europeBanners && europeBanners.length > 0 ? europeBanners[0] : null;
-  const europeCost =
-    activeEuropeBanner && activeEuropeBanner.cost > 0
-      ? activeEuropeBanner.cost
-      : config.get("gacha.europe_cost");
   return {
     stone_balance: parseInt(stoneRaw) || 0,
     daily_quota: quota,
     costs: {
       normal: 0,
-      pickup: config.get("gacha.pick_up_cost"),
-      ensure: config.get("gacha.ensure_cost"),
-      europe: europeCost,
+      pickup: GachaService.resolveCost(true, false, false, null).amount,
+      ensure: GachaService.resolveCost(false, true, false, null).amount,
+      europe: GachaService.resolveCost(false, false, true, activeEuropeBanner).amount,
     },
     europe_banner_active: Boolean(activeEuropeBanner),
   };

--- a/app/src/model/application/UserAutoPreference.js
+++ b/app/src/model/application/UserAutoPreference.js
@@ -4,5 +4,11 @@ class UserAutoPreference extends base {}
 
 module.exports = new UserAutoPreference({
   table: "user_auto_preference",
-  fillable: ["user_id", "auto_daily_gacha", "auto_janken_fate", "auto_janken_fate_with_bet"],
+  fillable: [
+    "user_id",
+    "auto_daily_gacha",
+    "auto_daily_gacha_mode",
+    "auto_janken_fate",
+    "auto_janken_fate_with_bet",
+  ],
 });

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -250,20 +250,15 @@ async function unlockAchievement(userId, achievement) {
   await UserProgressModel.delete(userId, achievement.id);
 
   if (achievement.reward_stones > 0) {
-    const existing = await mysql("Inventory")
-      .where({ userId, itemId: GODDESS_STONE_ITEM_ID })
-      .first();
-    if (existing) {
-      await mysql("Inventory")
-        .where({ userId, itemId: GODDESS_STONE_ITEM_ID })
-        .update({ itemAmount: mysql.raw("itemAmount + ?", [achievement.reward_stones]) });
-    } else {
-      await mysql("Inventory").insert({
-        userId,
-        itemId: GODDESS_STONE_ITEM_ID,
-        itemAmount: achievement.reward_stones,
-      });
-    }
+    // Append a new ledger row — balance is SUM(itemAmount) across rows.
+    // The prior UPDATE-without-row-ID version multiplied the reward by the
+    // user's existing row count (see project_stone_ledger_refactor memo).
+    await mysql("Inventory").insert({
+      userId,
+      itemId: GODDESS_STONE_ITEM_ID,
+      itemAmount: achievement.reward_stones,
+      note: "成就獎勵",
+    });
   }
 
   DefaultLogger.info(

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -126,7 +126,7 @@ function computeRepeatReward(uniqRewards, duplicateItems) {
  * @param {string} [opts.tag]       轉蛋池標籤（undefined 即為預設公主池）
  * @param {boolean} [opts.pickup]   祈願（花費女神石提升彩率）
  * @param {boolean} [opts.ensure]   保證（最後一抽必彩）
- * @param {boolean} [opts.europe]   歐派（只彩池）
+ * @param {boolean} [opts.europe]   歐洲（只彩池）
  * @returns {Promise<{
  *   rewards: Array,
  *   rareCount: Object,
@@ -307,4 +307,5 @@ async function getRemainingDailyQuota(userId) {
 module.exports = {
   runDailyDraw,
   getRemainingDailyQuota,
+  resolveCost,
 };

--- a/docs/plans/2026-04-19-auto-gacha-mode-selection.md
+++ b/docs/plans/2026-04-19-auto-gacha-mode-selection.md
@@ -1,0 +1,121 @@
+# AutoGacha Mode Selection — Plan
+
+Branch: `feat/auto-gacha-mode`
+
+Extend the nightly auto-gacha cron so month/season-card subscribers can pick
+_which_ draw mode the cron runs on their behalf, instead of always running the
+free "normal" path.
+
+## Current state (baseline)
+
+- `user_auto_preference.auto_daily_gacha` is a boolean toggle only.
+- `AutoGacha.drawForUser` calls `GachaService.runDailyDraw(userId)` with no
+  opts → always produces the free _normal_ 10-pull.
+- `runDailyDraw` already supports `{ pickup, ensure, europe }` opts (mutually
+  exclusive). Each option costs godstones per 10-pull:
+  - `pickup` → `gacha.pick_up_cost` (1500)
+  - `ensure` → `gacha.ensure_cost`  (3000)
+  - `europe` → `gacha.europe_cost`  (10000) _or_ `activeEuropeBanner.cost` when set
+- `rate_up` banners are pool-level and stack freely with any mode.
+- `europe` is **period-limited** — `controller/princess/gacha.js` blocks the
+  command when `europeBanners.length === 0`; `GachaService` itself does not
+  re-check, so the cron is responsible for this guard.
+
+## Design decisions (already agreed)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Mode storage shape | Single `ENUM('normal','pickup','ensure','europe')` column, default `normal` |
+| 2 | Behaviour when stone balance < full-day cost | Best-effort per 10-pull: run requested mode while affordable, fall back to `normal` for the remaining quota slots. Record `mode_breakdown` + `fallback_reason` in `reward_summary` |
+| 3 | Expose `pickup` too? | Yes — rate_up banner stacks regardless; pickup cost is always active |
+| 4 | Preference read timing | At cron execution time (23:50 local) — current behaviour, no change |
+| 5 | Frontend UX | Show estimated daily cost per mode (cost × remaining quota). Non-blocking warning when projected cost > stone balance. Do **not** block the save |
+| 6 | Stone check granularity | Re-read stone balance before each 10-pull (handles concurrent manual draws) |
+| 7 | `europe` with no active banner | Downgrade whole day to `normal`, flag `fallback_reason: europe_unavailable` |
+
+## Rollout: 3 PRs
+
+### PR 1 — Schema + API (this doc's starting point)
+
+Branch `feat/auto-gacha-mode`. Safe to deploy independently: cron still only
+runs `normal` until PR 2 lands, so the new `auto_daily_gacha_mode` column is
+read-but-inert.
+
+- Migration `20260419110722_add_auto_daily_gacha_mode.js`:
+  `user_auto_preference.auto_daily_gacha_mode ENUM('normal','pickup','ensure','europe') NOT NULL DEFAULT 'normal'`
+- `UserAutoPreference.fillable` gains `auto_daily_gacha_mode`
+- `AutoPreferenceController`:
+  - `VALID_MODES` constant + validation in `setPreference` (400 on bad mode)
+  - `loadPreference` returns `auto_daily_gacha_mode` (coerces invalid values to
+    `normal`)
+  - `loadGachaContext(userId)` adds `stone_balance`, `daily_quota`, per-mode
+    `costs`, and `europe_banner_active` to `getPreference` / `setPreference`
+    response — this is what the frontend needs to render the cost estimate
+    without a second round trip
+- Mode change requires **no** extra entitlement (the `auto_daily_gacha` toggle
+  gate already covers subscription status)
+- Tests: 14 new + existing cases in `__tests__/controller/AutoPreferenceController.test.js`
+
+### PR 2 — Cron integration
+
+Teach `app/bin/AutoGacha.js` to act on the mode.
+
+- `loadTargets` SELECTs `uap.auto_daily_gacha_mode` into each row
+- Before the per-user loop, batch-fetch active europe banner once (shared across
+  the batch — avoids one banner query per user)
+- `drawForUser` rewrite:
+  ```
+  mode = target.auto_daily_gacha_mode
+  if mode == 'europe' && no active europe banner:
+      fallback_reason = 'europe_unavailable'; mode = 'normal'
+
+  breakdown = { normal:0, pickup:0, ensure:0, europe:0 }
+  for i in 0..quota.remaining:
+      stone = GachaModel.getUserGodStoneCount(userId)  # re-read: prior loop iteration may have spent
+      cost = costForMode(mode)
+      if cost == 0 || stone >= cost:
+          runDailyDraw(userId, toOpts(mode));  breakdown[mode]++
+      else:
+          runDailyDraw(userId);  breakdown.normal++
+          fallback_reason ||= 'insufficient_stone'
+  ```
+- Extend `reward_summary` JSON with `mode_requested`, `mode_breakdown`,
+  `fallback_reason`
+- Tests in `__tests__/bin/AutoGacha.test.js` cover:
+  - each mode × sufficient stones
+  - ensure × stones only cover 1 of 2 rounds → `{ensure:1, normal:1}` +
+    `insufficient_stone`
+  - europe × no active banner → all normal + `europe_unavailable`
+  - mode field propagates through `loadTargets`
+
+### PR 3 — Frontend AutoSettings UI
+
+`frontend/src/pages/AutoSettings/index.jsx`:
+
+- Under the "自動抽卡" toggle, render a `RadioGroup` of modes (disabled when
+  toggle is off)
+- For each mode row, render `每次 N 石 × 今日 K 次 = 預估 NK 石`
+  (K = `gacha_context.daily_quota.total`, N = `gacha_context.costs[mode]`)
+- When `gacha_context.europe_banner_active === false`, show europe option with
+  a grey "歐派期間限定，目前無活動，將視為普通抽" tooltip (still selectable,
+  cron handles fallback)
+- When `estimate_for_selected_mode > gacha_context.stone_balance`, show an
+  amber inline hint: `目前女神石不足以完成全天 K 次，執行時不足會自動降為普通抽`
+  — non-blocking, no save-disable
+- Stone balance + quota fetch once on page load; add a manual "重新整理" button
+- History list rows show mode badge when `summary.reward_summary.mode_breakdown`
+  is present; show red tooltip for `fallback_reason`
+
+## Risks & notes
+
+- **Cost drift**: costs come from `config.get('gacha.*')`. Frontend must pull
+  them from `gacha_context` (not a hard-coded mirror). PR 1 already wires this.
+- **Banner cost 0**: `activeEuropeBanner.cost === 0` is treated as "no override"
+  and falls back to `config.gacha.europe_cost` — mirrors the existing
+  `resolveCost` behaviour in `GachaService`.
+- **Concurrent /抽 on cron night**: stone re-read per iteration handles this
+  best-effort; if user burns stones between cron's quota computation and draw,
+  worst case a slot falls back to `normal`. Documented, not blocking.
+- **Quota reduction between loads**: `runDailyDraw` does not re-check quota
+  internally — same risk exists today on the `normal` path, so not a
+  regression.

--- a/frontend/src/pages/AutoHistory/index.jsx
+++ b/frontend/src/pages/AutoHistory/index.jsx
@@ -1,11 +1,34 @@
 import { useEffect, useMemo, useState } from "react";
-import { Box, Card, CardContent, Chip, Paper, Skeleton, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Paper,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import CasinoIcon from "@mui/icons-material/Casino";
 import SportsMmaIcon from "@mui/icons-material/SportsMma";
 import HistoryIcon from "@mui/icons-material/History";
+import ReportProblemIcon from "@mui/icons-material/ReportProblem";
 import AlertLogin from "../../components/AlertLogin";
 import useLiff from "../../context/useLiff";
 import { getHistory } from "../../services/autoPreference";
+
+const MODE_LABEL = {
+  normal: "普通",
+  pickup: "機率調升",
+  ensure: "保證",
+  europe: "歐派",
+};
+
+const FALLBACK_LABEL = {
+  europe_unavailable: "歐派活動結束，已改為普通抽。",
+  insufficient_stone: "女神石不足，部份輪次改為普通抽。",
+};
 
 function formatDay(iso) {
   if (!iso) return "";
@@ -54,6 +77,48 @@ function summaryText(item) {
   return "";
 }
 
+/**
+ * Render a compact mode breakdown like `保證 ×1 + 普通 ×1`. Returns null
+ * when the log predates the mode feature (no breakdown recorded).
+ */
+function formatModeBreakdown(breakdown) {
+  if (!breakdown || typeof breakdown !== "object") return null;
+  const entries = Object.entries(breakdown).filter(([, n]) => Number(n) > 0);
+  if (entries.length === 0) return null;
+  return entries.map(([mode, n]) => `${MODE_LABEL[mode] || mode} ×${n}`).join(" + ");
+}
+
+function GachaModeBadge({ summary }) {
+  const reward = summary?.reward_summary;
+  const breakdown = formatModeBreakdown(reward?.mode_breakdown);
+  const fallback = reward?.fallback_reason;
+  if (!breakdown && !fallback) return null;
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.25 }}>
+      {breakdown && (
+        <Chip
+          size="small"
+          variant="outlined"
+          label={breakdown}
+          sx={{ fontSize: "0.7rem", height: 20 }}
+        />
+      )}
+      {fallback && (
+        <Tooltip title={FALLBACK_LABEL[fallback] || fallback} arrow>
+          <Chip
+            size="small"
+            color="warning"
+            variant="outlined"
+            icon={<ReportProblemIcon sx={{ fontSize: "0.85rem !important" }} />}
+            label="降級"
+            sx={{ fontSize: "0.7rem", height: 20 }}
+          />
+        </Tooltip>
+      )}
+    </Stack>
+  );
+}
+
 function HistoryItemCard({ item }) {
   const Icon = item.type === "gacha" ? CasinoIcon : SportsMmaIcon;
   return (
@@ -68,6 +133,7 @@ function HistoryItemCard({ item }) {
             <Typography variant="caption" color="text.secondary">
               {summaryText(item)}
             </Typography>
+            {item.type === "gacha" && <GachaModeBadge summary={item.summary} />}
           </Box>
           <Chip
             size="small"

--- a/frontend/src/pages/AutoHistory/index.jsx
+++ b/frontend/src/pages/AutoHistory/index.jsx
@@ -20,13 +20,13 @@ import { getHistory } from "../../services/autoPreference";
 
 const MODE_LABEL = {
   normal: "普通",
-  pickup: "機率調升",
+  pickup: "消耗抽",
   ensure: "保證",
-  europe: "歐派",
+  europe: "歐洲",
 };
 
 const FALLBACK_LABEL = {
-  europe_unavailable: "歐派活動結束，已改為普通抽。",
+  europe_unavailable: "歐洲活動結束，已改為普通抽。",
   insufficient_stone: "女神石不足，部份輪次改為普通抽。",
 };
 

--- a/frontend/src/pages/AutoSettings/index.jsx
+++ b/frontend/src/pages/AutoSettings/index.jsx
@@ -7,16 +7,24 @@ import {
   Card,
   CardContent,
   Chip,
+  Divider,
+  FormControlLabel,
+  IconButton,
   Paper,
+  Radio,
+  RadioGroup,
   Skeleton,
   Snackbar,
   Stack,
   Switch,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import HistoryIcon from "@mui/icons-material/History";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import AlertLogin from "../../components/AlertLogin";
 import useLiff from "../../context/useLiff";
 import { getPreference, setPreference } from "../../services/autoPreference";
@@ -40,6 +48,33 @@ const FLAGS = [
     dependsOn: "auto_janken_fate",
   },
 ];
+
+const MODE_OPTIONS = [
+  {
+    value: "normal",
+    label: "普通抽",
+    description: "不花費女神石，直接抽今日公主池。",
+  },
+  {
+    value: "pickup",
+    label: "機率調升（祈願）",
+    description: "提升限定角色中獎機率。",
+  },
+  {
+    value: "ensure",
+    label: "保證抽",
+    description: "最後一抽保證為三星。",
+  },
+  {
+    value: "europe",
+    label: "歐派抽（只彩池）",
+    description: "整池僅保留三星角色。期間限定。",
+  },
+];
+
+function formatStones(n) {
+  return Number(n || 0).toLocaleString("en-US");
+}
 
 function ToggleRow({ flag, value, entitled, disabled, onChange }) {
   const locked = !entitled;
@@ -77,10 +112,98 @@ function ToggleRow({ flag, value, entitled, disabled, onChange }) {
   );
 }
 
+/**
+ * Mode selector for the auto_daily_gacha feature. Renders cost estimates using
+ * gacha_context from the backend so we never drift from config defaults.
+ * Non-blocking: users can pick a mode they can't fully afford; the cron will
+ * fall back to normal for rounds they can't cover.
+ */
+function GachaModeSelector({ mode, context, disabled, onChange }) {
+  const costs = context?.costs || { normal: 0, pickup: 0, ensure: 0, europe: 0 };
+  const quotaTotal = context?.daily_quota?.total || 0;
+  const stoneBalance = context?.stone_balance || 0;
+  const europeActive = Boolean(context?.europe_banner_active);
+
+  const currentPerPull = costs[mode] || 0;
+  const currentEstimate = currentPerPull * quotaTotal;
+  const insufficient = currentEstimate > stoneBalance;
+
+  return (
+    <Card>
+      <CardContent>
+        <Stack spacing={1.5}>
+          <Box>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+              抽卡模式
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              今日預估配額 {quotaTotal} 次；女神石餘額 {formatStones(stoneBalance)} 顆。
+            </Typography>
+          </Box>
+          <Divider />
+          <RadioGroup value={mode} onChange={e => onChange(e.target.value)} sx={{ gap: 0.5 }}>
+            {MODE_OPTIONS.map(opt => {
+              const perPull = costs[opt.value] || 0;
+              const estimate = perPull * quotaTotal;
+              const isEurope = opt.value === "europe";
+              const europeUnavailable = isEurope && !europeActive;
+              return (
+                <FormControlLabel
+                  key={opt.value}
+                  value={opt.value}
+                  disabled={disabled}
+                  control={<Radio size="small" />}
+                  sx={{ alignItems: "flex-start", m: 0, py: 0.75 }}
+                  label={
+                    <Box sx={{ ml: 0.5 }}>
+                      <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap">
+                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                          {opt.label}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {perPull === 0
+                            ? "免費"
+                            : `每次 ${formatStones(perPull)} 石 × ${quotaTotal} 次 ≈ ${formatStones(estimate)} 石`}
+                        </Typography>
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary" display="block">
+                        {opt.description}
+                      </Typography>
+                      {europeUnavailable && (
+                        <Typography
+                          variant="caption"
+                          sx={{ color: "warning.main", mt: 0.25, display: "block" }}
+                        >
+                          目前無歐派活動，選擇後會自動視為普通抽。
+                        </Typography>
+                      )}
+                    </Box>
+                  }
+                />
+              );
+            })}
+          </RadioGroup>
+          {insufficient && currentPerPull > 0 && (
+            <Alert
+              severity="warning"
+              icon={<WarningAmberIcon fontSize="inherit" />}
+              sx={{ py: 0.5 }}
+            >
+              目前女神石不足以完成全天 {quotaTotal} 次（需要 {formatStones(currentEstimate)} 顆）。
+              執行時不足會自動降為普通抽。
+            </Alert>
+          )}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
 function SettingsSkeleton() {
   return (
     <Stack spacing={2}>
       <Skeleton variant="rounded" height={96} animation="wave" />
+      <Skeleton variant="rounded" height={180} animation="wave" />
       <Skeleton variant="rounded" height={96} animation="wave" />
     </Stack>
   );
@@ -92,6 +215,7 @@ export default function AutoSettings() {
   const [saving, setSaving] = useState(false);
   const [state, setState] = useState({
     auto_daily_gacha: 0,
+    auto_daily_gacha_mode: "normal",
     auto_janken_fate: 0,
     auto_janken_fate_with_bet: 0,
     entitlements: {
@@ -99,6 +223,7 @@ export default function AutoSettings() {
       auto_janken_fate: false,
       auto_janken_fate_with_bet: false,
     },
+    gacha_context: null,
   });
   const [snack, setSnack] = useState(null);
 
@@ -150,7 +275,30 @@ export default function AutoSettings() {
     [state]
   );
 
+  const handleModeChange = useCallback(
+    async nextMode => {
+      setSaving(true);
+      const prev = state;
+      setState(s => ({ ...s, auto_daily_gacha_mode: nextMode }));
+      try {
+        const updated = await setPreference({ auto_daily_gacha_mode: nextMode });
+        setState(updated);
+        setSnack({ severity: "success", message: "已更新" });
+      } catch {
+        setState(prev);
+        setSnack({ severity: "error", message: "更新失敗，請稍後再試" });
+      } finally {
+        setSaving(false);
+      }
+    },
+    [state]
+  );
+
   if (!isLoggedIn) return <AlertLogin />;
+
+  const dailyGachaEntitled = Boolean(state.entitlements?.auto_daily_gacha);
+  const showModeSelector =
+    !loading && state.auto_daily_gacha === 1 && dailyGachaEntitled && state.gacha_context;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
@@ -173,6 +321,18 @@ export default function AutoSettings() {
               開啟後，布丁會自動替你執行這些行為。隨時可以關閉。
             </Typography>
           </Box>
+          <Tooltip title="重新整理餘額與配額">
+            <span>
+              <IconButton
+                size="small"
+                onClick={reload}
+                disabled={loading || saving}
+                sx={{ color: "#fff" }}
+              >
+                <RefreshIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
           <Button
             component={RouterLink}
             to="/auto/history"
@@ -197,7 +357,7 @@ export default function AutoSettings() {
         <Stack spacing={2}>
           {FLAGS.map(flag => {
             const dependencyUnmet = flag.dependsOn && state[flag.dependsOn] !== 1;
-            return (
+            const row = (
               <ToggleRow
                 key={flag.key}
                 flag={flag}
@@ -207,6 +367,23 @@ export default function AutoSettings() {
                 onChange={handleToggle}
               />
             );
+            // Render the mode selector immediately beneath its parent toggle
+            if (flag.key === "auto_daily_gacha") {
+              return (
+                <Box key={flag.key} sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  {row}
+                  {showModeSelector && (
+                    <GachaModeSelector
+                      mode={state.auto_daily_gacha_mode || "normal"}
+                      context={state.gacha_context}
+                      disabled={saving}
+                      onChange={handleModeChange}
+                    />
+                  )}
+                </Box>
+              );
+            }
+            return row;
           })}
         </Stack>
       )}

--- a/frontend/src/pages/AutoSettings/index.jsx
+++ b/frontend/src/pages/AutoSettings/index.jsx
@@ -57,7 +57,7 @@ const MODE_OPTIONS = [
   },
   {
     value: "pickup",
-    label: "機率調升（祈願）",
+    label: "消耗抽（彩率上升）",
     description: "提升限定角色中獎機率。",
   },
   {
@@ -67,7 +67,7 @@ const MODE_OPTIONS = [
   },
   {
     value: "europe",
-    label: "歐派抽（只彩池）",
+    label: "歐洲抽（只彩池）",
     description: "整池僅保留三星角色。期間限定。",
   },
 ];
@@ -174,7 +174,7 @@ function GachaModeSelector({ mode, context, disabled, onChange }) {
                           variant="caption"
                           sx={{ color: "warning.main", mt: 0.25, display: "block" }}
                         >
-                          目前無歐派活動，選擇後會自動視為普通抽。
+                          目前無歐洲活動，選擇後會自動視為普通抽。
                         </Typography>
                       )}
                     </Box>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     host: true,
     port: 3000,
-    allowedHosts: ["host.docker.internal", ".ngrok-free.app"],
+    allowedHosts: ["host.docker.internal", ".ngrok-free.app", ".trycloudflare.com"],
     proxy: {
       "/api": {
         target: "http://localhost:9527",

--- a/makefile
+++ b/makefile
@@ -63,6 +63,55 @@ tunnel: ## 一鍵設定 ngrok URL 到 LINE webhook + LIFF
 		echo "⚠️  LIFF update skipped (missing LINE_LIFF_ID or LINE_LOGIN_CHANNEL_ID/SECRET)"; \
 	fi
 
+cf-up: ## 啟動 Cloudflare Quick Tunnel（背景執行，log 寫到 /tmp/cloudflared.log）
+	@if pgrep -x cloudflared > /dev/null; then echo "⚠️  cloudflared is already running"; exit 0; fi && \
+	: > /tmp/cloudflared.log && \
+	nohup cloudflared tunnel --url http://localhost:3000 --logfile /tmp/cloudflared.log > /dev/null 2>&1 & \
+	echo "🚀 cloudflared started (pid $$!). Waiting for URL..." && \
+	for i in 1 2 3 4 5 6 7 8 9 10; do \
+		URL=$$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' /tmp/cloudflared.log | head -1) && \
+		if [ -n "$$URL" ]; then echo "✅ $$URL"; exit 0; fi; \
+		sleep 1; \
+	done; \
+	echo "❌ Timed out waiting for tunnel URL. Check /tmp/cloudflared.log"; exit 1
+
+cf-down: ## 停止 Cloudflare Quick Tunnel
+	@pkill -x cloudflared && echo "🛑 cloudflared stopped" || echo "⚠️  cloudflared was not running"
+
+cf-url: ## 查詢目前 Cloudflare Tunnel 網址
+	@grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' /tmp/cloudflared.log 2>/dev/null | head -1 || echo "cloudflared is not running"
+
+cf-tunnel: ## 一鍵設定 Cloudflare URL 到 LINE webhook + LIFF
+	@CF_URL=$$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' /tmp/cloudflared.log 2>/dev/null | head -1) && \
+	if [ -z "$$CF_URL" ]; then echo "❌ cloudflared is not running (try: make cf-up)"; exit 1; fi && \
+	TOKEN=$$(grep '^LINE_ACCESS_TOKEN=' .env | cut -d'=' -f2-) && \
+	if [ -z "$$TOKEN" ]; then echo "❌ LINE_ACCESS_TOKEN not found in .env"; exit 1; fi && \
+	WEBHOOK_URL="$$CF_URL/webhooks/line" && \
+	curl -s -X PUT https://api.line.me/v2/bot/channel/webhook/endpoint \
+		-H "Authorization: Bearer $$TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"endpoint\": \"$$WEBHOOK_URL\"}" > /dev/null && \
+	echo "✅ Webhook: $$WEBHOOK_URL" && \
+	LIFF_ID=$$(grep '^LINE_LIFF_ID=' .env | cut -d'=' -f2-) && \
+	LOGIN_ID=$$(grep '^LINE_LOGIN_CHANNEL_ID=' .env | cut -d'=' -f2-) && \
+	LOGIN_SECRET=$$(grep '^LINE_LOGIN_CHANNEL_SECRET=' .env | cut -d'=' -f2-) && \
+	if [ -n "$$LIFF_ID" ] && [ -n "$$LOGIN_ID" ] && [ -n "$$LOGIN_SECRET" ]; then \
+		LIFF_TOKEN=$$(curl -s -X POST https://api.line.me/oauth2/v3/token \
+			-d "grant_type=client_credentials&client_id=$$LOGIN_ID&client_secret=$$LOGIN_SECRET" \
+			| python3 -c "import sys,json;print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null) && \
+		if [ -n "$$LIFF_TOKEN" ]; then \
+			curl -s -X PUT "https://api.line.me/liff/v1/apps/$$LIFF_ID" \
+				-H "Authorization: Bearer $$LIFF_TOKEN" \
+				-H "Content-Type: application/json" \
+				-d "{\"view\":{\"type\":\"full\",\"url\":\"$$CF_URL\"}}" > /dev/null && \
+			echo "✅ LIFF:    $$CF_URL ($$LIFF_ID)"; \
+		else \
+			echo "❌ Failed to issue LINE Login token, check LINE_LOGIN_CHANNEL_ID/SECRET"; \
+		fi; \
+	else \
+		echo "⚠️  LIFF update skipped (missing LINE_LIFF_ID or LINE_LOGIN_CHANNEL_ID/SECRET)"; \
+	fi
+
 help: ## 顯示所有可用指令
 	@sed \
 		-e '/^[a-zA-Z0-9_\-]*:.*##/!d' \


### PR DESCRIPTION
## Summary

- Adds per-user **auto daily gacha mode** selection (`normal` / `pickup` / `ensure` / `europe`):
  - DB schema + preference API with gacha_context (stone balance, daily quota, per-mode costs, europe banner active flag)
  - Cron honours the chosen mode per round with best-effort stone fallback (degrades to normal when stones run out, and when europe is requested without an active banner)
  - LIFF UI: AutoSettings mode selector with cost estimate + insufficient-stone warning, AutoHistory renders per-run mode breakdown + degradation reason
- Consolidates cost resolution: `GachaService.resolveCost` is now the single source; cron and controller delegate to it.
- UI wording aligned with player-familiar terms: 歐派 → 歐洲, 機率調升（祈願）→ 消耗抽（彩率上升）.
- **Unrelated fix (caught while testing):** `AchievementEngine.unlockAchievement` was crediting `reward_stones` via an UPDATE without a row-ID constraint, multiplying the reward by the user's existing itemId=999 ledger row count (e.g. a 30-stone reward became +5,340 for a user with 178 rows). Switched to a single-row INSERT + regression test. See `memory/project_stone_ledger_refactor.md` for the follow-up plan on tightening the 金流 ledger boundary.

## Test plan

- [x] Unit tests pass: AutoGacha.test.js (15), AutoPreferenceController.test.js (20), AchievementEngine.test.js (30)
- [x] Full suite: 250 tests passing (1 pre-existing images.test.js failure on main, unrelated)
- [x] Migration applied locally: `user_auto_preference.auto_daily_gacha_mode` ENUM column, default `normal`
- [x] End-to-end cron run: user set mode=ensure, cron ran 2 rounds × 保證抽, DB deductions match log (`-6000 cost + 302 repeat reward = -5698` net) with correct `mode_breakdown: { ensure: 2 }` and no achievement-leak inflation
- [ ] Manual UI check (reviewer): load `/auto/settings` while subscribed → mode selector appears below the 每日自動抽卡 toggle; cost estimate reflects gacha_context; europe option warns when no active banner
- [ ] Manual UI check (reviewer): load `/auto/history` → past auto-pulls show 保證 ×N / 消耗 ×N / 歐洲 ×N breakdown chips; degradation rows show the warning chip with tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)