### PR TITLE
refactor(me): dedupe tokens, parallelize gacha history, fix parseInt

### DIFF
--- a/app/src/controller/application/ChatLevelController.js
+++ b/app/src/controller/application/ChatLevelController.js
@@ -45,16 +45,8 @@ exports.showStatus = async (context, props) => {
       exp = 0,
     } = await ChatLevelModel.getUserData(userId);
     const expDatas = await ChatLevelModel.getExpUnitData();
-    const nowThreshold = get(
-      expDatas.find(d => d.level === level),
-      "exp",
-      0
-    );
-    const nextThreshold = get(
-      expDatas.find(d => d.level === level + 1),
-      "exp",
-      0
-    );
+    const nowThreshold = expDatas.find(d => d.level === level)?.exp ?? 0;
+    const nextThreshold = expDatas.find(d => d.level === level + 1)?.exp ?? 0;
     const expCurrent = Math.max(0, exp - nowThreshold);
     const expNext = Math.max(0, nextThreshold - nowThreshold);
     const expRate = expNext > 0 ? Math.round((expCurrent / expNext) * 100) : 0;
@@ -132,8 +124,8 @@ exports.showStatus = async (context, props) => {
       starProgress: gachaProgress.progress,
       godStone,
       paidStone: donateAmount || 0,
-      lastRainbowDays: gachaHistory.rainbow === "-" ? null : gachaHistory.rainbow,
-      lastHasNewDays: gachaHistory.hasNew === "-" ? null : gachaHistory.hasNew,
+      lastRainbowDays: gachaHistory.rainbow,
+      lastHasNewDays: gachaHistory.hasNew,
       janken: { win: winCount, lose: loseCount, draw: drawCount, rate: winRate },
       subscriptionCards,
     });
@@ -154,10 +146,11 @@ async function getGachaCollectProgress(userId) {
   const ownItems = await inventory.getAllUserOwnCharacters(userId);
   const princessCountInGame = await GachaModel.getPrincessCharacterCount();
   const userTotalStar = ownItems.reduce((acc, item) => {
-    const attributes = item && item.attributes;
+    const attributes = item?.attributes;
     if (!Array.isArray(attributes)) return acc;
     const star = attributes.find(attr => attr.key === "star");
-    return parseInt(star && star.value, 10) + acc || acc;
+    const value = parseInt(star?.value, 10);
+    return Number.isFinite(value) ? acc + value : acc;
   }, 0);
 
   const totalStarInGame = princessCountInGame * 5;
@@ -167,44 +160,26 @@ async function getGachaCollectProgress(userId) {
 }
 
 async function getGachaHistory(userId) {
-  const lastRainbowRecord = await GachaRecord.first({
-    filter: {
-      user_id: userId,
-      rainbow: {
-        operator: ">",
-        value: 0,
+  const [lastRainbowRecord, lastHasNewRecord] = await Promise.all([
+    GachaRecord.first({
+      filter: {
+        user_id: userId,
+        rainbow: { operator: ">", value: 0 },
       },
-    },
-    order: [{ column: "created_at", direction: "desc" }],
-  });
-
-  const lastHasNewRecord = await GachaRecord.first({
-    filter: {
-      user_id: userId,
-      has_new: 1,
-    },
-    order: [{ column: "created_at", direction: "desc" }],
-  });
+      order: [{ column: "created_at", direction: "desc" }],
+    }),
+    GachaRecord.first({
+      filter: { user_id: userId, has_new: 1 },
+      order: [{ column: "created_at", direction: "desc" }],
+    }),
+  ]);
 
   const now = moment();
-  const countLastDay = createdAt => {
-    const start = moment(createdAt).startOf("day");
-    return now.diff(start, "days");
-  };
-
-  let lastRainbow = "-";
-  if (lastRainbowRecord) {
-    lastRainbow = countLastDay(lastRainbowRecord.created_at);
-  }
-
-  let lastHasNew = "-";
-  if (lastHasNewRecord) {
-    lastHasNew = countLastDay(lastHasNewRecord.created_at);
-  }
+  const countLastDay = createdAt => now.diff(moment(createdAt).startOf("day"), "days");
 
   return {
-    rainbow: lastRainbow,
-    hasNew: lastHasNew,
+    rainbow: lastRainbowRecord ? countLastDay(lastRainbowRecord.created_at) : null,
+    hasNew: lastHasNewRecord ? countLastDay(lastHasNewRecord.created_at) : null,
   };
 }
 

--- a/app/src/templates/application/Me/Profile.js
+++ b/app/src/templates/application/Me/Profile.js
@@ -1,19 +1,5 @@
 const humanNumber = require("human-number");
-const { SEMANTIC } = require("../../common/theme");
-const { buildSubPanel } = require("./_shared");
-
-const CYAN_700 = "#00838F";
-const CYAN_600 = SEMANTIC.primary.main;
-const CYAN_BG = "#E0F7FA";
-const AMBER_400 = SEMANTIC.secondary.light;
-const AMBER_300 = "#FCD34D";
-const AMBER_BG = "#FFF7E6";
-const GREEN_500 = SEMANTIC.success.main;
-const GREEN_BG = "#E8F9EF";
-const RED_500 = SEMANTIC.danger.main;
-const RED_BG = "#FDECEC";
-const TEXT_DARK = "#3A2800";
-const MUTED = "#5A6B7F";
+const { buildSubPanel, COLORS } = require("./_shared");
 
 const formatExp = n => humanNumber(n, v => Number.parseFloat(v).toFixed(1));
 
@@ -56,11 +42,11 @@ function buildHero({
         text: `Lv.${level} · ${range}`,
         weight: "bold",
         size: "xxs",
-        color: TEXT_DARK,
+        color: COLORS.textDark,
         align: "center",
       },
     ],
-    backgroundColor: AMBER_400,
+    backgroundColor: COLORS.amber400,
     cornerRadius: "xl",
     paddingStart: "sm",
     paddingEnd: "sm",
@@ -92,7 +78,7 @@ function buildHero({
     type: "text",
     text: `Rank #${ranking}`,
     size: "xxs",
-    color: AMBER_300,
+    color: COLORS.amber300,
     weight: "bold",
     margin: "xs",
   };
@@ -125,7 +111,7 @@ function buildHero({
         type: "text",
         text: expText,
         size: "xxs",
-        color: AMBER_300,
+        color: COLORS.amber300,
         weight: "bold",
         align: "end",
       },
@@ -142,12 +128,12 @@ function buildHero({
         layout: "vertical",
         contents: [],
         height: "7px",
-        backgroundColor: AMBER_400,
+        backgroundColor: COLORS.amber400,
         width: `${clampedRate}%`,
         cornerRadius: "md",
       },
     ],
-    backgroundColor: "#FFFFFF44",
+    backgroundColor: COLORS.whiteOverlay,
     height: "7px",
     cornerRadius: "md",
     margin: "xs",
@@ -161,10 +147,10 @@ function buildHero({
     background: {
       type: "linearGradient",
       angle: "135deg",
-      startColor: CYAN_700,
-      endColor: CYAN_600,
+      startColor: COLORS.cyan700,
+      endColor: COLORS.cyan600,
     },
-    backgroundColor: CYAN_700,
+    backgroundColor: COLORS.cyan700,
   };
 }
 
@@ -177,7 +163,7 @@ function buildSubBadge({ text }) {
         type: "text",
         text: `🎟 訂閱中 · ${text}`,
         size: "xxs",
-        color: CYAN_700,
+        color: COLORS.cyan700,
         weight: "bold",
         flex: 1,
         gravity: "center",
@@ -186,13 +172,13 @@ function buildSubBadge({ text }) {
         type: "text",
         text: "›",
         size: "md",
-        color: CYAN_700,
+        color: COLORS.cyan700,
         weight: "bold",
         align: "end",
         flex: 0,
       },
     ],
-    backgroundColor: CYAN_BG,
+    backgroundColor: COLORS.cyanBg,
     paddingStart: "md",
     paddingEnd: "md",
     paddingTop: "sm",
@@ -203,9 +189,9 @@ function buildSubBadge({ text }) {
 
 function buildStat({ fraction, icon, label, tone }) {
   const toneMap = {
-    done: { bg: GREEN_BG, fg: GREEN_500, accent: GREEN_500 },
-    miss: { bg: RED_BG, fg: RED_500, accent: RED_500 },
-    progress: { bg: CYAN_BG, fg: CYAN_700, accent: CYAN_600 },
+    done: { bg: COLORS.greenBg, fg: COLORS.green500, accent: COLORS.green500 },
+    miss: { bg: COLORS.redBg, fg: COLORS.red500, accent: COLORS.red500 },
+    progress: { bg: COLORS.cyanBg, fg: COLORS.cyan700, accent: COLORS.cyan600 },
   };
   const { bg, fg, accent } = toneMap[tone] || toneMap.progress;
 
@@ -234,7 +220,7 @@ function buildStat({ fraction, icon, label, tone }) {
         type: "text",
         text: label,
         size: "xxs",
-        color: MUTED,
+        color: COLORS.textMuted,
         align: "center",
         margin: "xs",
       },
@@ -294,7 +280,7 @@ function buildStreak(signinDays) {
         type: "text",
         text: "🔥 連續簽到",
         size: "xs",
-        color: MUTED,
+        color: COLORS.textMuted,
         flex: 1,
         gravity: "center",
       },
@@ -305,16 +291,16 @@ function buildStreak(signinDays) {
             type: "span",
             text: `${signinDays || 0}`,
             weight: "bold",
-            color: SEMANTIC.warning.main,
+            color: COLORS.amber500,
             size: "md",
           },
-          { type: "span", text: " 天", color: MUTED, size: "xs" },
+          { type: "span", text: " 天", color: COLORS.textMuted, size: "xs" },
         ],
         align: "end",
         flex: 0,
       },
     ],
-    backgroundColor: AMBER_BG,
+    backgroundColor: COLORS.amberBg,
     cornerRadius: "md",
     paddingStart: "md",
     paddingEnd: "md",

--- a/app/src/templates/application/Me/Progress.js
+++ b/app/src/templates/application/Me/Progress.js
@@ -1,36 +1,4 @@
-const { SEMANTIC } = require("../../common/theme");
-
-const CYAN_700 = "#00838F";
-const CYAN_600 = SEMANTIC.primary.main;
-const CYAN_400 = "#4DD0E1";
-const CYAN_BG = "#E0F7FA";
-const AMBER_500 = SEMANTIC.secondary.main;
-const AMBER_400 = SEMANTIC.secondary.light;
-const AMBER_BG = "#FFF7E6";
-const GREEN_500 = SEMANTIC.success.main;
-const GREEN_BG = "#E8F9EF";
-const RED_500 = SEMANTIC.danger.main;
-const RED_BG = "#FDECEC";
-const TEXT = "#1A2332";
-const MUTED = "#5A6B7F";
-const TRACK = "#F0F4F7";
-const DIVIDER = "#EEF2F6";
-
-function accentBar() {
-  return {
-    type: "box",
-    layout: "vertical",
-    contents: [],
-    height: "4px",
-    background: {
-      type: "linearGradient",
-      angle: "90deg",
-      startColor: CYAN_700,
-      endColor: CYAN_400,
-    },
-    backgroundColor: CYAN_700,
-  };
-}
+const { COLORS, buildAccentBar } = require("./_shared");
 
 function header() {
   return {
@@ -42,14 +10,14 @@ function header() {
         text: "布丁世界進度",
         weight: "bold",
         size: "sm",
-        color: TEXT,
+        color: COLORS.text,
         flex: 1,
       },
       {
         type: "text",
         text: "蒐集 · 戰績",
         size: "xxs",
-        color: MUTED,
+        color: COLORS.textMuted,
         align: "end",
         gravity: "bottom",
         flex: 0,
@@ -70,12 +38,12 @@ function progressBlock({ label, valueText, percent, fillColorStart, fillColorEnd
     type: "box",
     layout: "horizontal",
     contents: [
-      { type: "text", text: label, size: "xs", color: MUTED, weight: "bold", flex: 1 },
+      { type: "text", text: label, size: "xs", color: COLORS.textMuted, weight: "bold", flex: 1 },
       {
         type: "text",
         text: valueText,
         size: "xs",
-        color: TEXT,
+        color: COLORS.text,
         weight: "bold",
         align: "end",
         flex: 0,
@@ -103,7 +71,7 @@ function progressBlock({ label, valueText, percent, fillColorStart, fillColorEnd
         backgroundColor: fillColorStart,
       },
     ],
-    backgroundColor: TRACK,
+    backgroundColor: COLORS.track,
     height: "6px",
     cornerRadius: "md",
     margin: "sm",
@@ -115,7 +83,7 @@ function progressBlock({ label, valueText, percent, fillColorStart, fillColorEnd
       type: "text",
       text: metaText,
       size: "xxs",
-      color: MUTED,
+      color: COLORS.textMuted,
       align: "end",
       margin: "xs",
     });
@@ -130,7 +98,7 @@ function progressBlock({ label, valueText, percent, fillColorStart, fillColorEnd
     paddingTop: "md",
     paddingBottom: "md",
     borderWidth: "1px",
-    borderColor: DIVIDER,
+    borderColor: COLORS.divider,
     cornerRadius: "none",
   };
 }
@@ -138,7 +106,7 @@ function progressBlock({ label, valueText, percent, fillColorStart, fillColorEnd
 function divider() {
   return {
     type: "separator",
-    color: DIVIDER,
+    color: COLORS.divider,
   };
 }
 
@@ -148,17 +116,17 @@ function walletRow({ godStone, paidStone }) {
     type: "box",
     layout: "vertical",
     contents: [
-      { type: "text", text: label, size: "xxs", color: MUTED },
+      { type: "text", text: label, size: "xxs", color: COLORS.textMuted },
       {
         type: "text",
         text: format(value),
         size: "md",
-        color: AMBER_500,
+        color: COLORS.amber500,
         weight: "bold",
         margin: "xs",
       },
     ],
-    backgroundColor: AMBER_BG,
+    backgroundColor: COLORS.amberBg,
     cornerRadius: "md",
     paddingAll: "sm",
     flex: 1,
@@ -185,7 +153,7 @@ function jankenBlock({ win, lose, draw, rate }) {
     layout: "vertical",
     contents: [
       { type: "text", text: String(value), size: "md", color: fg, weight: "bold", align: "center" },
-      { type: "text", text: label, size: "xxs", color: MUTED, align: "center" },
+      { type: "text", text: label, size: "xxs", color: COLORS.textMuted, align: "center" },
     ],
     backgroundColor: bg,
     cornerRadius: "md",
@@ -204,12 +172,25 @@ function jankenBlock({ win, lose, draw, rate }) {
         type: "box",
         layout: "horizontal",
         contents: [
-          { type: "text", text: "猜拳戰績", size: "xs", color: MUTED, weight: "bold", flex: 1 },
+          {
+            type: "text",
+            text: "猜拳戰績",
+            size: "xs",
+            color: COLORS.textMuted,
+            weight: "bold",
+            flex: 1,
+          },
           {
             type: "text",
             contents: [
-              { type: "span", text: "勝率 ", size: "xs", color: MUTED },
-              { type: "span", text: rateDisplay, size: "xs", color: CYAN_700, weight: "bold" },
+              { type: "span", text: "勝率 ", size: "xs", color: COLORS.textMuted },
+              {
+                type: "span",
+                text: rateDisplay,
+                size: "xs",
+                color: COLORS.cyan700,
+                weight: "bold",
+              },
             ],
             align: "end",
             flex: 0,
@@ -220,9 +201,9 @@ function jankenBlock({ win, lose, draw, rate }) {
         type: "box",
         layout: "horizontal",
         contents: [
-          cell({ value: win || 0, label: "勝", fg: GREEN_500, bg: GREEN_BG }),
-          cell({ value: lose || 0, label: "敗", fg: RED_500, bg: RED_BG }),
-          cell({ value: draw || 0, label: "平", fg: CYAN_700, bg: CYAN_BG }),
+          cell({ value: win || 0, label: "勝", fg: COLORS.green500, bg: COLORS.greenBg }),
+          cell({ value: lose || 0, label: "敗", fg: COLORS.red500, bg: COLORS.redBg }),
+          cell({ value: draw || 0, label: "平", fg: COLORS.cyan700, bg: COLORS.cyanBg }),
         ],
         spacing: "sm",
         margin: "sm",
@@ -236,7 +217,7 @@ function jankenBlock({ win, lose, draw, rate }) {
 }
 
 function formatLastDay(days) {
-  if (days === null || days === undefined || days === "-") return "-";
+  if (days === null || days === undefined) return "-";
   return `${days} 天前`;
 }
 
@@ -254,15 +235,15 @@ exports.build = ({
     characterTotal > 0 ? Math.round(((characterCurrent || 0) / characterTotal) * 100) : 0;
 
   const contents = [
-    accentBar(),
+    buildAccentBar({ startColor: COLORS.cyan700, endColor: COLORS.cyan400 }),
     header(),
     divider(),
     progressBlock({
       label: "蒐集角色",
       valueText: `${characterCurrent || 0} / ${characterTotal || 0}`,
       percent: characterPercent,
-      fillColorStart: CYAN_600,
-      fillColorEnd: CYAN_400,
+      fillColorStart: COLORS.cyan600,
+      fillColorEnd: COLORS.cyan400,
       metaText: `🌈 ${formatLastDay(lastRainbowDays)}上次出彩`,
     }),
     divider(),
@@ -270,8 +251,8 @@ exports.build = ({
       label: "累積星數",
       valueText: `${starProgress || 0}%`,
       percent: starProgress || 0,
-      fillColorStart: AMBER_500,
-      fillColorEnd: AMBER_400,
+      fillColorStart: COLORS.amber500,
+      fillColorEnd: COLORS.amber400,
       metaText: `✨ ${formatLastDay(lastHasNewDays)}上次出新`,
     }),
     divider(),

--- a/app/src/templates/application/Me/Subscription.js
+++ b/app/src/templates/application/Me/Subscription.js
@@ -1,26 +1,4 @@
-const { SEMANTIC } = require("../../common/theme");
-const { buildSubPanel } = require("./_shared");
-
-const AMBER_500 = SEMANTIC.secondary.main;
-const AMBER_300 = "#FCD34D";
-const TEXT = "#1A2332";
-const MUTED = "#5A6B7F";
-
-function accentBar() {
-  return {
-    type: "box",
-    layout: "vertical",
-    contents: [],
-    height: "4px",
-    background: {
-      type: "linearGradient",
-      angle: "90deg",
-      startColor: AMBER_500,
-      endColor: AMBER_300,
-    },
-    backgroundColor: AMBER_500,
-  };
-}
+const { COLORS, buildAccentBar, buildSubPanel } = require("./_shared");
 
 function header(count) {
   return {
@@ -32,14 +10,14 @@ function header(count) {
         text: "訂閱特權",
         weight: "bold",
         size: "sm",
-        color: TEXT,
+        color: COLORS.text,
         flex: 1,
       },
       {
         type: "text",
         text: `${count} 張啟用中`,
         size: "xxs",
-        color: MUTED,
+        color: COLORS.textMuted,
         align: "end",
         gravity: "bottom",
         flex: 0,
@@ -54,7 +32,10 @@ function header(count) {
 }
 
 exports.build = ({ panels }) => {
-  const contents = [accentBar(), header(panels.length)];
+  const contents = [
+    buildAccentBar({ startColor: COLORS.amber500, endColor: COLORS.amber300 }),
+    header(panels.length),
+  ];
   panels.forEach(p => contents.push(buildSubPanel(p)));
 
   return {

--- a/app/src/templates/application/Me/_shared.js
+++ b/app/src/templates/application/Me/_shared.js
@@ -1,44 +1,60 @@
-const { SEMANTIC } = require("../../common/theme");
+const { PALETTE, SEMANTIC, SURFACE, HERO_SURFACE } = require("../../common/theme");
 
-const HERO_BG_ALT = "#12243A";
-const HERO_TEXT = "#E8EEF4";
-const HERO_MUTED = "#B0BEC5";
-const AMBER_500 = SEMANTIC.secondary.main;
-const AMBER_300 = "#FCD34D";
-const AMBER_400 = SEMANTIC.secondary.light;
-const CYAN_500 = SEMANTIC.primary.light;
-const TAG_CYAN_TEXT = "#002A30";
-const TAG_AMBER_TEXT = "#3A2800";
+const COLORS = {
+  cyan700: PALETTE.cyan700,
+  cyan600: SEMANTIC.primary.main,
+  cyan500: SEMANTIC.primary.light,
+  cyan400: PALETTE.cyan400,
+  cyanBg: "#E0F7FA",
 
-/**
- * Dark-luxury subscription panel — used by Profile (inline) and Subscription (standalone bubble).
- * Design: dark navy base + amber "gold hairline" at top + tag chip per card type.
- *
- * @param {Object} param0
- * @param {String} param0.key         "month" | "season"
- * @param {String} param0.titleText   e.g. "月卡"
- * @param {String} param0.expireText  e.g. "2026-05-01"
- * @param {String[]} param0.effects   pre-formatted effect row strings
- * @returns {Object} LINE Flex box
- */
-exports.buildSubPanel = ({ key, titleText, expireText, effects }) => {
+  amber500: SEMANTIC.secondary.main,
+  amber400: SEMANTIC.secondary.light,
+  amber300: PALETTE.amber300,
+  amberBg: "#FFF7E6",
+
+  green500: SEMANTIC.success.main,
+  greenBg: "#E8F9EF",
+  red500: SEMANTIC.danger.main,
+  redBg: "#FDECEC",
+
+  text: SURFACE.text,
+  textMuted: SURFACE.textMuted,
+  textDark: "#3A2800",
+  track: "#F0F4F7",
+  divider: "#EEF2F6",
+  whiteOverlay: "#FFFFFF44",
+
+  heroBgAlt: HERO_SURFACE.bgAlt,
+  heroText: HERO_SURFACE.text,
+  heroTextMuted: HERO_SURFACE.textMuted,
+  tagCyanText: "#002A30",
+  tagAmberText: "#3A2800",
+};
+
+const buildAccentBar = ({ startColor, endColor, height = "4px" }) => ({
+  type: "box",
+  layout: "vertical",
+  contents: [],
+  height,
+  background: {
+    type: "linearGradient",
+    angle: "90deg",
+    startColor,
+    endColor,
+  },
+  backgroundColor: startColor,
+});
+
+const buildSubPanel = ({ key, titleText, expireText, effects }) => {
   const isSeason = key === "season";
-  const tagBg = isSeason ? AMBER_400 : CYAN_500;
-  const tagFg = isSeason ? TAG_AMBER_TEXT : TAG_CYAN_TEXT;
+  const tagBg = isSeason ? COLORS.amber400 : COLORS.cyan500;
+  const tagFg = isSeason ? COLORS.tagAmberText : COLORS.tagCyanText;
 
-  const goldHairline = {
-    type: "box",
-    layout: "vertical",
-    contents: [],
+  const goldHairline = buildAccentBar({
+    startColor: COLORS.amber500,
+    endColor: COLORS.amber300,
     height: "3px",
-    background: {
-      type: "linearGradient",
-      angle: "90deg",
-      startColor: AMBER_500,
-      endColor: AMBER_300,
-    },
-    backgroundColor: AMBER_500,
-  };
+  });
 
   const tagChip = {
     type: "box",
@@ -71,7 +87,7 @@ exports.buildSubPanel = ({ key, titleText, expireText, effects }) => {
         type: "text",
         text: `${expireText} 到期`,
         size: "xxs",
-        color: HERO_MUTED,
+        color: COLORS.heroTextMuted,
         gravity: "center",
         align: "end",
         flex: 1,
@@ -84,8 +100,8 @@ exports.buildSubPanel = ({ key, titleText, expireText, effects }) => {
   const effectLines = effects.map(text => ({
     type: "text",
     contents: [
-      { type: "span", text: "◆ ", color: AMBER_400, weight: "bold" },
-      { type: "span", text, color: HERO_TEXT },
+      { type: "span", text: "◆ ", color: COLORS.amber400, weight: "bold" },
+      { type: "span", text, color: COLORS.heroText },
     ],
     size: "xxs",
   }));
@@ -94,7 +110,7 @@ exports.buildSubPanel = ({ key, titleText, expireText, effects }) => {
     type: "box",
     layout: "vertical",
     contents: [headRow, ...effectLines],
-    backgroundColor: HERO_BG_ALT,
+    backgroundColor: COLORS.heroBgAlt,
     paddingStart: "lg",
     paddingEnd: "lg",
     paddingTop: "md",
@@ -109,3 +125,5 @@ exports.buildSubPanel = ({ key, titleText, expireText, effects }) => {
     spacing: "none",
   };
 };
+
+module.exports = { COLORS, buildAccentBar, buildSubPanel };


### PR DESCRIPTION
## Summary
Follow-up cleanup on `#686` (`/me` bubble redesign) surfaced by a review pass.

- **Templates** — consolidate color palette + accent-bar builder into `Me/_shared.js`. `Profile` / `Progress` / `Subscription` now import a shared `COLORS` object and a shared `buildAccentBar({ startColor, endColor, height })`. No more triplicated hex constants or near-identical `accentBar()` helpers.
- **Controller** — parallelize the two `GachaRecord.first` queries inside `getGachaHistory` (was serial); shaves one round-trip from every `/me`.
- **Sentinels** — `getGachaHistory` now returns `null` directly; drop the `"-" → null → "-"` round-trip between controller and `Progress.formatLastDay`.
- **Correctness** — replace the `parseInt(...) + acc || acc` precedence hack in `getGachaCollectProgress` with an explicit `Number.isFinite` guard + optional chaining on `star?.value`.
- **Micro** — collapse `expDatas.find + lodash.get` pair into `?.exp ?? 0`.

No behavior change in rendering. DB footprint is reduced (one `await` pair → `Promise.all`).

## Test plan
- [ ] `/me` in 1:1 chat renders unchanged (2 bubbles: Profile + Progress)
- [ ] `/me` with 1 subscription — inline panel still appears on Profile
- [ ] `/me` with 2+ subscriptions — Subscription bubble + Profile badge still appear
- [ ] `🌈 / ✨ 上次出彩 / 出新` shows `-` for users with no matching history
- [ ] Star progress % numeric for users with 0, some, and many characters
- [ ] MAX-level user still shows `EXP · MAX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)