### PR TITLE
feat(achievement): wire command_use + boss_attack + feature-tagged events

### DIFF
--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -280,12 +280,17 @@ exports.decide = async (context, { payload }) => {
   if (p1Result !== "draw") {
     const winnerId = p1Result === "win" ? userId : targetUserId;
     const [winResult, challengeResult] = await Promise.all([
-      AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => ({
+      AchievementEngine.evaluate(winnerId, "janken_win", {
+        streak: winnerStreak,
+        feature: "janken",
+      }).catch(() => ({
         unlocked: [],
       })),
-      AchievementEngine.evaluate(targetUserId, "janken_challenge", {}).catch(() => ({
-        unlocked: [],
-      })),
+      AchievementEngine.evaluate(targetUserId, "janken_challenge", { feature: "janken" }).catch(
+        () => ({
+          unlocked: [],
+        })
+      ),
     ]);
     await notifyUnlocks(context, winnerId, winResult.unlocked);
     await notifyUnlocks(context, targetUserId, challengeResult.unlocked);
@@ -457,10 +462,15 @@ exports.challenge = async (context, { payload }) => {
     if (p1Result !== "draw") {
       const winnerId = p1Result === "win" ? holderUserId : challengerUserId;
       const [winResult, challengeResult] = await Promise.all([
-        AchievementEngine.evaluate(winnerId, "janken_win", { streak: winnerStreak }).catch(() => ({
+        AchievementEngine.evaluate(winnerId, "janken_win", {
+          streak: winnerStreak,
+          feature: "janken",
+        }).catch(() => ({
           unlocked: [],
         })),
-        AchievementEngine.evaluate(challengerUserId, "janken_challenge", {}).catch(() => ({
+        AchievementEngine.evaluate(challengerUserId, "janken_challenge", {
+          feature: "janken",
+        }).catch(() => ({
           unlocked: [],
         })),
       ]);

--- a/app/src/controller/application/WorldBossController.js
+++ b/app/src/controller/application/WorldBossController.js
@@ -10,6 +10,8 @@ const minigameService = require("../../service/MinigameService");
 const worldBossUserAttackMessageService = require("../../service/WorldBossUserAttackMessageService");
 const EquipmentService = require("../../service/EquipmentService");
 const worldBossTemplate = require("../../templates/application/WorldBoss");
+const AchievementEngine = require("../../service/AchievementEngine");
+const { notifyUnlocks } = require("../../service/achievementNotifier");
 const { model: worldBossLogModel } = require("../../model/application/WorldBossLog");
 const UserModel = require("../../model/application/UserModel");
 const { inventory: Inventory } = require("../../model/application/Inventory");
@@ -548,6 +550,14 @@ const attackOnBoss = async (context, props) => {
   };
   await worldBossEventLogService.create(attributes);
 
+  AchievementEngine.evaluate(userId, "boss_attack", {
+    level,
+    damage,
+    feature: "world_boss",
+  })
+    .then(({ unlocked }) => notifyUnlocks(context, userId, unlocked))
+    .catch(() => {});
+
   // 隨機取得此次攻擊的訊息樣板
   const messageTemplates = await worldBossUserAttackMessageService.all();
   const tags = await worldBossUserAttackMessageService.getTags();
@@ -555,7 +565,9 @@ const attackOnBoss = async (context, props) => {
   const tag = sample(tags);
   // 再根據 tag 抽取訊息樣板
   const templateData = sample(messageTemplates.filter(data => data.tag === tag)) ||
-    sample(messageTemplates) || { template: "{display_name} 對 {boss_name} 造成了 {damage} 傷害！" };
+    sample(messageTemplates) || {
+      template: "{display_name} 對 {boss_name} 造成了 {damage} 傷害！",
+    };
 
   let causedDamagePercent = calculateDamagePercentage(eventBoss.hp, damage);
   let earnedExp = (eventBoss.exp * causedDamagePercent) / 100;

--- a/app/src/middleware/statistics.js
+++ b/app/src/middleware/statistics.js
@@ -5,6 +5,8 @@ const AchievementEngine = require("../service/AchievementEngine");
 const { notifyUnlocks } = require("../service/achievementNotifier");
 const MessageIO = io.of("/admin/messages");
 
+const COMMAND_PREFIX_RE = /^[/#.]\p{L}/u;
+
 /**
  * 數據紀錄
  * @param {Context} context
@@ -24,10 +26,17 @@ const statistics = async (context, props) => {
 
       const unlocksByUser = { [userId]: [] };
       const evaluations = [
-        AchievementEngine.evaluate(userId, "chat_message", { groupId, text })
+        AchievementEngine.evaluate(userId, "chat_message", { groupId, text, feature: "chat" })
           .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
           .catch(() => {}),
       ];
+      if (COMMAND_PREFIX_RE.test(text)) {
+        evaluations.push(
+          AchievementEngine.evaluate(userId, "command_use", {})
+            .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
+            .catch(() => {})
+        );
+      }
       if (mentionedUserIds.length) {
         evaluations.push(
           AchievementEngine.evaluate(userId, "mention_keyword", {

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -45,7 +45,14 @@ function matchesAllKeywords(text, keywords) {
 
 // Maps event types to achievement keys
 const EVENT_ACHIEVEMENT_MAP = {
-  chat_message: ["chat_100", "chat_1000", "chat_5000", "chat_night_owl", "chat_multi_group"],
+  chat_message: [
+    "chat_100",
+    "chat_1000",
+    "chat_5000",
+    "chat_night_owl",
+    "chat_multi_group",
+    "social_all_features",
+  ],
   gacha_pull: [
     "gacha_first",
     "gacha_100",
@@ -61,13 +68,26 @@ const EVENT_ACHIEVEMENT_MAP = {
     "gacha_ensure_1",
     "gacha_ensure_10",
     "gacha_ensure_50",
+    "social_all_features",
   ],
-  janken_win: ["janken_first_win", "janken_win_50", "janken_streak_5", "janken_streak_10"],
+  janken_win: [
+    "janken_first_win",
+    "janken_win_50",
+    "janken_streak_5",
+    "janken_streak_10",
+    "social_all_features",
+  ],
   janken_lose: [],
   janken_draw: [],
-  janken_challenge: ["janken_challenged_10"],
-  boss_attack: ["boss_first_kill", "boss_level_10", "boss_level_50", "boss_top_damage"],
-  command_use: ["social_first_command", "social_all_features"],
+  janken_challenge: ["janken_challenged_10", "social_all_features"],
+  boss_attack: [
+    "boss_first_kill",
+    "boss_level_10",
+    "boss_level_50",
+    "boss_top_damage",
+    "social_all_features",
+  ],
+  command_use: ["social_first_command"],
   subscribe: ["subscribe_first", "subscribe_3", "subscribe_6", "subscribe_12"],
   mention_keyword: ["mention_admin_hi", "mention_memory_seeker", "mention_void_gazer"],
   received_mention: [

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -246,6 +246,7 @@ async function runDailyDraw(userId, opts = {}) {
     threeStarCount: rareCount[3] || 0,
     uniqueCount: ownCharactersCount + newCharacters.length,
     pullType: europe ? "europe" : ensure ? "ensure" : pickup ? "pickup" : undefined,
+    feature: "gacha",
   }).catch(err => {
     DefaultLogger.warn(
       `GachaService.runDailyDraw achievement.evaluate failed user=${userId}: ${err && err.message}`


### PR DESCRIPTION
## Summary
- `social_first_command` (指令新手) now fires from `statistics.js` when a text message starts with `/`, `#`, or `.` followed by a letter.
- `social_all_features` (全能玩家) re-mapped from the orphaned `command_use` to the native events (`chat_message`, `gacha_pull`, `janken_win`, `janken_challenge`, `boss_attack`), with each call site now passing `feature: "chat|gacha|janken|world_boss"`.
- `WorldBossController.attackOnBoss` now dispatches `boss_attack` with `level` + `damage` + `feature` context so `boss_first_kill`, `boss_level_10`, `boss_level_50` (and the world_boss leg of 全能玩家) can progress.

### Status after this PR
- ✅ 20 / 24 achievements in the seed data can be triggered realtime or by the existing cron.
- ⚠️ Still inert (spec not yet wired — not in this PR's scope):
  - `boss_top_damage` — needs kill-time top-damager detection.
  - `social_invite_group` — needs an event from the bot-invited lineEvent flow.
  - `social_easter_egg` — no event/strategy defined yet.
  - `legacy_pioneer` — presumably granted manually to legacy players.

## Test plan
- [x] `yarn eslint` clean on the 5 touched files
- [x] `yarn test --testPathPattern='AchievementEngine|GachaService|Janken|WorldBoss'` → all 100 tests pass
- [ ] Smoke test in staging: send `/help` as a new-ish account → `social_first_command` unlocks with 30 💎 reply
- [ ] Smoke test in staging: run through chat + gacha + janken + world boss once each → `social_all_features` unlocks
- [ ] Smoke test in staging: attack world boss at character level ≥10 → `boss_first_kill` + `boss_level_10` fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)