### PR TITLE
feat(rankings): add achievement leaderboard + polish mobile chart

### DIFF
--- a/app/src/controller/application/AchievementController.js
+++ b/app/src/controller/application/AchievementController.js
@@ -1,9 +1,13 @@
 // eslint-disable-next-line no-unused-vars
-const { Context } = require("bottender");
+const { Context, getClient } = require("bottender");
 const { text } = require("bottender/router");
+const { get } = require("lodash");
 const AchievementEngine = require("../../service/AchievementEngine");
 const UserTitleModel = require("../../model/application/UserTitle");
+const UserAchievementModel = require("../../model/application/UserAchievement");
 const AchievementTemplate = require("../../templates/application/Achievement");
+
+const lineClient = getClient("line");
 
 exports.router = [text(/^[.#/](成就|achievement|adv)$/, showAchievements)];
 
@@ -70,6 +74,22 @@ exports.api = {
       const { userId } = req.params;
       const titles = await UserTitleModel.findByUser(userId);
       res.json(titles);
+    } catch (err) {
+      res.status(500).json({ message: err.message });
+    }
+  },
+
+  async getRanking(req, res) {
+    try {
+      const rankData = await UserAchievementModel.getUnlockRank({ limit: 10 });
+      const result = await Promise.all(
+        rankData.map(async (data, index) => {
+          const profile = await lineClient.getUserProfile(data.user_id).catch(() => null);
+          const displayName = get(profile, "displayName", `未知${index + 1}`);
+          return { ...data, displayName };
+        })
+      );
+      res.json(result);
     } catch (err) {
       res.status(500).json({ message: err.message });
     }

--- a/app/src/model/application/UserAchievement.js
+++ b/app/src/model/application/UserAchievement.js
@@ -58,3 +58,12 @@ exports.getRecentByUser = async (userId, limit = 3) => {
     .orderBy("user_achievements.unlocked_at", "desc")
     .limit(limit);
 };
+
+exports.getUnlockRank = async ({ limit = 10 } = {}) => {
+  return mysql(TABLE)
+    .select("user_id")
+    .count({ cnt: "id" })
+    .groupBy("user_id")
+    .orderBy("cnt", "desc")
+    .limit(limit);
+};

--- a/app/src/router/api.js
+++ b/app/src/router/api.js
@@ -368,6 +368,7 @@ router.use("/race", RaceRouter);
 const AchievementController = require("../controller/application/AchievementController");
 
 router.get("/achievements", AchievementController.api.getAll);
+router.get("/achievements/rankings", AchievementController.api.getRanking);
 router.get("/achievements/user/:userId", AchievementController.api.getUserAchievements);
 router.get("/achievements/stats", AchievementController.api.getStats);
 router.get("/titles/user/:userId", AchievementController.api.getUserTitles);

--- a/frontend/src/pages/Rankings/AchievementRankChart.jsx
+++ b/frontend/src/pages/Rankings/AchievementRankChart.jsx
@@ -1,0 +1,8 @@
+import RankingBarChart from "./RankingBarChart";
+import { RANK_COLORS } from "./OverviewCard";
+import { useAchievementRankData } from "./hooks";
+
+export default function AchievementRankChart() {
+  const { rows } = useAchievementRankData();
+  return <RankingBarChart data={rows} color={RANK_COLORS.achievement} />;
+}

--- a/frontend/src/pages/Rankings/OverviewCard.jsx
+++ b/frontend/src/pages/Rankings/OverviewCard.jsx
@@ -4,6 +4,7 @@ const RANK_COLORS = {
   level: "#7c4dff",
   gacha: "#ff6d00",
   godStone: "#00bfa5",
+  achievement: "#d81b60",
 };
 
 export default function OverviewCard({ icon, title, topName, topValue, count, color, onClick }) {

--- a/frontend/src/pages/Rankings/RankingBarChart.jsx
+++ b/frontend/src/pages/Rankings/RankingBarChart.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -13,6 +13,8 @@ import {
 
 const MEDAL_COLORS = ["#FFD700", "#C0C0C0", "#CD7F32"];
 const DEFAULT_COLOR = "#90a4ae";
+const WIDE_CHAR =
+  /[\u3000-\u9fff\uac00-\ud7af\uff00-\uffef]|[\u{1D400}-\u{1D7FF}]|\p{Extended_Pictographic}/u;
 
 function formatValue(val) {
   if (val >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
@@ -20,7 +22,26 @@ function formatValue(val) {
   return String(val);
 }
 
+function truncateName(name, maxWidth) {
+  if (!name) return "";
+  let width = 0;
+  let out = "";
+  for (const ch of name) {
+    const w = WIDE_CHAR.test(ch) ? 2 : 1;
+    if (width + w > maxWidth) return out + "…";
+    width += w;
+    out += ch;
+  }
+  return out;
+}
+
 export default function RankingBarChart({ data, color = DEFAULT_COLOR }) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const axisWidth = isMobile ? 104 : 140;
+  const nameMaxWidth = isMobile ? 9 : 14;
+  const rightMargin = isMobile ? 44 : 60;
+
   const chartData = useMemo(() => {
     if (!data?.length) return [];
     return data.slice(0, 10).map((d, i) => ({
@@ -51,18 +72,21 @@ export default function RankingBarChart({ data, color = DEFAULT_COLOR }) {
       <BarChart
         data={chartData}
         layout="vertical"
-        margin={{ top: 8, right: 60, left: 8, bottom: 8 }}
+        margin={{ top: 8, right: rightMargin, left: 8, bottom: 8 }}
       >
         <XAxis type="number" hide />
         <YAxis
           type="category"
           dataKey="name"
-          width={120}
-          tick={{ fontSize: 13 }}
+          width={axisWidth}
+          interval={0}
+          tickLine={false}
+          axisLine={false}
+          tick={{ fontSize: 13, textAnchor: "start", dx: -axisWidth + 4 }}
           tickFormatter={(name, i) => {
             const medals = ["\u{1F947}", "\u{1F948}", "\u{1F949}"];
             const prefix = i < 3 ? medals[i] : `${i + 1}.`;
-            return `${prefix} ${name}`;
+            return `${prefix} ${truncateName(name, nameMaxWidth)}`;
           }}
         />
         <Tooltip formatter={val => [val.toLocaleString(), "數值"]} />

--- a/frontend/src/pages/Rankings/hooks.js
+++ b/frontend/src/pages/Rankings/hooks.js
@@ -43,3 +43,17 @@ export function useGodStoneData() {
 
   return { rows, loading, topEntry: rows[0], count: rows.length };
 }
+
+export function useAchievementRankData() {
+  const [{ data, loading }] = useAxios("/api/achievements/rankings");
+
+  const rows = useMemo(() => {
+    if (!data) return [];
+    return data.map(d => ({
+      displayName: d.displayName,
+      value: d.cnt,
+    }));
+  }, [data]);
+
+  return { rows, loading, topEntry: rows[0], count: rows.length };
+}

--- a/frontend/src/pages/Rankings/index.jsx
+++ b/frontend/src/pages/Rankings/index.jsx
@@ -1,11 +1,17 @@
 import { useEffect, useState } from "react";
 import { Box, Typography, Grid, Tabs, Tab, Paper, Skeleton } from "@mui/material";
-import { EmojiEvents, Casino, Diamond } from "@mui/icons-material";
+import { EmojiEvents, Casino, Diamond, MilitaryTech } from "@mui/icons-material";
 import OverviewCard, { RANK_COLORS } from "./OverviewCard";
 import ChatLevelChart from "./ChatLevelChart";
 import GachaRankChart from "./GachaRankChart";
 import GodStoneChart from "./GodStoneChart";
-import { useChatLevelData, useGachaRankData, useGodStoneData } from "./hooks";
+import AchievementRankChart from "./AchievementRankChart";
+import {
+  useChatLevelData,
+  useGachaRankData,
+  useGodStoneData,
+  useAchievementRankData,
+} from "./hooks";
 
 function TabPanel({ children, value, index }) {
   return value === index ? <Box sx={{ pt: 2 }}>{children}</Box> : null;
@@ -16,6 +22,7 @@ export default function Rankings() {
   const level = useChatLevelData();
   const gacha = useGachaRankData();
   const godStone = useGodStoneData();
+  const achievement = useAchievementRankData();
 
   useEffect(() => {
     document.title = "各大排行榜";
@@ -49,6 +56,15 @@ export default function Rankings() {
       color: RANK_COLORS.godStone,
       loading: godStone.loading,
     },
+    {
+      icon: <MilitaryTech sx={{ fontSize: 28, color: RANK_COLORS.achievement }} />,
+      title: "獎盃獵人",
+      topName: achievement.topEntry?.displayName,
+      topValue: achievement.topEntry?.value?.toLocaleString(),
+      count: achievement.count,
+      color: RANK_COLORS.achievement,
+      loading: achievement.loading,
+    },
   ];
 
   return (
@@ -60,7 +76,7 @@ export default function Rankings() {
       {/* Overview Cards */}
       <Grid container spacing={2}>
         {cards.map((card, i) => (
-          <Grid size={{ xs: 12, sm: 4 }} key={i}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }} key={i}>
             {card.loading ? (
               <Skeleton variant="rounded" height={160} />
             ) : (
@@ -71,13 +87,16 @@ export default function Rankings() {
       </Grid>
 
       {/* Tabbed Charts */}
-      <Paper sx={{ p: 2 }}>
+      <Paper sx={{ p: { xs: 1, sm: 2 } }}>
         <Tabs
           value={tab}
           onChange={(_, v) => setTab(v)}
           textColor="inherit"
+          variant="scrollable"
+          scrollButtons="auto"
+          allowScrollButtonsMobile
           sx={{
-            "& .MuiTab-root": { fontWeight: 600 },
+            "& .MuiTab-root": { fontWeight: 600, minWidth: 72 },
             borderBottom: 1,
             borderColor: "divider",
           }}
@@ -85,6 +104,7 @@ export default function Rankings() {
           <Tab label="等級排行" />
           <Tab label="轉蛋蒐集" />
           <Tab label="女神石" />
+          <Tab label="成就蒐集" />
         </Tabs>
         <TabPanel value={tab} index={0}>
           <ChatLevelChart />
@@ -94,6 +114,9 @@ export default function Rankings() {
         </TabPanel>
         <TabPanel value={tab} index={2}>
           <GodStoneChart />
+        </TabPanel>
+        <TabPanel value={tab} index={3}>
+          <AchievementRankChart />
         </TabPanel>
       </Paper>
     </Box>


### PR DESCRIPTION
## Summary
- 排行榜頁新增第 4 個「成就蒐集」tab（獎盃獵人），依解鎖成就數排名；後端新增 `GET /api/achievements/rankings` + `UserAchievement.getUnlockRank`
- 解決手機長名字換兩行的問題：`RankingBarChart` 標籤改左對齊、加入 CJK／全形／數學花體／emoji 寬字元感知的截斷，超出寬度以「…」收尾
- 手機 Tab 改 scrollable 避免第 4 個 tab 被截，`Paper` 內距在 xs 下從 16px 降為 8px 讓圖表呼吸空間更大

## Test plan
- [x] `yarn lint:app` / `yarn lint:frontend` 0 errors
- [x] `yarn test:app` — 250/251 (唯一失敗是既有 `images.test.js` imgur→PictShare 遷移遺留測試)
- [x] 桌面 1280px 視覺檢查：四張卡片一列 + 四個 tab、長條圖 label 左對齊、bar 延伸到右側
- [x] 手機 375px 視覺檢查（以正式站長名字資料驗證）：`🥇 𝕂𝕦𝕛𝕠𝕦…`、`7. 火車上有…` 等全部單行顯示、bar 與數值都清楚
- [x] 成就 tab 實機確認：資料由 API 正確回傳並依解鎖數排序，金銀銅獎牌 + 粉色 bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)