### PR TITLE
feat(me): add XP history CTA and clarify daily-cap wording

### DIFF
--- a/app/src/controller/application/ChatLevelController.js
+++ b/app/src/controller/application/ChatLevelController.js
@@ -63,6 +63,8 @@ function resolveActiveTrialStar(activeTrialId, allTrials) {
 const { resolveTierUppers } = require("../../service/chatXp/diminishTier");
 const { todayUtc8 } = require("../../util/date");
 
+const XP_HISTORY_LIFF_PATH = "/xp-history";
+
 /**
  * 顯示個人狀態，現複合了其他布丁系統的資訊
  * @param {import("bottender").LineContext} context
@@ -187,6 +189,7 @@ exports.showStatus = async (context, props) => {
       dailyRaw,
       tier1Upper,
       tier2Upper,
+      xpHistoryUri: commonTemplate.getLiffUri("full", XP_HISTORY_LIFF_PATH),
     });
 
     context.replyFlex(`${displayName} 的狀態`, { type: "carousel", contents: bubbles });
@@ -433,7 +436,7 @@ exports.showXpHistory = async context => {
       }
     }
 
-    const liffUri = commonTemplate.getLiffUri("full", "/xp-history");
+    const liffUri = commonTemplate.getLiffUri("full", XP_HISTORY_LIFF_PATH);
     const prestigeLiffUri = commonTemplate.getLiffUri("full", "/prestige");
     const flex = XpHistoryBubble.build({ summary, groupName, liffUri, prestigeLiffUri });
     context.replyFlex(flex.altText, flex.contents);

--- a/app/src/templates/application/Me/Profile.js
+++ b/app/src/templates/application/Me/Profile.js
@@ -1,5 +1,5 @@
 const humanNumber = require("human-number");
-const { buildSubPanel, COLORS } = require("./_shared");
+const { buildSubPanel, buildLinkPill, COLORS } = require("./_shared");
 
 const formatExp = n => humanNumber(n, v => Number.parseFloat(v).toFixed(1));
 
@@ -10,18 +10,26 @@ function buildDailyCap({ dailyRaw, tier1Upper, tier2Upper }) {
   const fillPct = Math.max(0, Math.min(100, Math.round((raw / tier2Upper) * 100)));
 
   let zoneLabel;
-  if (raw < tier1Upper) zoneLabel = "🟢 滿速";
-  else if (raw < tier2Upper) zoneLabel = "🟡 30%";
-  else zoneLabel = "🔴 已封頂";
+  let valueText;
+  if (raw < tier1Upper) {
+    zoneLabel = "🟢 滿速";
+    valueText = `${raw} / ${tier1Upper} · ${zoneLabel}`;
+  } else if (raw < tier2Upper) {
+    zoneLabel = "🟡 30%";
+    valueText = `${raw} / ${tier2Upper} · ${zoneLabel}`;
+  } else {
+    zoneLabel = "🔴 3% 微量";
+    valueText = `${raw} · ${zoneLabel}`;
+  }
 
   const head = {
     type: "box",
     layout: "horizontal",
     contents: [
-      { type: "text", text: "今日獲取上限", size: "xxs", color: "#FFFFFF", flex: 0 },
+      { type: "text", text: "今日經驗區段", size: "xxs", color: "#FFFFFF", flex: 0 },
       {
         type: "text",
-        text: `${raw} / ${tier2Upper} · ${zoneLabel}`,
+        text: valueText,
         size: "xxs",
         color: COLORS.amber300,
         weight: "bold",
@@ -218,36 +226,7 @@ function buildHero({
 }
 
 function buildSubBadge({ text }) {
-  return {
-    type: "box",
-    layout: "horizontal",
-    contents: [
-      {
-        type: "text",
-        text: `🎟 訂閱中 · ${text}`,
-        size: "xxs",
-        color: COLORS.cyan700,
-        weight: "bold",
-        flex: 1,
-        gravity: "center",
-      },
-      {
-        type: "text",
-        text: "›",
-        size: "md",
-        color: COLORS.cyan700,
-        weight: "bold",
-        align: "end",
-        flex: 0,
-      },
-    ],
-    backgroundColor: COLORS.cyanBg,
-    paddingStart: "md",
-    paddingEnd: "md",
-    paddingTop: "sm",
-    paddingBottom: "sm",
-    margin: "none",
-  };
+  return buildLinkPill({ label: `🎟 訂閱中 · ${text}`, margin: "none" });
 }
 
 function buildStat({ fraction, icon, label, tone }) {
@@ -389,6 +368,7 @@ exports.build = ({
   dailyRaw,
   tier1Upper,
   tier2Upper,
+  xpHistoryUri,
 }) => {
   const bodyContents = [
     buildHero({
@@ -431,16 +411,13 @@ exports.build = ({
     type: "box",
     layout: "vertical",
     contents: [
-      {
-        type: "button",
-        style: "secondary",
-        height: "sm",
-        action: {
-          type: "message",
-          label: "查看經驗歷程",
-          text: "#經驗歷程",
-        },
-      },
+      buildLinkPill({
+        label: "📈 查看經驗歷程",
+        size: "xs",
+        cornerRadius: "md",
+        alignItems: "center",
+        action: { type: "uri", label: "查看經驗歷程", uri: xpHistoryUri },
+      }),
     ],
     paddingStart: "lg",
     paddingEnd: "lg",

--- a/app/src/templates/application/Me/__tests__/Profile.test.js
+++ b/app/src/templates/application/Me/__tests__/Profile.test.js
@@ -11,32 +11,32 @@ const baseInput = {
   signinDays: 7,
   subscriptionPanel: null,
   subscriptionBadge: null,
+  xpHistoryUri: "https://liff.line.me/test-liff-id/xp-history",
 };
 
-/**
- * Recursively scan a flex bubble for any text element matching predicate.
- * Walks every plain-object property — handles bubble.body / .header /
- * box.contents / etc. uniformly.
- */
-function findText(node, predicate) {
+function findNode(node, predicate) {
   if (!node) return null;
   if (Array.isArray(node)) {
     for (const child of node) {
-      const found = findText(child, predicate);
+      const found = findNode(child, predicate);
       if (found) return found;
     }
     return null;
   }
   if (typeof node !== "object") return null;
-  if (node.type === "text" && typeof node.text === "string" && predicate(node.text)) {
-    return node.text;
-  }
+  const hit = predicate(node);
+  if (hit) return hit;
   for (const value of Object.values(node)) {
-    const found = findText(value, predicate);
+    const found = findNode(value, predicate);
     if (found) return found;
   }
   return null;
 }
+
+const findText = (root, pred) =>
+  findNode(root, n =>
+    n.type === "text" && typeof n.text === "string" && pred(n.text) ? n.text : null
+  );
 
 describe("Me/Profile.build", () => {
   it("renders Lv pill without legacy range/rank text", () => {
@@ -84,15 +84,22 @@ describe("Me/Profile.build", () => {
     expect(flagRow).toBe("★ 轉生 1 次");
   });
 
-  it("includes 經驗歷程 CTA button", () => {
+  it("renders 經驗歷程 CTA as a uri action pointing at the LIFF URL", () => {
     const bubble = Profile.build(baseInput);
-    expect(JSON.stringify(bubble)).toMatch(/查看經驗歷程/);
+    const action = findNode(bubble, n =>
+      n.action && n.action.label === "查看經驗歷程" ? n.action : null
+    );
+    expect(action).toEqual({
+      type: "uri",
+      label: "查看經驗歷程",
+      uri: baseInput.xpHistoryUri,
+    });
   });
 
   describe("daily cap bar", () => {
     it("omits the daily-cap bar when caps are missing", () => {
       const bubble = Profile.build(baseInput);
-      const capText = findText(bubble, t => t.includes("今日獲取上限"));
+      const capText = findText(bubble, t => t.includes("今日經驗區段"));
       expect(capText).toBeNull();
     });
 
@@ -103,10 +110,10 @@ describe("Me/Profile.build", () => {
         tier1Upper: 400,
         tier2Upper: 1000,
       });
-      const labelText = findText(bubble, t => t.startsWith("今日獲取"));
-      expect(labelText).toBe("今日獲取上限");
+      const labelText = findText(bubble, t => t.startsWith("今日經驗"));
+      expect(labelText).toBe("今日經驗區段");
       const valueText = findText(bubble, t => /^\d+\s*\/\s*\d+/.test(t));
-      expect(valueText).toBe("250 / 1000 · 🟢 滿速");
+      expect(valueText).toBe("250 / 400 · 🟢 滿速");
     });
 
     it("renders 30% zone when daily raw is between tier1 and tier2", () => {
@@ -120,15 +127,15 @@ describe("Me/Profile.build", () => {
       expect(valueText).toBe("700 / 1000 · 🟡 30%");
     });
 
-    it("renders 已封頂 zone when daily raw exceeds tier2", () => {
+    it("renders 3% 微量 zone without misleading divisor when daily raw exceeds tier2", () => {
       const bubble = Profile.build({
         ...baseInput,
         dailyRaw: 1500,
         tier1Upper: 400,
         tier2Upper: 1000,
       });
-      const valueText = findText(bubble, t => /^\d+\s*\/\s*\d+/.test(t));
-      expect(valueText).toBe("1500 / 1000 · 🔴 已封頂");
+      const valueText = findText(bubble, t => t.includes("微量"));
+      expect(valueText).toBe("1500 · 🔴 3% 微量");
     });
 
     it("uses expanded caps when blessings widen the tiers", () => {
@@ -139,7 +146,7 @@ describe("Me/Profile.build", () => {
         tier2Upper: 1200, // blessing 5
       });
       const valueText = findText(bubble, t => /^\d+\s*\/\s*\d+/.test(t));
-      expect(valueText).toBe("500 / 1200 · 🟢 滿速");
+      expect(valueText).toBe("500 / 600 · 🟢 滿速");
     });
   });
 });

--- a/app/src/templates/application/Me/_shared.js
+++ b/app/src/templates/application/Me/_shared.js
@@ -126,4 +126,41 @@ const buildSubPanel = ({ key, titleText, expireText, effects }) => {
   };
 };
 
-module.exports = { COLORS, buildAccentBar, buildSubPanel };
+const buildLinkPill = ({ label, action, size = "xxs", cornerRadius, alignItems, margin }) => {
+  const pill = {
+    type: "box",
+    layout: "horizontal",
+    contents: [
+      {
+        type: "text",
+        text: label,
+        size,
+        color: COLORS.cyan700,
+        weight: "bold",
+        flex: 1,
+        gravity: "center",
+      },
+      {
+        type: "text",
+        text: "›",
+        size: "md",
+        color: COLORS.cyan700,
+        weight: "bold",
+        align: "end",
+        flex: 0,
+      },
+    ],
+    backgroundColor: COLORS.cyanBg,
+    paddingStart: "md",
+    paddingEnd: "md",
+    paddingTop: "sm",
+    paddingBottom: "sm",
+  };
+  if (cornerRadius) pill.cornerRadius = cornerRadius;
+  if (alignItems) pill.alignItems = alignItems;
+  if (margin) pill.margin = margin;
+  if (action) pill.action = action;
+  return pill;
+};
+
+module.exports = { COLORS, buildAccentBar, buildSubPanel, buildLinkPill };

--- a/app/src/templates/application/Me/index.js
+++ b/app/src/templates/application/Me/index.js
@@ -52,6 +52,7 @@ exports.buildBubbles = data => {
         dailyRaw: data.dailyRaw,
         tier1Upper: data.tier1Upper,
         tier2Upper: data.tier2Upper,
+        xpHistoryUri: data.xpHistoryUri,
       })
     );
   } else {
@@ -71,6 +72,7 @@ exports.buildBubbles = data => {
         dailyRaw: data.dailyRaw,
         tier1Upper: data.tier1Upper,
         tier2Upper: data.tier2Upper,
+        xpHistoryUri: data.xpHistoryUri,
       })
     );
     bubbles.push(Subscription.build({ panels: cards }));


### PR DESCRIPTION
## Summary

- /me Profile flex 新增「📈 查看經驗歷程」link pill，點擊開啟 `/xp-history` LIFF
- 修正 daily-cap 文案誤導：玩家原本以為超過 tier2 後就「封頂」拿不到經驗，實際上 Tier 3 仍以 3% 倍率累積
  - 標題：「今日獲取上限」→「今日經驗區段」
  - Tier 3 標籤：「🔴 已封頂」→「🔴 3% 微量」，並移除誤導的 `raw / tier2Upper` 分母
  - 滿速區改用 `tier1Upper` 為分母，更貼近下個邊界

## Test plan

- [x] `yarn test src/templates/application/Me` — 12/12 通過
- [ ] 在 LINE 中觸發 `!me` 確認：
  - [ ] 「查看經驗歷程」link pill 可點擊並開啟 LIFF
  - [ ] 滿速區顯示 `raw / tier1Upper · 🟢 滿速`
  - [ ] 30% 區顯示 `raw / tier2Upper · 🟡 30%`
  - [ ] Tier 3 顯示 `raw · 🔴 3% 微量`（無分母）

🤖 Generated with [Claude Code](https://claude.com/claude-code)