### PR TITLE
ci(deploy): pin image tags to commit SHA, use /git/redeploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           context: ./app
           push: true
-          tags: hanshino/redive_backend:latest
+          tags: |
+            hanshino/redive_backend:latest
+            hanshino/redive_backend:${{ github.sha }}
           cache-from: type=registry,ref=hanshino/redive_backend:buildcache
           cache-to: type=registry,ref=hanshino/redive_backend:buildcache,mode=max
 
@@ -56,7 +58,9 @@ jobs:
         with:
           context: ./frontend
           push: true
-          tags: hanshino/redive_frontend:latest
+          tags: |
+            hanshino/redive_frontend:latest
+            hanshino/redive_frontend:${{ github.sha }}
           cache-from: type=registry,ref=hanshino/redive_frontend:buildcache
           cache-to: type=registry,ref=hanshino/redive_frontend:buildcache,mode=max
 
@@ -65,17 +69,44 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend, frontend]
     steps:
-      - name: Trigger redeploy via Portainer git webhook
+      - name: Redeploy stack with new image tags
         run: |
-          # Stack is now git-managed; webhook makes Portainer pull main and
-          # recreate containers (forcePullImage is enabled at stack level).
-          HTTP_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" -X POST \
-            "${{ secrets.PORTAINER_URL }}/api/stacks/webhooks/${{ secrets.PORTAINER_WEBHOOK_UUID }}")
-          if [ "$HTTP_STATUS" != "204" ]; then
-            echo "::error::Webhook trigger failed with HTTP $HTTP_STATUS"
+          # Pin BACKEND_IMAGE_TAG / FRONTEND_IMAGE_TAG to this commit SHA so
+          # docker-compose pulls the freshly-pushed images. We fetch the full
+          # current env, replace just these two, and POST it back via
+          # /git/redeploy with pullImage:true to force a recreate.
+          SHA="${{ github.sha }}"
+
+          CURRENT_ENV=$(curl -sf \
+            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
+            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}" \
+            | jq '.Env')
+
+          NEW_ENV=$(jq --arg sha "$SHA" '
+            map(select(.name != "BACKEND_IMAGE_TAG" and .name != "FRONTEND_IMAGE_TAG"))
+            + [{name: "BACKEND_IMAGE_TAG", value: $sha}, {name: "FRONTEND_IMAGE_TAG", value: $sha}]
+          ' <<< "$CURRENT_ENV")
+
+          BODY=$(jq -n --argjson env "$NEW_ENV" '{
+            repositoryReferenceName: "refs/heads/main",
+            repositoryAuthentication: false,
+            env: $env,
+            prune: true,
+            pullImage: true
+          }')
+
+          HTTP_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}/git/redeploy?endpointId=${{ secrets.PORTAINER_ENDPOINT_ID }}" \
+            -d "$BODY")
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::git/redeploy failed with HTTP $HTTP_STATUS"
             exit 1
           fi
-          echo "Redeploy triggered"
+          echo "Stack redeployed at SHA $SHA"
 
       - name: Wait for containers to be ready
         run: sleep 30

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,6 +1,6 @@
 services:
   frontend:
-    image: hanshino/redive_frontend
+    image: hanshino/redive_frontend:${FRONTEND_IMAGE_TAG:-latest}
     restart: always
     networks:
       - traefik
@@ -14,7 +14,7 @@ services:
       - "traefik.docker.network=traefik"
 
   bot:
-    image: hanshino/redive_backend
+    image: hanshino/redive_backend:${BACKEND_IMAGE_TAG:-latest}
     env_file: stack.env
     restart: always
     expose:
@@ -40,7 +40,7 @@ services:
         max-file: "10"
 
   worker:
-    image: hanshino/redive_backend
+    image: hanshino/redive_backend:${BACKEND_IMAGE_TAG:-latest}
     env_file: stack.env
     restart: always
     networks:


### PR DESCRIPTION
## Background

PR #698 的 webhook-only deploy 在 image push 後 silently 沒效，原因：

- CI 永遠把 image push 為 `:latest`
- compose file 文字沒變
- Portainer 比對 compose hash 沒變 → 跳過 redeploy
- 容器繼續跑舊 image

驗證證據：merge PR #698 後，Portainer 的 stack `ConfigHash` 有更新到新 commit，但容器 `CREATED AT` 完全沒動。

## Fix（GitOps 風）

把 image tag 拉進 compose 變成 `${BACKEND_IMAGE_TAG:-latest}` / `${FRONTEND_IMAGE_TAG:-latest}`，CI build 時推 SHA tag、deploy 時更新 stack env 把這兩個值換成新 SHA。compose 內容因 env interpolation 而改變 → Portainer 自然 redeploy + pull image。

### 改動

- `.github/workflows/main.yml`
  - backend / frontend 各推兩個 tag：`:latest` 與 `:${{ github.sha }}`
  - deploy step 改用 `POST /api/stacks/{id}/git/redeploy` 帶 `{env, prune:true, pullImage:true}`
- `docker-compose.traefik.yml`
  - 三個 service 的 image 都改用環境變數讀 tag，預設 fallback 為 `:latest`

### Secrets
- `PORTAINER_STACK_ID` 已更新為 23
- `PORTAINER_WEBHOOK_UUID` 仍保留（不再被 CI 用，但可作 manual trigger）

## Test plan

- [ ] Merge 後 Actions run 應顯示「Stack redeployed at SHA <sha>」
- [ ] `docker ps --filter name=redive_linebot` 應看到容器 `CREATED AT` 更新到 deploy 時間
- [ ] `docker inspect redive_linebot-bot-1 --format '{{.Config.Image}}'` 應為 `hanshino/redive_backend:<sha>`
- [ ] Portainer stack #23 的 env 多兩筆 `BACKEND_IMAGE_TAG` / `FRONTEND_IMAGE_TAG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)