### PR TITLE
fix(middleware): always refetch guild config so LIFF toggles take effect

### DIFF
--- a/app/src/middleware/config.js
+++ b/app/src/middleware/config.js
@@ -19,10 +19,9 @@ module.exports = async (context, props) => {
   }
 
   if (type !== "group") return props.next;
-  // 如果已經設定過就不再設定
-  let isSet = context.state.sender && context.state.guildConfig;
-  if (isSet) return props.next;
 
+  // 每次事件都重新取（兩端皆走 Redis 快取，寫入時即時 invalidate），
+  // 避免 Bottender session state 把舊的 guildConfig 持久化導致 LIFF 設定不生效。
   const { groupId } = context.event.source;
 
   const [sender, guildConfig] = await Promise.all([


### PR DESCRIPTION
## Summary
- LIFF 群組設定（關閉抽卡等開關）儲存後不會生效，使用者仍可繼續使用功能。
- 根因：`app/src/middleware/config.js` 在 `context.state.guildConfig` 已存在時直接 `return`；但 Bottender 把 `context.state` 持久化到 Redis session，因此這條路徑只會在群組第一次出現時跑一次。LIFF 儲存雖正確 invalidate `GuildConfig_*` Redis 快取，但 middleware 從此不再查那個快取，舊的 toggle 就一直黏在 session state 裡。
- 修法：拿掉 `isSet` 早退邏輯，每個 event 都呼叫 `GuildConfigModel.fetchConfig` / `getSender`。兩個 model 都已經有 60 分鐘 Redis 快取且寫入時即時 invalidate，DB 流量不受影響，每次事件多 2 個 sub-ms 的 Redis GET 而已。
- 影響範圍：所有依賴 `context.state.guildConfig` 的 gate（`Gacha` / `Battle` / `PrincessCharacter` / `CustomerOrder` / `GlobalOrder` / `PrincessInformation`）以及 `context.state.sender`（自訂頭像）一併修好。

## Test plan
- [x] `yarn lint` 在 `app/` 通過
- [x] `yarn test` 在 `app/`：254/255 通過（剩一個 `__tests__/api/images.test.js` 是 pre-existing imgur stale test，main 分支同樣 fail）
- [ ] 部署後手動驗證：在 LIFF 把群組抽卡關掉 → 立即在 LINE 群組嘗試 `抽蛋` → 應被拒絕；再開回來 → 立即可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)