### PR TITLE
fix(xp-history): use HelpOutlined icon name (unblocks frontend build)

### DIFF
--- a/frontend/src/pages/XpHistory/index.jsx
+++ b/frontend/src/pages/XpHistory/index.jsx
@@ -14,7 +14,7 @@ import {
   Divider,
   Link,
 } from "@mui/material";
-import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutlined";
 import useLiff from "../../context/useLiff";
 import AlertLogin from "../../components/AlertLogin";
 import api from "../../services/api";


### PR DESCRIPTION
## Summary

- 修 typo：`@mui/icons-material/HelpOutline` → `HelpOutlined`（MUI 8 沒有 `HelpOutline.js`，正確名稱是 `HelpOutlined`）
- 解掉 main 上 frontend Docker build 失敗的問題（rolldown production build 嚴格遵守 exports field）

## Why dev didn't catch this

Vite dev server 解析 sub-path import 比較寬鬆；rolldown production build 嚴格按 `@mui/icons-material/package.json` 的 `exports` 條件，找不到 `./HelpOutline.js` 直接報錯。

CI/CD failure: https://github.com/hanshino/redive_linebot/actions/runs/25231028896/job/73986283161

## Test plan

- [x] `yarn --cwd frontend build` — passed (1.32s)
- [ ] CI/CD 重跑，frontend job 通過後 deploy job 自動接上
- [ ] Portainer 確認新映像 pull 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)