### PR TITLE
refactor(rankings): collapse chart wrappers + cache achievement ranking

### DIFF
--- a/app/src/controller/application/AchievementController.js
+++ b/app/src/controller/application/AchievementController.js
@@ -2,12 +2,15 @@
 const { Context, getClient } = require("bottender");
 const { text } = require("bottender/router");
 const { get } = require("lodash");
+const redis = require("../../util/redis");
 const AchievementEngine = require("../../service/AchievementEngine");
 const UserTitleModel = require("../../model/application/UserTitle");
 const UserAchievementModel = require("../../model/application/UserAchievement");
 const AchievementTemplate = require("../../templates/application/Achievement");
 
 const lineClient = getClient("line");
+const RANKING_CACHE_KEY = "AchievementRanking_v1";
+const RANKING_CACHE_TTL = 60 * 60;
 
 exports.router = [text(/^[.#/](成就|achievement|adv)$/, showAchievements)];
 
@@ -81,6 +84,9 @@ exports.api = {
 
   async getRanking(req, res) {
     try {
+      const cached = await redis.get(RANKING_CACHE_KEY);
+      if (cached) return res.json(JSON.parse(cached));
+
       const rankData = await UserAchievementModel.getUnlockRank({ limit: 10 });
       const result = await Promise.all(
         rankData.map(async (data, index) => {
@@ -89,6 +95,7 @@ exports.api = {
           return { ...data, displayName };
         })
       );
+      redis.set(RANKING_CACHE_KEY, JSON.stringify(result), { EX: RANKING_CACHE_TTL });
       res.json(result);
     } catch (err) {
       res.status(500).json({ message: err.message });

--- a/frontend/src/pages/Rankings/AchievementRankChart.jsx
+++ b/frontend/src/pages/Rankings/AchievementRankChart.jsx
@@ -1,8 +1,0 @@
-import RankingBarChart from "./RankingBarChart";
-import { RANK_COLORS } from "./OverviewCard";
-import { useAchievementRankData } from "./hooks";
-
-export default function AchievementRankChart() {
-  const { rows } = useAchievementRankData();
-  return <RankingBarChart data={rows} color={RANK_COLORS.achievement} />;
-}

--- a/frontend/src/pages/Rankings/ChatLevelChart.jsx
+++ b/frontend/src/pages/Rankings/ChatLevelChart.jsx
@@ -1,8 +1,0 @@
-import RankingBarChart from "./RankingBarChart";
-import { RANK_COLORS } from "./OverviewCard";
-import { useChatLevelData } from "./hooks";
-
-export default function ChatLevelChart() {
-  const { rows } = useChatLevelData();
-  return <RankingBarChart data={rows} color={RANK_COLORS.level} />;
-}

--- a/frontend/src/pages/Rankings/GachaRankChart.jsx
+++ b/frontend/src/pages/Rankings/GachaRankChart.jsx
@@ -1,8 +1,0 @@
-import RankingBarChart from "./RankingBarChart";
-import { RANK_COLORS } from "./OverviewCard";
-import { useGachaRankData } from "./hooks";
-
-export default function GachaRankChart() {
-  const { rows } = useGachaRankData();
-  return <RankingBarChart data={rows} color={RANK_COLORS.gacha} />;
-}

--- a/frontend/src/pages/Rankings/GodStoneChart.jsx
+++ b/frontend/src/pages/Rankings/GodStoneChart.jsx
@@ -1,8 +1,0 @@
-import RankingBarChart from "./RankingBarChart";
-import { RANK_COLORS } from "./OverviewCard";
-import { useGodStoneData } from "./hooks";
-
-export default function GodStoneChart() {
-  const { rows } = useGodStoneData();
-  return <RankingBarChart data={rows} color={RANK_COLORS.godStone} />;
-}

--- a/frontend/src/pages/Rankings/index.jsx
+++ b/frontend/src/pages/Rankings/index.jsx
@@ -2,10 +2,7 @@ import { useEffect, useState } from "react";
 import { Box, Typography, Grid, Tabs, Tab, Paper, Skeleton } from "@mui/material";
 import { EmojiEvents, Casino, Diamond, MilitaryTech } from "@mui/icons-material";
 import OverviewCard, { RANK_COLORS } from "./OverviewCard";
-import ChatLevelChart from "./ChatLevelChart";
-import GachaRankChart from "./GachaRankChart";
-import GodStoneChart from "./GodStoneChart";
-import AchievementRankChart from "./AchievementRankChart";
+import RankingBarChart from "./RankingBarChart";
 import {
   useChatLevelData,
   useGachaRankData,
@@ -107,16 +104,16 @@ export default function Rankings() {
           <Tab label="成就蒐集" />
         </Tabs>
         <TabPanel value={tab} index={0}>
-          <ChatLevelChart />
+          <RankingBarChart data={level.rows} color={RANK_COLORS.level} />
         </TabPanel>
         <TabPanel value={tab} index={1}>
-          <GachaRankChart />
+          <RankingBarChart data={gacha.rows} color={RANK_COLORS.gacha} />
         </TabPanel>
         <TabPanel value={tab} index={2}>
-          <GodStoneChart />
+          <RankingBarChart data={godStone.rows} color={RANK_COLORS.godStone} />
         </TabPanel>
         <TabPanel value={tab} index={3}>
-          <AchievementRankChart />
+          <RankingBarChart data={achievement.rows} color={RANK_COLORS.achievement} />
         </TabPanel>
       </Paper>
     </Box>


### PR DESCRIPTION
## Summary
Follow-up cleanup on #689 driven by `/simplify` review:

- Remove the four one-line chart-wrapper files (`ChatLevelChart`, `GachaRankChart`, `GodStoneChart`, `AchievementRankChart`) and feed each ranking's already-captured hook data into `RankingBarChart` directly from `Rankings/index.jsx`. Each hook now fires once per page instead of twice (overview card + wrapper).
- Cache `GET /api/achievements/rankings` in Redis for 1 hour to match the existing gacha ranking pattern. Once warm, a request skips 10 `lineClient.getUserProfile` calls.

## Test plan
- [x] `yarn lint:app` / `yarn lint:frontend` 0 errors
- [x] `yarn test:app` — 250/251 (pre-existing imgur test unrelated)
- [x] 桌面 1280 + 手機 375 實機確認四個 tab 圖表仍正確渲染、成就 tab 資料正常載入

🤖 Generated with [Claude Code](https://claude.com/claude-code)