### PR TITLE
fix(ci): PUT (not POST) for portainer git/redeploy + show error body

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,8 +95,8 @@ jobs:
             pullImage: true
           }')
 
-          HTTP_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
-            -X POST \
+          HTTP_STATUS=$(curl -s -o /tmp/redeploy-response -w "%{http_code}" \
+            -X PUT \
             -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
             -H "Content-Type: application/json" \
             "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}/git/redeploy?endpointId=${{ secrets.PORTAINER_ENDPOINT_ID }}" \
@@ -104,6 +104,8 @@ jobs:
 
           if [ "$HTTP_STATUS" != "200" ]; then
             echo "::error::git/redeploy failed with HTTP $HTTP_STATUS"
+            echo "Response body:"
+            cat /tmp/redeploy-response
             exit 1
           fi
           echo "Stack redeployed at SHA $SHA"


### PR DESCRIPTION
## Why

PR #699 的 deploy step 失敗（exit code 22）卻沒有可讀錯誤訊息。原因：

- Portainer 的 `/api/stacks/{id}/git/redeploy` 實際只接受 **PUT**，POST 回 405
- `curl -sf` 看到 405 自己 exit 22
- `bash -e` 立刻 abort 整個 step，連我們自己 echo 的錯誤訊息都沒印出來

手動實測確認：

```
$ curl -X PUT .../api/stacks/23/git/redeploy?endpointId=3 -d '{...}'
HTTP 200
```

Containers 隨即用新 SHA tag 重啟（`docker ps` 確認 image 為 `hanshino/redive_backend:7ba3a5e6...`）。

## What

- `-X POST` → `-X PUT`
- `curl -sf -o /dev/null` → `curl -s -o /tmp/redeploy-response`
- 失敗時 `cat` 回應 body，避免下次 API 錯誤再被吃掉

## Test plan

- [ ] Merge → Actions 跑成功
- [ ] log 應顯示 `Stack redeployed at SHA <sha>`
- [ ] `docker inspect redive_linebot-bot-1 --format '{{.Config.Image}}'` = `hanshino/redive_backend:<merge-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)