### PR TITLE
fix(cron): start every scheduled job on worker boot

### DIFF
--- a/app/__tests__/tasks.test.js
+++ b/app/__tests__/tasks.test.js
@@ -1,0 +1,64 @@
+// Regression test for 2026-03-08 bug (befa043) where positional-args wiring
+// of CronJob routed `immediate` into the `start` slot, leaving every
+// `immediate: false` cron job constructed but never ticking.
+//
+// The invariant below rejects that class of bug at the tasks.js layer:
+// every crontab entry must be registered with `start: true`, regardless of
+// whether it should also run on init.
+
+const path = require("path");
+
+jest.mock("../src/model/application/Task", () => ({
+  init: jest.fn().mockResolvedValue(undefined),
+  write: jest.fn().mockResolvedValue(undefined),
+}));
+
+const fromMock = jest.fn(() => ({ start: jest.fn(), stop: jest.fn() }));
+jest.mock("cron", () => ({
+  CronJob: { from: fromMock },
+}));
+
+describe("app/tasks.js cron registration", () => {
+  let crontab;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = "test";
+    fromMock.mockClear();
+    jest.isolateModules(() => {
+      require("../tasks");
+    });
+    crontab = require("../config/crontab.config");
+  });
+
+  test("every configured job is registered exactly once", () => {
+    expect(fromMock).toHaveBeenCalledTimes(crontab.length);
+  });
+
+  test("every job is constructed with start: true (would have caught befa043)", () => {
+    for (const call of fromMock.mock.calls) {
+      const options = call[0];
+      expect(options).toEqual(
+        expect.objectContaining({
+          start: true,
+          cronTime: expect.any(String),
+          onTick: expect.any(Function),
+        })
+      );
+    }
+  });
+
+  test("runOnInit mirrors the config's `immediate` flag", () => {
+    const calls = fromMock.mock.calls.map(c => c[0]);
+    crontab.forEach((entry, idx) => {
+      expect(calls[idx].runOnInit).toBe(Boolean(entry.immediate));
+      expect(calls[idx].cronTime).toBe(entry.period.join(" "));
+    });
+  });
+
+  test("every crontab entry points at a resolvable bin script", () => {
+    for (const entry of crontab) {
+      const resolved = path.resolve(__dirname, "..", entry.require_path);
+      expect(() => require.resolve(resolved)).not.toThrow();
+    }
+  });
+});

--- a/app/tasks.js
+++ b/app/tasks.js
@@ -1,4 +1,4 @@
-const cron = require("cron").CronJob;
+const { CronJob } = require("cron");
 const crontab = require("./config/crontab.config");
 const Task = require("./src/model/application/Task");
 const moment = require("moment");
@@ -12,17 +12,22 @@ const jobs = [];
 
 Task.init();
 
+// `immediate` in crontab.config maps to cron's `runOnInit` (fire once on
+// startup in addition to the schedule). `start: true` must always be set —
+// without it the job is constructed but never ticks. A previous positional-
+// args wiring (befa043) silently misrouted `immediate` into the `start`
+// slot and left every `immediate: false` job dormant for weeks.
 crontab.forEach(job => {
   const { name, description, period, immediate, require_path } = job;
-  const task = new cron(
-    period.join(" "),
-    async () => {
+  const task = CronJob.from({
+    cronTime: period.join(" "),
+    onTick: async () => {
       await require(require_path)();
       await Task.write({ name, description }, moment().toDate());
     },
-    null,
-    immediate
-  );
+    start: true,
+    runOnInit: Boolean(immediate),
+  });
 
   jobs.push({
     name,


### PR DESCRIPTION
## Summary

Restore 8 silently-dormant cron jobs on the worker container. Since the 2026-03-08 deploy (commit befa043), every job configured with `immediate: false` was constructed but never ticked, because `CronJob`'s positional constructor routed the config's `immediate` flag into the `start` slot (arg 4) instead of `runOnInit` (arg 7).

Affected jobs (none ran for ~6 weeks):
- `AutoGacha` — monthly-card subscribers' nightly auto-draw (what triggered this investigation)
- `AchievementCron` — daily milestone evaluation
- `TitleDelivery` — daily title reassignment (the entire achievement titles feature shipped 2026-04-16 has never actually delivered a title in prod)
- `DailyCleanup` — closed groups / left members / dead custom commands
- `MonthlyReset` — monthly message record reset (missed 2026-04-01)
- `ChatRanking` — chat-level ranking refresh
- `WeeklyMemberAudit` + `ConsumeCleanUpMembers` — member cleanup pipeline

## Fix

Switch `app/tasks.js` from the positional `new CronJob(...)` form to the named `CronJob.from({...})` form so `start: true` is always explicit and `immediate` correctly maps to `runOnInit`. Cron v4.4.0 supports this via `CronJob.from`.

Add a regression test (`app/__tests__/tasks.test.js`) that asserts every crontab entry is registered with `start: true` and that `runOnInit` mirrors the config's `immediate` flag. That invariant directly catches the class of bug befa043 introduced.

## Deployment notes

First boot after deploy will wake up all 8 jobs. Expect:
- `ChatRanking` fires on next `:12` minute — rank column refreshes within 10 min.
- `AchievementCron` + `TitleDelivery` fire at the next 03:00 / 03:10 — first `/稱號` with real data goes live the morning after deploy.
- `DailyCleanup` fires at next 00:00 — first run will sweep 6 weeks of accumulated stale rows. Watch DB load; nothing should break, but the delete volume will be larger than steady-state.
- `MonthlyReset` will next fire on 1st of the following month. April's reset was missed; manual replay optional, depending on whether stale monthly counters matter.
- `AutoGacha` fires tonight at 23:50 — monthly-card users will get their full daily quota (fixed in 5975302).

No new migrations. Worker restart required to pick up the change.

## Test plan

- [x] `yarn test __tests__/tasks.test.js` — 4 passing
- [x] `yarn lint` — clean
- [ ] Deploy to prod worker, check `docker logs redive_linebot-worker-1` for `cron.auto_gacha.start` within 24h
- [ ] Verify `SELECT COUNT(*) FROM auto_gacha_job_log WHERE run_date = CURDATE()` > 0 after 23:50
- [ ] Verify `SELECT COUNT(*) FROM user_titles` > 0 after next 03:10
- [ ] Verify `tasks` table in `app/assets/task.db` starts receiving rows for previously-dormant job names

🤖 Generated with [Claude Code](https://claude.com/claude-code)