### PR TITLE
refactor(logging): cut noise, raise docker log retention

### DIFF
--- a/app/bin/EventDequeue.js
+++ b/app/bin/EventDequeue.js
@@ -119,10 +119,6 @@ async function handleMessage(event) {
   let { userId, groupId } = event.source;
   if (!userId || !groupId) return;
 
-  if (event.message.type === "text") {
-    DefaultLogger.info(groupId, userId, event.message.text);
-  }
-
   userRecord(userId);
   await Promise.all([groupRecord(groupId), handleMemberJoined(event)]);
 

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -38,6 +38,7 @@ const { transfer } = require("./middleware/dcWebhook");
 const redis = require("./util/redis");
 const i18n = require("./util/i18n");
 const traffic = require("./util/traffic");
+const { DefaultLogger } = require("./util/Logger");
 const { showManagePlace } = require("./templates/application/Admin");
 const AdminModel = require("./model/application/Admin");
 const axios = require("axios");
@@ -138,7 +139,7 @@ async function HandlePostback(context, { next }) {
       route("*", next),
     ]);
   } catch (e) {
-    console.error(e);
+    DefaultLogger.error("HandlePostback failed", e);
     return next;
   }
 }
@@ -200,7 +201,6 @@ async function OrderBased(context, { next }) {
     ),
     text(/^[.#/](你的狀態|you)/, context => {
       const mentionees = context.event.message.mention.mentionees;
-      console.log(mentionees);
       if (mentionees.length === 0) {
         return context.replyText("請標記要查詢的對象");
       }
@@ -262,7 +262,7 @@ async function OrderBased(context, { next }) {
 
       context.replyFlex("實用連結", bubble);
     }),
-    text(".test", () => console.log("test")),
+    text(".test", () => DefaultLogger.debug("test")),
     text("/resetsession", OpenaiController.resetSession),
     route("*", next),
   ]);
@@ -347,7 +347,7 @@ async function recordLatestGroupUser(context, { next }) {
     // 保留 timestamp 在 30 分鐘內的資料
     await redis.zRemRangeByScore(key, 0, Date.now() - 30 * 60 * 1000);
   } catch (e) {
-    console.error(e);
+    DefaultLogger.error("recordLatestGroupUser zAdd failed", e);
   }
 
   return next;

--- a/app/src/controller/application/OpenaiController.js
+++ b/app/src/controller/application/OpenaiController.js
@@ -63,13 +63,7 @@ exports.naturalLanguageUnderstanding = async function (context, { next }) {
 
   await recordSession(sourceId, `${displayName}:${replaceText}`);
   const chatSession = await getSession(sourceId);
-  console.log("=== PROMPT ===");
-  console.log(prompt);
-  console.log("=== CHAT SESSION ===");
-  console.log(chatSession);
-  console.log("=== FULL CONTENT ===");
   const fullContent = [...prompt, ...chatSession, "x"];
-  console.log(fullContent);
   const result = await model.generateContent(fullContent);
 
   const reponseText = result.response.text().replace(/bot:/gi, "").trim();

--- a/app/src/controller/application/WorldBossController.js
+++ b/app/src/controller/application/WorldBossController.js
@@ -51,7 +51,7 @@ async function revokeCharm(context) {
     EX: 20,
   });
 
-  DefaultLogger.info(`${userId} 已詠唱 持續 20 秒`);
+  DefaultLogger.debug(`${userId} 已詠唱 持續 20 秒`);
 }
 
 /**
@@ -144,7 +144,7 @@ async function revokeAttack(context) {
     },
   ];
   const isSuccess = random(successSettings);
-  DefaultLogger.info(`${userId} 詠唱結果 ${isSuccess ? "成功" : "失敗"}`);
+  DefaultLogger.debug(`${userId} 詠唱結果 ${isSuccess ? "成功" : "失敗"}`);
   if (hasCharm == 1 && isSuccess) {
     cost = 0;
     messages.push(i18n.__("message.world_boss.revoke_attack_success"));
@@ -455,14 +455,14 @@ const attackOnBoss = async (context, props) => {
 
   // 沒有會員id，跳過不處理
   if (!id) {
-    DefaultLogger.info(`no member id ${userId}`);
+    DefaultLogger.warn(`no member id ${userId}`);
     return;
   }
 
   // 判斷是否可以攻擊
   const canAttack = await isUserCanAttack(id);
   if (!canAttack) {
-    DefaultLogger.info(
+    DefaultLogger.debug(
       `user ${displayName} can not attack ${userId}. Maybe cache or reach limit in this period.`
     );
 
@@ -481,7 +481,7 @@ const attackOnBoss = async (context, props) => {
 
   // 如果抓不到資料，跳過不處理
   if (!eventBoss) {
-    DefaultLogger.info(`no event boss ${worldBossEventId}`);
+    DefaultLogger.warn(`no event boss ${worldBossEventId}`);
     return;
   }
 
@@ -491,14 +491,14 @@ const attackOnBoss = async (context, props) => {
 
   // 如果這個活動已經結束，則不處理
   if (moment(end_time).isBefore(moment())) {
-    DefaultLogger.info(`event ${name} is ended.`);
+    DefaultLogger.debug(`event ${name} is ended.`);
     return;
   }
 
   // 如果此王已經死亡，則不處理
   let remainHp = eventBoss.hp - parseInt(totalDamage || 0);
   if (remainHp <= 0) {
-    DefaultLogger.info(
+    DefaultLogger.debug(
       `boss is dead ${displayName} skip, boss hp ${eventBoss.hp}, totaldamage ${totalDamage}`
     );
     return;
@@ -628,7 +628,7 @@ const attackOnBoss = async (context, props) => {
     );
   }
 
-  DefaultLogger.info(
+  DefaultLogger.debug(
     `${displayName} 造成了 ${calculateDamagePercentage(eventBoss.hp, damage)} ${JSON.stringify(
       sender
     )}`
@@ -674,7 +674,7 @@ async function handleKeepingMessage(worldBossEventId, context, keepMessage) {
         identify: groupId,
       }
     );
-    DefaultLogger.info(`keep message ${keepMessage}`);
+    DefaultLogger.debug(`keep message ${keepMessage}`);
     return;
   }
 
@@ -723,7 +723,7 @@ async function isUserCanAttack(userId) {
   }
 
   let canAttack = totalCost < config.get("worldboss.daily_limit");
-  console.log(`${userId} can attack ${canAttack}, currentCost ${totalCost}`);
+  DefaultLogger.debug(`${userId} can attack ${canAttack}, currentCost ${totalCost}`);
 
   // 不管是否可以攻擊，都要更新 redis 的資料
   await redis.set(key, 1, {
@@ -777,10 +777,8 @@ async function decideLevelResult({ level, exp, earnedExp }) {
     levelUp = true;
   }
 
-  console.log(
-    `${level} level up to ${newLevel}`,
-    { levelUp, levelUpCount },
-    { newExp, nextLevelExp }
+  DefaultLogger.debug(
+    `${level} level up to ${newLevel} levelUp=${levelUp} count=${levelUpCount} newExp=${newExp} nextLevelExp=${nextLevelExp}`
   );
 
   return {

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -270,7 +270,7 @@ async function detectCanDaily(userId) {
     return acc + effectCount;
   }, dailyLimit);
 
-  CustomLogger.info(`detectCanDaily: ${userId} useCount: ${usedCount} bonusCount: ${bonusCount}`);
+  CustomLogger.debug(`detectCanDaily: ${userId} useCount: ${usedCount} bonusCount: ${bonusCount}`);
 
   if (usedCount >= bonusCount) {
     // 超過每日限制，設定 cache 1 天

--- a/app/src/util/Logger.js
+++ b/app/src/util/Logger.js
@@ -1,20 +1,20 @@
 const log4js = require("log4js");
 
+const isProduction = process.env.NODE_ENV === "production";
+const defaultLevel = isProduction ? "info" : "debug";
+const level = process.env.LOG_LEVEL || defaultLevel;
+
+const layout = isProduction
+  ? { type: "pattern", pattern: "[%d{ISO8601}] [%p] %c - %m" }
+  : { type: "basic" };
+
 log4js.configure({
   appenders: {
-    std: { type: "stdout", level: "all", layout: { type: "basic" } },
-    file: {
-      type: "dateFile",
-      filename: `${__dirname}/../../log/error_log.log`,
-      keepFileExt: true,
-      encoding: "utf-8",
-      compress: true,
-      pattern: ".yyyMMdd",
-    },
+    std: { type: "stdout", layout },
   },
   categories: {
-    default: { appenders: ["std"], level: "debug" },
-    custom: { appenders: ["std"], level: "all" },
+    default: { appenders: ["std"], level },
+    custom: { appenders: ["std"], level },
   },
 });
 

--- a/app/src/util/sqlite.js
+++ b/app/src/util/sqlite.js
@@ -4,7 +4,6 @@ const knex = require("knex");
  * @returns { import("knex").Knex }
  */
 module.exports = file => {
-  console.log("file", file);
   return knex({
     client: "better-sqlite3",
     connection: {

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -15,7 +15,7 @@ services:
 
   bot:
     image: hanshino/redive_backend
-    env_file: ./.env
+    env_file: stack.env
     restart: always
     expose:
       - 9527
@@ -23,7 +23,7 @@ services:
       - infra
       - traefik
     volumes:
-      - ./app/assets:/usr/src/app/assets
+      - /home/hanshino/workspace/redive_linebot/app/assets:/usr/src/app/assets
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.${PROJECT_NAME}_bot-secure.rule=Host(`${APP_DOMAIN}`) && (PathPrefix(`/api`) || PathPrefix(`/webhooks`) || PathPrefix(`/bot-assets`) || PathPrefix(`/socket.io`))"
@@ -41,12 +41,12 @@ services:
 
   worker:
     image: hanshino/redive_backend
-    env_file: ./.env
+    env_file: stack.env
     restart: always
     networks:
       - infra
     volumes:
-      - ./app/assets:/usr/src/app/assets
+      - /home/hanshino/workspace/redive_linebot/app/assets:/usr/src/app/assets
     command: yarn worker
     logging:
       driver: "json-file"

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -36,8 +36,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "1k"
-        max-file: "3"
+        max-size: "10m"
+        max-file: "10"
 
   worker:
     image: hanshino/redive_backend
@@ -51,8 +51,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "1k"
-        max-file: "3"
+        max-size: "10m"
+        max-file: "10"
 
 networks:
   traefik:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -23,7 +23,7 @@ services:
       - infra
       - traefik
     volumes:
-      - /home/hanshino/workspace/redive_linebot/app/assets:/usr/src/app/assets
+      - ${ASSETS_HOST_PATH}:/usr/src/app/assets
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.${PROJECT_NAME}_bot-secure.rule=Host(`${APP_DOMAIN}`) && (PathPrefix(`/api`) || PathPrefix(`/webhooks`) || PathPrefix(`/bot-assets`) || PathPrefix(`/socket.io`))"
@@ -46,7 +46,7 @@ services:
     networks:
       - infra
     volumes:
-      - /home/hanshino/workspace/redive_linebot/app/assets:/usr/src/app/assets
+      - ${ASSETS_HOST_PATH}:/usr/src/app/assets
     command: yarn worker
     logging:
       driver: "json-file"


### PR DESCRIPTION
## Summary

- 線上 docker log driver 設成 `max-size: 1k`、`max-file: 3`（總量 3KB），`docker logs --tail 100` 實測只剩 23 行；改為 `10m × 10`（100MB）
- 移除主要噪音源：`EventDequeue` 對每則聊天訊息 log groupId/userId/text、`OpenaiController` 對每次請求 dump 完整 prompt/session/full content、`sqlite.js` 遺留 debug、app.js `.test`/mentionees 裸 `console.log`
- WorldBoss / gacha 的 per-action info log 降為 debug；缺 member id 與缺 event boss 升為 warn（屬異常狀況需追蹤）
- `Logger.js` 讀取 `LOG_LEVEL` env，預設 production=info、dev=debug，layout 改為 ISO8601 + level 樣式；catch handler 改用 `DefaultLogger.error` 並補上 context

部署生效需重 build image，並對 stack 執行 down/up 才會套用 docker logging options。

## Test plan

- [x] `yarn lint`：本 PR 修改的 8 個檔案皆通過（`analyze_chat_xp.js` 既有 lint error 與本 PR 無關）
- [x] `yarn test`：611/611 通過
- [ ] 部署後 `docker inspect` 確認 log driver 套用 `max-size: 10m / max-file: 10`
- [ ] 觀察 worker container 的 log 不再充斥每則聊天訊息文字
- [ ] 觸發一次錯誤（例如 OpenaiController 失敗），確認 stdout 出現 `[ISO8601] [ERROR] default - ...` 格式

🤖 Generated with [Claude Code](https://claude.com/claude-code)