### PR TITLE
chore(race): switch to weekly betting cycle (Mon 08:00 → Sun 20:00)

### DIFF
--- a/app/config/default.json
+++ b/app/config/default.json
@@ -42,7 +42,7 @@
     "race": {
       "trackLength": 50,
       "runnerCount": 5,
-      "bettingDurationMinutes": 240,
+      "bettingDurationMinutes": 9360,
       "advanceIntervalMinutes": 1,
       "stamina": {
         "initial": 100,
@@ -64,7 +64,7 @@
         "feeRate": 0.1
       },
       "schedule": {
-        "startHours": [8, 14, 20]
+        "startHours": [8]
       }
     },
     "janken": {


### PR DESCRIPTION
## Summary

賽馬參與度偏低（目前一天 3 場、4 小時下注期），改成一週一場、週一 08:00 開放下注 → 週日 20:00 開賽 → ~20:50 結束。週期拉長後可以把人潮集中到單一場次、提高賠率張力。

- `bettingDurationMinutes`: 240 → 9360（6.5 天 = 156 小時）
- `schedule.startHours`: [8, 14, 20] → [8]

## Why no code change

`bin/RaceAdvance.js` 的 cron 邏輯本身就支援這個週期：

- `getActive()` 過濾 `betting/running` → 比賽進行中不會建第二場
- 比賽結束後 `getActive()` 回 null，但 `startHours=[8]` 不會在當天 21:00 之後再觸發 → 自然等到下個 08:00
- 同小時去重（`hourStart` 那段）防止 cron 一分鐘內重複建場

第一場新週期比賽建立後，後續會自動鎖在「開放 = 週X 08:00、開賽 = 週(X-1) 20:00」這個迴圈。

## Deploy notes

- **現有 in-flight race 不受影響**：`betting_end_at` 在建場時就鎖入 DB，舊場次跑完它原本的 4 小時下注期，新設定只影響下一場之後。
- 純 config 變更，無 migration、無 seed。
- 第一場新週期的「星期幾」由 worker 重啟後第一個無 active 比賽的 08:00 決定。如果想精準從週一開始，可以挑時間部署。

## Test plan

- [ ] worker 重啟，確認 `Race Advance` cron 正常啟動
- [ ] 等舊場結束後，下個 08:00 確認新場以 `bettingDurationMinutes=9360` 建立（檢查 DB `race.betting_end_at` 是 6.5 天後）
- [ ] 該場 betting 期間，cron 持續沒有重複建場
- [ ] betting_end_at 到了之後，自動轉 running 並開始 advance round