### PR TITLE
ci: switch portainer deploy to git webhook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,40 +65,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend, frontend]
     steps:
-      - name: Redeploy stack via Portainer
+      - name: Trigger redeploy via Portainer git webhook
         run: |
-          # Get current stack file content
-          STACK_FILE=$(curl -sf \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}/file" \
-            | jq -r '.StackFileContent')
-
-          # Get current env vars
-          STACK_ENV=$(curl -sf \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}" \
-            | jq '.Env')
-
-          # Redeploy stack with pullImage to get latest images
-          HTTP_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
-            -X PUT \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}?endpointId=${{ secrets.PORTAINER_ENDPOINT_ID }}" \
-            -d "$(jq -n \
-              --arg stackFile "$STACK_FILE" \
-              --argjson env "$STACK_ENV" \
-              '{stackFileContent: $stackFile, env: $env, prune: true, pullImage: true}')")
-
-          if [ "$HTTP_STATUS" != "200" ]; then
-            echo "::error::Stack redeploy failed with HTTP $HTTP_STATUS"
+          # Stack is now git-managed; webhook makes Portainer pull main and
+          # recreate containers (forcePullImage is enabled at stack level).
+          HTTP_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" -X POST \
+            "${{ secrets.PORTAINER_URL }}/api/stacks/webhooks/${{ secrets.PORTAINER_WEBHOOK_UUID }}")
+          if [ "$HTTP_STATUS" != "204" ]; then
+            echo "::error::Webhook trigger failed with HTTP $HTTP_STATUS"
             exit 1
           fi
-
-          echo "Stack redeployed successfully"
+          echo "Redeploy triggered"
 
       - name: Wait for containers to be ready
-        run: sleep 15
+        run: sleep 30
 
       - name: Run database migrations
         run: |


### PR DESCRIPTION
## Summary

- Stack `redive_linebot` 已轉為 git-managed（Portainer stack #23），`forcePullImage: true`
- 原本的 `PUT /api/stacks/{id}` 帶 `stackFileContent` 是 manual stack 的做法，git stack 不適用且 stack id 也已變
- 改成單一 `POST /api/stacks/webhooks/{uuid}` — Portainer 收到後自動 git pull + image pull + recreate
- Post-redeploy `sleep 15` → `sleep 30`（image pull 比原本的 in-place 慢）
- 新增 secret `PORTAINER_WEBHOOK_UUID`（已加好）
- `PORTAINER_STACK_ID` 已不再使用，先留著待這個流程驗證 OK 後再刪

## Test plan

- [ ] PR merge 後觀察一次 Actions run：backend / frontend build push 完 → deploy job webhook 觸發 → migration → Discord 通知
- [ ] `docker logs redive_linebot-bot-1` 確認新 image 載入（時間戳 / Sentry release）
- [ ] 觀察服務中斷時間是否在 30-60 秒內

🤖 Generated with [Claude Code](https://claude.com/claude-code)