### PR TITLE
feat(janken): season reset + daily rank rewards + ELO rebalance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ REDIS_PASSWORD=
 #LINE_LIFF_TALL_ID=
 #LINE_LIFF_FULL_ID=
 
-### LINE Login Channel（LIFF 管理用，make tunnel 自動更新 LIFF endpoint）
+### LINE Login Channel（LIFF 管理用，make cf-tunnel 自動更新 LIFF endpoint）
 #LINE_LOGIN_CHANNEL_ID=
 #LINE_LOGIN_CHANNEL_SECRET=
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ There is no `job/` package — cron is `yarn worker` inside `app/` (see below).
 - `app/` and `frontend/` run on the host via `yarn dev`, **not** in containers.
 - The bot listens on `PORT=9527` (fallback default in `app/server.js`); frontend on `3000`.
 - Vite proxies `/api`, `/webhooks`, `/socket.io` from `3000` → `9527` (`frontend/vite.config.js`), so the frontend talks to the bot directly without nginx.
-- ngrok is launched manually on the host (`ngrok http 9527 --region ap`), then `make tunnel` syncs the public URL into LINE's webhook + LIFF endpoint.
+- For LINE webhook + LIFF testing, use Cloudflare quick tunnel: `make cf-go` (= `cf-up` + `cf-tunnel`) launches `cloudflared --url http://localhost:3000`, then syncs the trycloudflare URL into LINE's webhook, LIFF endpoint, and `.env`'s `APP_DOMAIN` in one shot. Restart the bot afterwards so Flex image URLs pick up the new `APP_DOMAIN`.
 - Root `.env` is the single env file — loaded by `app/server.js`, `app/tasks.js`, and `app/knexfile.js` via `dotenv` pointing at `../.env`.
 
 ### Production
@@ -80,7 +80,7 @@ Command routing in `OrderBased` composes routers from every domain controller (g
 - React 19, MUI 7 (`@mui/material`, `@mui/x-data-grid` v8), Emotion, `react-router-dom` v7, Framer Motion, Recharts, Socket.IO client.
 - Bundler: **Vite 8** (not CRA). Dev: `yarn dev`. Build: `yarn build`. No test runner currently configured.
 - Entry: `frontend/src/main.jsx` → `App.jsx`. Pages under `src/pages/` (Achievement, Admin, Auto{History,Settings}, Bag, CustomerOrder, Equipment, Gacha, Group, Home, Janken, Panel, Race, Rankings, Tools, Trade).
-- Auth uses LINE LIFF (`@line/liff`) — pages assume a LIFF context, and LIFF endpoint URLs are kept in sync by `make tunnel` in dev.
+- Auth uses LINE LIFF (`@line/liff`) — pages assume a LIFF context, and LIFF endpoint URLs are kept in sync by `make cf-tunnel` in dev.
 - Progressive redesign toward MUI card layouts is in progress; see memory for which pages are done.
 
 ## Common Commands
@@ -104,8 +104,11 @@ make infra-stop       # docker compose down
 make migrate          # cd app && yarn migrate
 make logs             # tail infra logs
 make bash-redis       # redis-cli into the redis container
-make ngrok-url        # fetch the current ngrok public URL from localhost:4040
-make tunnel           # push ngrok URL → LINE webhook + LIFF endpoint
+make cf-up            # start cloudflared quick tunnel (background, log → /tmp/cloudflared.log)
+make cf-down          # stop cloudflared
+make cf-url           # print current trycloudflare URL
+make cf-tunnel        # push cloudflared URL → LINE webhook + LIFF endpoint + .env APP_DOMAIN
+make cf-go            # cf-up + cf-tunnel one-shot
 make get-webhook      # print current LINE webhook endpoint
 make get-liff         # print LIFF app config
 make help             # list all targets
@@ -137,7 +140,7 @@ Tests currently live only in `app/` (Jest, `__tests__/` dirs alongside services/
 
 ## LINE Webhook Flow
 
-LINE channel is the only enabled webhook (`app/bottender.config.js`): `POST /webhooks/line`. Messenger / WhatsApp / Telegram / Slack / Viber blocks exist but are disabled. To update LINE after starting a new ngrok session: `make tunnel`.
+LINE channel is the only enabled webhook (`app/bottender.config.js`): `POST /webhooks/line`. Messenger / WhatsApp / Telegram / Slack / Viber blocks exist but are disabled. To rotate the public URL during development, run `make cf-go` (or just `make cf-tunnel` if cloudflared is already up) and restart the bot.
 
 ## Code Style
 
@@ -146,7 +149,7 @@ LINE channel is the only enabled webhook (`app/bottender.config.js`): `POST /web
 
 ## Environment
 
-Copy `.env.example` to root `.env`. Required: `LINE_ACCESS_TOKEN`, `LINE_CHANNEL_SECRET`, `DB_PASSWORD`, `DB_USER`, `DB_USER_PASSWORD`, `REDIS_PASSWORD`. Optional but commonly used: `LINE_LIFF_ID` + variants, `LINE_LOGIN_CHANNEL_ID/SECRET` (for `make tunnel`'s LIFF update), `GEMINI_API_KEY`, `PICTSHARE_URL` + `PICTSHARE_UPLOAD_CODE`, `UMAMI_URL` + `UMAMI_WEBSITE_ID`.
+Copy `.env.example` to root `.env`. Required: `LINE_ACCESS_TOKEN`, `LINE_CHANNEL_SECRET`, `DB_PASSWORD`, `DB_USER`, `DB_USER_PASSWORD`, `REDIS_PASSWORD`. Optional but commonly used: `LINE_LIFF_ID` + variants, `LINE_LOGIN_CHANNEL_ID/SECRET` (for `make cf-tunnel`'s LIFF update), `GEMINI_API_KEY`, `PICTSHARE_URL` + `PICTSHARE_UPLOAD_CODE`, `UMAMI_URL` + `UMAMI_WEBSITE_ID`. `APP_DOMAIN` is rewritten in-place by `make cf-tunnel` so Flex image URLs always point at the active tunnel host.
 
 ## Key Config Files
 

--- a/app/__tests__/model/JankenRating.test.js
+++ b/app/__tests__/model/JankenRating.test.js
@@ -1,3 +1,6 @@
+// Integration tests against the real default.json config.
+// Pure-unit tier tests with a mocked config live at
+// app/src/model/application/__tests__/JankenRating.test.js.
 const JankenRating = require("../../src/model/application/JankenRating");
 
 describe("JankenRating", () => {

--- a/app/__tests__/model/JankenRating.test.js
+++ b/app/__tests__/model/JankenRating.test.js
@@ -2,34 +2,34 @@ const JankenRating = require("../../src/model/application/JankenRating");
 
 describe("JankenRating", () => {
   describe("getRankTier", () => {
-    it("returns beginner for elo < 1200", () => {
+    it("returns beginner for elo < 1100", () => {
       expect(JankenRating.getRankTier(1000)).toBe("beginner");
-      expect(JankenRating.getRankTier(1199)).toBe("beginner");
+      expect(JankenRating.getRankTier(1099)).toBe("beginner");
     });
 
-    it("returns challenger for elo 1200-1399", () => {
-      expect(JankenRating.getRankTier(1200)).toBe("challenger");
-      expect(JankenRating.getRankTier(1399)).toBe("challenger");
+    it("returns challenger for elo 1100-1249", () => {
+      expect(JankenRating.getRankTier(1100)).toBe("challenger");
+      expect(JankenRating.getRankTier(1249)).toBe("challenger");
     });
 
-    it("returns fighter for elo 1400-1599", () => {
-      expect(JankenRating.getRankTier(1400)).toBe("fighter");
+    it("returns fighter for elo 1250-1399", () => {
+      expect(JankenRating.getRankTier(1250)).toBe("fighter");
     });
 
-    it("returns master for elo 1600-1799", () => {
-      expect(JankenRating.getRankTier(1600)).toBe("master");
+    it("returns master for elo 1400-1549", () => {
+      expect(JankenRating.getRankTier(1400)).toBe("master");
     });
 
-    it("returns legend for elo >= 1800", () => {
-      expect(JankenRating.getRankTier(1800)).toBe("legend");
+    it("returns legend for elo >= 1550", () => {
+      expect(JankenRating.getRankTier(1550)).toBe("legend");
       expect(JankenRating.getRankTier(2500)).toBe("legend");
     });
   });
 
   describe("getMaxBet", () => {
     it("returns max bet for rank tier", () => {
-      expect(JankenRating.getMaxBet("beginner")).toBe(20000);
-      expect(JankenRating.getMaxBet("legend")).toBe(500000);
+      expect(JankenRating.getMaxBet("beginner")).toBe(50000);
+      expect(JankenRating.getMaxBet("legend")).toBe(1000000);
     });
   });
 
@@ -40,21 +40,24 @@ describe("JankenRating", () => {
     it("returns 4 for elo 1040", () => {
       expect(JankenRating.getSubTier(1040)).toBe(4);
     });
-    it("returns 1 for elo 1160+", () => {
-      expect(JankenRating.getSubTier(1160)).toBe(1);
-      expect(JankenRating.getSubTier(1199)).toBe(1);
+    it("returns 5 for elo 1100 (challenger base)", () => {
+      expect(JankenRating.getSubTier(1100)).toBe(5);
     });
-    it("returns 5 for elo 1200 (challenger base)", () => {
-      expect(JankenRating.getSubTier(1200)).toBe(5);
+    it("returns 3 for elo 1200 (challenger mid)", () => {
+      expect(JankenRating.getSubTier(1200)).toBe(3);
     });
-    it("returns 1 for elo 1360 (challenger top)", () => {
-      expect(JankenRating.getSubTier(1360)).toBe(1);
+    it("returns 5 for elo 1250 (fighter base)", () => {
+      expect(JankenRating.getSubTier(1250)).toBe(5);
     });
-    it("returns 5 for elo 1800 (legend base)", () => {
-      expect(JankenRating.getSubTier(1800)).toBe(5);
+    it("returns 2 for elo 1390+ (fighter top)", () => {
+      expect(JankenRating.getSubTier(1390)).toBe(2);
+      expect(JankenRating.getSubTier(1399)).toBe(2);
     });
-    it("returns 1 for elo 1960+ (legend top)", () => {
-      expect(JankenRating.getSubTier(1960)).toBe(1);
+    it("returns 5 for elo 1550 (legend base)", () => {
+      expect(JankenRating.getSubTier(1550)).toBe(5);
+    });
+    it("returns 1 for elo 1710+ (legend top)", () => {
+      expect(JankenRating.getSubTier(1710)).toBe(1);
     });
     it("handles elo below 1000", () => {
       expect(JankenRating.getSubTier(900)).toBe(5);
@@ -62,46 +65,49 @@ describe("JankenRating", () => {
   });
 
   describe("getKFactor", () => {
-    it("returns 8 for bet < 500", () => {
-      expect(JankenRating.getKFactor(10)).toBe(8);
-      expect(JankenRating.getKFactor(499)).toBe(8);
+    it("returns 12 for bet < 100", () => {
+      expect(JankenRating.getKFactor(10)).toBe(12);
+      expect(JankenRating.getKFactor(99)).toBe(12);
     });
-    it("returns 16 for bet 500-2999", () => {
-      expect(JankenRating.getKFactor(500)).toBe(16);
-      expect(JankenRating.getKFactor(2999)).toBe(16);
+    it("returns 20 for bet 100-999", () => {
+      expect(JankenRating.getKFactor(100)).toBe(20);
+      expect(JankenRating.getKFactor(999)).toBe(20);
     });
-    it("returns 24 for bet 3000-9999", () => {
-      expect(JankenRating.getKFactor(3000)).toBe(24);
-      expect(JankenRating.getKFactor(9999)).toBe(24);
+    it("returns 32 for bet 1000-4999", () => {
+      expect(JankenRating.getKFactor(1000)).toBe(32);
+      expect(JankenRating.getKFactor(4999)).toBe(32);
     });
-    it("returns 40 for bet >= 10000", () => {
-      expect(JankenRating.getKFactor(10000)).toBe(40);
-      expect(JankenRating.getKFactor(50000)).toBe(40);
+    it("returns 60 for bet 5000-49999", () => {
+      expect(JankenRating.getKFactor(5000)).toBe(60);
+      expect(JankenRating.getKFactor(49999)).toBe(60);
+    });
+    it("returns 80 for bet >= 50000", () => {
+      expect(JankenRating.getKFactor(50000)).toBe(80);
+      expect(JankenRating.getKFactor(100000)).toBe(80);
     });
   });
 
   describe("getRankLabel", () => {
     it("returns Chinese name with sub-tier", () => {
       expect(JankenRating.getRankLabel(1000)).toBe("見習者 5");
-      expect(JankenRating.getRankLabel(1280)).toBe("挑戰者 3");
-      expect(JankenRating.getRankLabel(1800)).toBe("傳說 5");
+      expect(JankenRating.getRankLabel(1550)).toBe("傳說 5");
     });
   });
 
   describe("getNextTierElo", () => {
     it("returns next major tier threshold", () => {
-      expect(JankenRating.getNextTierElo(1000)).toBe(1200);
-      expect(JankenRating.getNextTierElo(1350)).toBe(1400);
+      expect(JankenRating.getNextTierElo(1000)).toBe(1100);
+      expect(JankenRating.getNextTierElo(1200)).toBe(1250);
     });
     it("returns null for legend", () => {
-      expect(JankenRating.getNextTierElo(1800)).toBeNull();
+      expect(JankenRating.getNextTierElo(1550)).toBeNull();
     });
   });
 
   describe("getRankImageKey", () => {
     it("returns rank image key", () => {
       expect(JankenRating.getRankImageKey(1000)).toBe("rank_beginner");
-      expect(JankenRating.getRankImageKey(1500)).toBe("rank_fighter");
+      expect(JankenRating.getRankImageKey(1300)).toBe("rank_fighter");
     });
   });
 });

--- a/app/bin/JankenDailyRewards.js
+++ b/app/bin/JankenDailyRewards.js
@@ -1,3 +1,8 @@
+// Standalone-CLI dotenv preload (worker entry already calls dotenv).
+if (require.main === module && process.env.NODE_ENV !== "production") {
+  require("dotenv").config({ path: require("path").resolve(__dirname, "../../.env") });
+}
+
 const JankenRewardService = require("../src/service/JankenRewardService");
 const { DefaultLogger } = require("../src/util/Logger");
 

--- a/app/bin/JankenDailyRewards.js
+++ b/app/bin/JankenDailyRewards.js
@@ -1,4 +1,5 @@
-// Standalone-CLI dotenv preload (worker entry already calls dotenv).
+// Standalone-CLI dotenv preload — must run before the requires below, since
+// knex/config read process.env at import time. Gated so worker re-loads skip.
 if (require.main === module && process.env.NODE_ENV !== "production") {
   require("dotenv").config({ path: require("path").resolve(__dirname, "../../.env") });
 }

--- a/app/bin/JankenDailyRewards.js
+++ b/app/bin/JankenDailyRewards.js
@@ -1,0 +1,31 @@
+const JankenRewardService = require("../src/service/JankenRewardService");
+const { DefaultLogger } = require("../src/util/Logger");
+
+function computeRewardDate(now = new Date()) {
+  // Shift to Asia/Taipei (UTC+8), then subtract one day to get "yesterday in TPE".
+  // Uses UTC arithmetic only — independent of the runner's local TZ.
+  const tpeMs = now.getTime() + 8 * 60 * 60 * 1000;
+  const tpe = new Date(tpeMs);
+  tpe.setUTCDate(tpe.getUTCDate() - 1);
+  return tpe.toISOString().slice(0, 10);
+}
+exports.computeRewardDate = computeRewardDate;
+
+async function main() {
+  const date = computeRewardDate();
+  DefaultLogger.info(`[JankenDailyRewards] running for ${date}`);
+  const result = await JankenRewardService.payoutDaily(date);
+  DefaultLogger.info(`[JankenDailyRewards] done: ${JSON.stringify(result)}`);
+}
+
+module.exports = main;
+module.exports.computeRewardDate = computeRewardDate;
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch(err => {
+      DefaultLogger.error("[JankenDailyRewards] failed", err);
+      process.exit(1);
+    });
+}

--- a/app/bin/JankenSeasonEnd.js
+++ b/app/bin/JankenSeasonEnd.js
@@ -1,0 +1,38 @@
+const JankenSeasonService = require("../src/service/JankenSeasonService");
+const { DefaultLogger } = require("../src/util/Logger");
+
+function parseArgv(argv) {
+  const out = { note: null, enableRewards: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--enable-rewards") out.enableRewards = true;
+    else if (a === "--note" && i + 1 < argv.length) {
+      out.note = argv[++i];
+    }
+  }
+  return out;
+}
+exports.parseArgv = parseArgv;
+
+async function main(argv = process.argv.slice(2)) {
+  const args = parseArgv(argv);
+  DefaultLogger.info(
+    `[JankenSeasonEnd] starting: note=${args.note} enableRewards=${args.enableRewards}`
+  );
+  const result = await JankenSeasonService.endCurrentAndOpenNext({
+    note: args.note,
+    payoutEnabled: args.enableRewards,
+  });
+  DefaultLogger.info(`[JankenSeasonEnd] done: ${JSON.stringify(result)}`);
+  return result;
+}
+exports.main = main;
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch(err => {
+      DefaultLogger.error("[JankenSeasonEnd] failed", err);
+      process.exit(1);
+    });
+}

--- a/app/bin/JankenSeasonEnd.js
+++ b/app/bin/JankenSeasonEnd.js
@@ -1,6 +1,5 @@
-// When run as a standalone CLI (not via the cron worker), load .env first so
-// downstream knex/config picks up DB credentials. Worker entry already calls
-// dotenv at startup, so this is gated to avoid a redundant second load there.
+// Standalone-CLI dotenv preload — must run before the requires below, since
+// knex/config read process.env at import time. Gated so worker re-loads skip.
 if (require.main === module && process.env.NODE_ENV !== "production") {
   require("dotenv").config({ path: require("path").resolve(__dirname, "../../.env") });
 }

--- a/app/bin/JankenSeasonEnd.js
+++ b/app/bin/JankenSeasonEnd.js
@@ -1,3 +1,10 @@
+// When run as a standalone CLI (not via the cron worker), load .env first so
+// downstream knex/config picks up DB credentials. Worker entry already calls
+// dotenv at startup, so this is gated to avoid a redundant second load there.
+if (require.main === module && process.env.NODE_ENV !== "production") {
+  require("dotenv").config({ path: require("path").resolve(__dirname, "../../.env") });
+}
+
 const JankenSeasonService = require("../src/service/JankenSeasonService");
 const { DefaultLogger } = require("../src/util/Logger");
 

--- a/app/bin/__tests__/JankenDailyRewards.test.js
+++ b/app/bin/__tests__/JankenDailyRewards.test.js
@@ -1,0 +1,12 @@
+const DailyRewards = require("../JankenDailyRewards");
+
+describe("JankenDailyRewards CLI", () => {
+  test("computeRewardDate returns yesterday in YYYY-MM-DD (Asia/Taipei)", () => {
+    const now = new Date("2026-05-02T03:00:00+08:00");
+    expect(DailyRewards.computeRewardDate(now)).toBe("2026-05-01");
+  });
+  test("computeRewardDate around midnight TPE", () => {
+    const now = new Date("2026-05-02T00:10:00+08:00");
+    expect(DailyRewards.computeRewardDate(now)).toBe("2026-05-01");
+  });
+});

--- a/app/bin/__tests__/JankenSeasonEnd.test.js
+++ b/app/bin/__tests__/JankenSeasonEnd.test.js
@@ -1,0 +1,12 @@
+const SeasonEnd = require("../JankenSeasonEnd");
+
+describe("JankenSeasonEnd CLI", () => {
+  test("parseArgv parses --note and --enable-rewards", () => {
+    const args = SeasonEnd.parseArgv(["--note", "foo bar", "--enable-rewards"]);
+    expect(args.note).toBe("foo bar");
+    expect(args.enableRewards).toBe(true);
+  });
+  test("parseArgv defaults: note null, enableRewards false", () => {
+    expect(SeasonEnd.parseArgv([])).toEqual({ note: null, enableRewards: false });
+  });
+});

--- a/app/config/crontab.config.js
+++ b/app/config/crontab.config.js
@@ -112,4 +112,11 @@ module.exports = [
     immediate: false,
     require_path: "./bin/AutoGacha",
   },
+  {
+    name: "Janken Daily Rewards",
+    description: "credit daily women-stones to active janken players (kill-switched in config)",
+    period: ["0", "10", "0", "*", "*", "*"],
+    immediate: false,
+    require_path: "./bin/JankenDailyRewards",
+  },
 ];

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -71,16 +71,76 @@
       "paper": "🖐️",
       "rock": "✊",
       "scissors": "✌️",
+      "season": {
+        "snapshotTopN": 50,
+        "enableSeasonEndRewards": false,
+        "endRewards": {
+          "top1": 50000,
+          "top2": 30000,
+          "top3": 20000,
+          "top4_10": 5000,
+          "top11_50": 1000
+        }
+      },
+      "daily_reward": {
+        "enableDailyRankReward": false,
+        "amounts": {
+          "top1": 500,
+          "top2": 300,
+          "top3": 200,
+          "top4_10": 50,
+          "legend": 100,
+          "master": 50,
+          "fighter": 25,
+          "challenger": 10,
+          "beginner": 0
+        }
+      },
       "bet": {
         "minAmount": 10,
         "maxAmountByRank": {
+          "beginner": 50000,
+          "challenger": 100000,
+          "fighter": 200000,
+          "master": 500000,
+          "legend": 1000000
+        },
+        "feeRate": 0.1
+      },
+      "streak": {
+        "maxBountyByRank": {
           "beginner": 20000,
           "challenger": 50000,
           "fighter": 100000,
           "master": 200000,
-          "legend": 500000
+          "legend": 300000
         },
-        "feeRate": 0.1
+        "bountyMinBet": 1000,
+        "bountyClaimMultiplier": 5
+      },
+      "elo": {
+        "initial": 1000,
+        "tiers": [
+          { "key": "beginner",   "name": "見習者", "minElo": 0    },
+          { "key": "challenger", "name": "挑戰者", "minElo": 1100 },
+          { "key": "fighter",    "name": "強者",   "minElo": 1250 },
+          { "key": "master",     "name": "達人",   "minElo": 1400 },
+          { "key": "legend",     "name": "傳說",   "minElo": 1550 }
+        ],
+        "kFactorTiers": [
+          { "minBet": 50000, "k": 80 },
+          { "minBet":  5000, "k": 60 },
+          { "minBet":  1000, "k": 32 },
+          { "minBet":   100, "k": 20 },
+          { "minBet":     0, "k": 12 }
+        ],
+        "lossFactor": 0.5,
+        "nonBetK": 0,
+        "streakBonus": [
+          { "minStreak": 7, "multiplier": 2.0 },
+          { "minStreak": 5, "multiplier": 1.5 },
+          { "minStreak": 3, "multiplier": 1.25 }
+        ]
       },
       "images": {
         "rock": "/assets/janken/rock.png",
@@ -90,32 +150,6 @@
         "lose": "/assets/janken/lose.png",
         "draw": "/assets/janken/draw.png",
         "vs": "/assets/janken/vs.png"
-      },
-      "streak": {
-        "maxBountyByRank": {
-          "beginner": 10000,
-          "challenger": 25000,
-          "fighter": 50000,
-          "master": 80000,
-          "legend": 120000
-        },
-        "bountyMinBet": 1000,
-        "bountyClaimMultiplier": 5
-      },
-      "elo": {
-        "initial": 1000,
-        "kFactorTiers": [
-          { "minBet": 10000, "k": 40 },
-          { "minBet": 3000, "k": 24 },
-          { "minBet": 500, "k": 16 },
-          { "minBet": 0, "k": 8 }
-        ],
-        "lossFactor": 0.5,
-        "streakBonus": [
-          { "minStreak": 7, "multiplier": 2.0 },
-          { "minStreak": 5, "multiplier": 1.5 },
-          { "minStreak": 3, "multiplier": 1.25 }
-        ]
       }
     }
   },

--- a/app/migrations/20260501221727_create_janken_seasons.js
+++ b/app/migrations/20260501221727_create_janken_seasons.js
@@ -1,0 +1,22 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("janken_seasons", table => {
+    table.increments("id").unsigned().primary();
+    table.dateTime("started_at").notNullable();
+    table.dateTime("ended_at").nullable();
+    table.enu("status", ["active", "closed"]).notNullable().defaultTo("active");
+    table.text("notes").nullable();
+    table.timestamps(true, true);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("janken_seasons");
+};

--- a/app/migrations/20260501221843_create_janken_season_snapshot.js
+++ b/app/migrations/20260501221843_create_janken_season_snapshot.js
@@ -1,0 +1,29 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("janken_season_snapshot", table => {
+    table.increments("id").unsigned().primary();
+    table.integer("season_id").unsigned().notNullable();
+    table.smallint("rank").unsigned().notNullable();
+    table.string("user_id", 33).notNullable();
+    table.string("display_name", 255).nullable();
+    table.integer("elo").notNullable();
+    table.string("rank_tier", 20).notNullable();
+    table.integer("win_count").notNullable().defaultTo(0);
+    table.integer("lose_count").notNullable().defaultTo(0);
+    table.integer("draw_count").notNullable().defaultTo(0);
+    table.integer("max_streak").notNullable().defaultTo(0);
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.index(["season_id", "rank"], "idx_season_rank");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("janken_season_snapshot");
+};

--- a/app/migrations/20260501221854_create_janken_daily_reward_log.js
+++ b/app/migrations/20260501221854_create_janken_daily_reward_log.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("janken_daily_reward_log", table => {
+    table.increments("id").unsigned().primary();
+    table.string("user_id", 33).notNullable();
+    table.date("reward_date").notNullable();
+    table.integer("season_id").unsigned().notNullable();
+    table.string("reward_type", 20).notNullable();
+    table.integer("amount").notNullable().defaultTo(0);
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.unique(["user_id", "reward_date"], "uniq_user_date");
+    table.index("reward_date", "idx_reward_date");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable("janken_daily_reward_log");
+};

--- a/app/migrations/20260501221858_add_lifetime_counts_to_janken_rating.js
+++ b/app/migrations/20260501221858_add_lifetime_counts_to_janken_rating.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("janken_rating", table => {
+    table.integer("lifetime_win_count").notNullable().defaultTo(0);
+    table.integer("lifetime_lose_count").notNullable().defaultTo(0);
+    table.integer("lifetime_draw_count").notNullable().defaultTo(0);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("janken_rating", table => {
+    table.dropColumn("lifetime_win_count");
+    table.dropColumn("lifetime_lose_count");
+    table.dropColumn("lifetime_draw_count");
+  });
+};

--- a/app/migrations/20260501221909_seed_janken_season_one.js
+++ b/app/migrations/20260501221909_seed_janken_season_one.js
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const existing = await knex("janken_seasons").first();
+  if (existing) return;
+
+  const oldest = await knex("janken_records").min({ ts: "created_at" }).first();
+  const startedAt = (oldest && oldest.ts) || new Date();
+
+  await knex("janken_seasons").insert({
+    id: 1,
+    started_at: startedAt,
+    status: "active",
+    notes: "v1 retroactive — first season",
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex("janken_seasons").where({ id: 1 }).delete();
+};

--- a/app/migrations/20260502091913_unify_lingering_unicode_to_0900.js
+++ b/app/migrations/20260502091913_unify_lingering_unicode_to_0900.js
@@ -1,0 +1,46 @@
+/**
+ * Self-healing collation drift fix.
+ *
+ * 20260327_unify_all_collation_to_0900.js converted a known list of legacy
+ * tables to utf8mb4_0900_ai_ci, but environments restored from older dumps
+ * (or tables created since by other branches) can drift back to unicode_ci,
+ * which breaks JOINs against the newer janken / season tables with
+ * ER_CANT_AGGREGATE_2COLLATIONS.
+ *
+ * Rescans information_schema for any base tables in the current database
+ * still on a *_unicode_ci collation and converts them. CONVERT TO CHARACTER
+ * SET is idempotent, so running on an already-clean DB is a no-op.
+ */
+
+exports.up = async function (knex) {
+  const [rows] = await knex.raw(
+    `SELECT TABLE_NAME
+       FROM information_schema.TABLES
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_TYPE = 'BASE TABLE'
+        AND TABLE_COLLATION LIKE 'utf8mb4_unicode_ci%'`
+  );
+
+  if (!rows || rows.length === 0) {
+    console.log("[unify_lingering_unicode_to_0900] no drift detected — skipping.");
+    return;
+  }
+
+  const names = rows.map(r => r.TABLE_NAME);
+  console.log(
+    `[unify_lingering_unicode_to_0900] converting ${names.length} table(s): ${names.join(", ")}`
+  );
+
+  for (const name of names) {
+    await knex.raw(
+      `ALTER TABLE \`${name}\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci`
+    );
+  }
+};
+
+exports.down = async function () {
+  // Intentional no-op: we cannot know which tables the up step touched in a
+  // given environment, and rolling string columns back to unicode_ci would
+  // re-introduce the collation mismatch this migration exists to fix.
+  // Use 20260327_unify_all_collation_to_0900.js's down for explicit rollback.
+};

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -15,6 +15,7 @@ const { notifyUnlocks } = require("../../service/achievementNotifier");
 const JankenSeason = require("../../model/application/JankenSeason");
 const JankenSeasonSnapshot = require("../../model/application/JankenSeasonSnapshot");
 const JankenDailyRewardLog = require("../../model/application/JankenDailyRewardLog");
+const { yesterdayUtc8 } = require("../../util/date");
 
 const baseUrl = `https://${process.env.APP_DOMAIN}`;
 const ASSET_VERSION = Date.now();
@@ -51,8 +52,9 @@ async function queryRank(context) {
   const winRate = totalGames > 0 ? Math.round((rating.win_count / totalGames) * 100) : 0;
 
   const season = await JankenSeason.getActive();
-  const today = new Date().toISOString().slice(0, 10);
-  const todayRewardRow = await JankenDailyRewardLog.getByUserAndDate(userId, today);
+  // Daily-reward cron stores reward_date = yesterday-TPE (the play day).
+  // "今日獎勵" means the reward credited today, which corresponds to that row.
+  const todayRewardRow = await JankenDailyRewardLog.getByUserAndDate(userId, yesterdayUtc8());
   const todayReward = todayRewardRow
     ? { type: todayRewardRow.reward_type, amount: todayRewardRow.amount }
     : null;
@@ -615,8 +617,7 @@ exports.api.todayReward = async (req, res) => {
   try {
     const userId = req.query.userId;
     if (!userId) return res.status(400).json({ message: "userId required" });
-    const today = new Date().toISOString().slice(0, 10);
-    const row = await JankenDailyRewardLog.getByUserAndDate(userId, today);
+    const row = await JankenDailyRewardLog.getByUserAndDate(userId, yesterdayUtc8());
     res.json(row || null);
   } catch (err) {
     console.error("[Janken Today Reward API]", err);

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -12,6 +12,9 @@ const uuid = require("uuid-random");
 const { DefaultLogger } = require("../../util/Logger");
 const AchievementEngine = require("../../service/AchievementEngine");
 const { notifyUnlocks } = require("../../service/achievementNotifier");
+const JankenSeason = require("../../model/application/JankenSeason");
+const JankenSeasonSnapshot = require("../../model/application/JankenSeasonSnapshot");
+const JankenDailyRewardLog = require("../../model/application/JankenDailyRewardLog");
 
 const baseUrl = `https://${process.env.APP_DOMAIN}`;
 const ASSET_VERSION = Date.now();
@@ -47,6 +50,18 @@ async function queryRank(context) {
   const serverRank = totalGames > 0 ? await JankenRating.getServerRank(userId) : null;
   const winRate = totalGames > 0 ? Math.round((rating.win_count / totalGames) * 100) : 0;
 
+  const season = await JankenSeason.getActive();
+  const today = new Date().toISOString().slice(0, 10);
+  const todayRewardRow = await JankenDailyRewardLog.getByUserAndDate(userId, today);
+  const todayReward = todayRewardRow
+    ? { type: todayRewardRow.reward_type, amount: todayRewardRow.amount }
+    : null;
+  const lifetime = {
+    win: (rating.lifetime_win_count || 0) + rating.win_count,
+    lose: (rating.lifetime_lose_count || 0) + rating.lose_count,
+    draw: (rating.lifetime_draw_count || 0) + rating.draw_count,
+  };
+
   const rankCard = jankenTemplate.generateRankCard({
     rankLabel,
     rankImageKey,
@@ -62,6 +77,10 @@ async function queryRank(context) {
     serverRank,
     maxBet,
     baseUrl,
+    seasonId: season ? season.id : null,
+    seasonStartedAt: season ? season.started_at : null,
+    lifetime,
+    todayReward,
   });
 
   await context.replyFlex("猜拳段位", rankCard);

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -20,6 +20,10 @@ const { yesterdayUtc8 } = require("../../util/date");
 const baseUrl = `https://${process.env.APP_DOMAIN}`;
 const ASSET_VERSION = Date.now();
 const jankenAsset = name => `${baseUrl}/bot-assets/janken/${name}?v=${ASSET_VERSION}`;
+// Relative-path variant for browser-facing API responses. Same-origin in
+// dev (via Vite proxy) and prod (via Traefik), so it dodges the DNS issue
+// when APP_DOMAIN is a non-resolvable local hostname like `redivebot.local`.
+const webJankenAsset = name => `/bot-assets/janken/${name}?v=${ASSET_VERSION}`;
 const BountySender = { name: "懸賞官", iconUrl: jankenAsset("bounty.png") };
 
 exports.router = [
@@ -80,7 +84,6 @@ async function queryRank(context) {
     maxBet,
     baseUrl,
     seasonId: season ? season.id : null,
-    seasonStartedAt: season ? season.started_at : null,
     lifetime,
     todayReward,
   });
@@ -542,7 +545,7 @@ exports.api.rankings = async (req, res) => {
         displayName: r.display_name || `玩家${index + 1}`,
         rankLabel: JankenRating.getRankLabel(r.elo),
         rankTier: r.rank_tier,
-        rankImage: jankenAsset(`${JankenRating.getRankImageKey(r.elo)}.png`),
+        rankImage: webJankenAsset(`${JankenRating.getRankImageKey(r.elo)}.png`),
         elo: r.elo,
         winCount: r.win_count,
         loseCount: r.lose_count,

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -529,8 +529,9 @@ exports.api = {};
 exports.api.rankings = async (req, res) => {
   try {
     const ratings = await JankenRating.getTopRankings(20);
+    const season = await JankenSeason.getActive();
 
-    const result = ratings.map((r, index) => {
+    const items = ratings.map((r, index) => {
       const total = r.win_count + r.lose_count + r.draw_count;
       const winRate = total > 0 ? Math.round((r.win_count / total) * 1000) / 10 : 0;
 
@@ -549,7 +550,7 @@ exports.api.rankings = async (req, res) => {
       };
     });
 
-    res.json(result);
+    res.json({ seasonId: season ? season.id : null, items });
   } catch (err) {
     console.error("[Janken Rankings API]", err);
     res.status(500).json({ message: "Failed to fetch rankings" });
@@ -585,5 +586,40 @@ exports.api.recentMatches = async (req, res) => {
   } catch (err) {
     console.error("[Janken Recent Matches API]", err);
     res.status(500).json({ message: "Failed to fetch recent matches" });
+  }
+};
+
+exports.api.seasons = async (req, res) => {
+  try {
+    const seasons = await JankenSeason.list(50);
+    res.json(seasons);
+  } catch (err) {
+    console.error("[Janken Seasons API]", err);
+    res.status(500).json({ message: "Failed to fetch seasons" });
+  }
+};
+
+exports.api.seasonTop = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!id) return res.status(400).json({ message: "Invalid season id" });
+    const rows = await JankenSeasonSnapshot.getBySeason(id);
+    res.json(rows);
+  } catch (err) {
+    console.error("[Janken Season Top API]", err);
+    res.status(500).json({ message: "Failed to fetch season top" });
+  }
+};
+
+exports.api.todayReward = async (req, res) => {
+  try {
+    const userId = req.query.userId;
+    if (!userId) return res.status(400).json({ message: "userId required" });
+    const today = new Date().toISOString().slice(0, 10);
+    const row = await JankenDailyRewardLog.getByUserAndDate(userId, today);
+    res.json(row || null);
+  } catch (err) {
+    console.error("[Janken Today Reward API]", err);
+    res.status(500).json({ message: "Failed to fetch today reward" });
   }
 };

--- a/app/src/model/application/Inventory.js
+++ b/app/src/model/application/Inventory.js
@@ -112,12 +112,14 @@ class Inventory extends base {
     ]);
   }
 
-  async increaseGodStone({ userId, amount, note }) {
-    return this.knex.insert([{ userId, itemId: 999, itemAmount: amount, note }]);
+  async increaseGodStone({ userId, amount, note, trx }) {
+    const db = trx ? trx(this.table) : this.knex;
+    return db.insert([{ userId, itemId: 999, itemAmount: amount, note }]);
   }
 
-  async decreaseGodStone({ userId, amount, note }) {
-    return this.knex.insert([{ userId, itemId: 999, itemAmount: `${-amount}`, note }]);
+  async decreaseGodStone({ userId, amount, note, trx }) {
+    const db = trx ? trx(this.table) : this.knex;
+    return db.insert([{ userId, itemId: 999, itemAmount: `${-amount}`, note }]);
   }
 }
 

--- a/app/src/model/application/JankenDailyRewardLog.js
+++ b/app/src/model/application/JankenDailyRewardLog.js
@@ -1,0 +1,19 @@
+const mysql = require("../../util/mysql");
+
+const TABLE = "janken_daily_reward_log";
+
+exports.tryInsert = async function ({ user_id, reward_date, season_id, reward_type, amount }, trx) {
+  const db = trx || mysql;
+  try {
+    await db(TABLE).insert({ user_id, reward_date, season_id, reward_type, amount });
+    return true;
+  } catch (err) {
+    if (err && err.code === "ER_DUP_ENTRY") return false;
+    throw err;
+  }
+};
+
+exports.getByUserAndDate = async function (user_id, reward_date, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ user_id, reward_date }).first();
+};

--- a/app/src/model/application/JankenRating.js
+++ b/app/src/model/application/JankenRating.js
@@ -30,7 +30,7 @@ function getTiers() {
   try {
     const tiers = config.get("minigame.janken.elo.tiers");
     if (Array.isArray(tiers) && tiers.length > 0) return tiers;
-  } catch (_) {
+  } catch {
     /* config miss → fallback */
   }
   return FALLBACK_TIERS;

--- a/app/src/model/application/JankenRating.js
+++ b/app/src/model/application/JankenRating.js
@@ -13,6 +13,9 @@ const fillable = [
   "streak",
   "max_streak",
   "bounty",
+  "lifetime_win_count",
+  "lifetime_lose_count",
+  "lifetime_draw_count",
 ];
 
 const FALLBACK_TIERS = [
@@ -136,4 +139,25 @@ exports.getTopRankings = async function (limit = 20) {
     .leftJoin(subquery, "u.platform_id", "=", `${TABLE}.user_id`)
     .orderBy("elo", "desc")
     .limit(limit);
+};
+
+exports.getTopByElo = async function (limit = 50, trx) {
+  const db = trx || mysql;
+  return db(TABLE).orderBy("elo", "desc").orderBy("win_count", "desc").limit(limit);
+};
+
+exports.resetSeasonFields = async function (trx) {
+  const db = trx || mysql;
+  return db(TABLE).update({
+    lifetime_win_count: db.raw("lifetime_win_count + win_count"),
+    lifetime_lose_count: db.raw("lifetime_lose_count + lose_count"),
+    lifetime_draw_count: db.raw("lifetime_draw_count + draw_count"),
+    elo: 1000,
+    rank_tier: "beginner",
+    win_count: 0,
+    lose_count: 0,
+    draw_count: 0,
+    streak: 0,
+    bounty: 0,
+  });
 };

--- a/app/src/model/application/JankenRating.js
+++ b/app/src/model/application/JankenRating.js
@@ -15,28 +15,40 @@ const fillable = [
   "bounty",
 ];
 
-const RANK_TIERS = [
+const FALLBACK_TIERS = [
   { key: "beginner", name: "見習者", minElo: 0 },
-  { key: "challenger", name: "挑戰者", minElo: 1200 },
-  { key: "fighter", name: "強者", minElo: 1400 },
-  { key: "master", name: "達人", minElo: 1600 },
-  { key: "legend", name: "傳說", minElo: 1800 },
+  { key: "challenger", name: "挑戰者", minElo: 1100 },
+  { key: "fighter", name: "強者", minElo: 1250 },
+  { key: "master", name: "達人", minElo: 1400 },
+  { key: "legend", name: "傳說", minElo: 1550 },
 ];
 
-exports.RANK_TIERS = RANK_TIERS;
+function getTiers() {
+  try {
+    const tiers = config.get("minigame.janken.elo.tiers");
+    if (Array.isArray(tiers) && tiers.length > 0) return tiers;
+  } catch (_) {
+    /* config miss → fallback */
+  }
+  return FALLBACK_TIERS;
+}
+
+exports.RANK_TIERS = FALLBACK_TIERS; // back-compat for any external import
 
 exports.getRankTier = function (elo) {
-  for (let i = RANK_TIERS.length - 1; i >= 0; i--) {
-    if (elo >= RANK_TIERS[i].minElo) return RANK_TIERS[i].key;
+  const tiers = getTiers();
+  for (let i = tiers.length - 1; i >= 0; i--) {
+    if (elo >= tiers[i].minElo) return tiers[i].key;
   }
   return "beginner";
 };
 
 exports.getRankInfo = function (elo) {
-  for (let i = RANK_TIERS.length - 1; i >= 0; i--) {
-    if (elo >= RANK_TIERS[i].minElo) return RANK_TIERS[i];
+  const tiers = getTiers();
+  for (let i = tiers.length - 1; i >= 0; i--) {
+    if (elo >= tiers[i].minElo) return tiers[i];
   }
-  return RANK_TIERS[0];
+  return tiers[0];
 };
 
 exports.getSubTier = function (elo) {
@@ -62,10 +74,11 @@ exports.getKFactor = function (betAmount) {
 };
 
 exports.getNextTierElo = function (elo) {
+  const tiers = getTiers();
   const currentKey = exports.getRankTier(elo);
-  const idx = RANK_TIERS.findIndex(t => t.key === currentKey);
-  if (idx >= RANK_TIERS.length - 1) return null;
-  return RANK_TIERS[idx + 1].minElo;
+  const idx = tiers.findIndex(t => t.key === currentKey);
+  if (idx >= tiers.length - 1) return null;
+  return tiers[idx + 1].minElo;
 };
 
 exports.getRankImageKey = function (elo) {

--- a/app/src/model/application/JankenRating.js
+++ b/app/src/model/application/JankenRating.js
@@ -33,8 +33,6 @@ function getTiers() {
   return FALLBACK_TIERS;
 }
 
-exports.RANK_TIERS = FALLBACK_TIERS; // back-compat for any external import
-
 exports.getRankTier = function (elo) {
   const tiers = getTiers();
   for (let i = tiers.length - 1; i >= 0; i--) {

--- a/app/src/model/application/JankenSeason.js
+++ b/app/src/model/application/JankenSeason.js
@@ -1,0 +1,33 @@
+const mysql = require("../../util/mysql");
+
+const TABLE = "janken_seasons";
+
+exports.getActive = async function (trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ status: "active" }).first();
+};
+
+exports.close = async function (id, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ id }).update({ status: "closed", ended_at: new Date() });
+};
+
+exports.openNew = async function (notes, trx) {
+  const db = trx || mysql;
+  const [id] = await db(TABLE).insert({
+    started_at: new Date(),
+    status: "active",
+    notes: notes || null,
+  });
+  return id;
+};
+
+exports.findById = async function (id, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ id }).first();
+};
+
+exports.list = async function (limit = 50, trx) {
+  const db = trx || mysql;
+  return db(TABLE).orderBy("id", "desc").limit(limit);
+};

--- a/app/src/model/application/JankenSeasonSnapshot.js
+++ b/app/src/model/application/JankenSeasonSnapshot.js
@@ -1,0 +1,27 @@
+const mysql = require("../../util/mysql");
+
+const TABLE = "janken_season_snapshot";
+
+exports.bulkInsert = async function (seasonId, rows, trx) {
+  if (!rows || rows.length === 0) return undefined;
+  const db = trx || mysql;
+  const data = rows.map(r => ({
+    season_id: seasonId,
+    rank: r.rank,
+    user_id: r.user_id,
+    display_name: r.display_name || null,
+    elo: r.elo,
+    rank_tier: r.rank_tier,
+    win_count: r.win_count || 0,
+    lose_count: r.lose_count || 0,
+    draw_count: r.draw_count || 0,
+    max_streak: r.max_streak || 0,
+  }));
+  await db(TABLE).insert(data);
+  return undefined;
+};
+
+exports.getBySeason = async function (seasonId, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ season_id: seasonId }).orderBy("rank", "asc");
+};

--- a/app/src/model/application/__tests__/JankenDailyRewardLog.test.js
+++ b/app/src/model/application/__tests__/JankenDailyRewardLog.test.js
@@ -1,0 +1,43 @@
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../../.env") });
+jest.unmock("../../../util/mysql");
+const mysql = jest.requireActual("../../../util/mysql");
+const JankenDailyRewardLog = require("../JankenDailyRewardLog");
+
+describe("JankenDailyRewardLog", () => {
+  beforeEach(async () => {
+    await mysql("janken_daily_reward_log").delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  test("tryInsert returns true on first insert, false on duplicate same-day", async () => {
+    const args = {
+      user_id: "U1",
+      reward_date: "2026-05-01",
+      season_id: 1,
+      reward_type: "top1",
+      amount: 500,
+    };
+    expect(await JankenDailyRewardLog.tryInsert(args)).toBe(true);
+    expect(await JankenDailyRewardLog.tryInsert(args)).toBe(false);
+    const count = await mysql("janken_daily_reward_log").count({ c: "*" }).first();
+    expect(Number(count.c)).toBe(1);
+  });
+
+  test("getByUserAndDate returns the row when present", async () => {
+    await JankenDailyRewardLog.tryInsert({
+      user_id: "U2",
+      reward_date: "2026-05-02",
+      season_id: 1,
+      reward_type: "challenger",
+      amount: 10,
+    });
+    const row = await JankenDailyRewardLog.getByUserAndDate("U2", "2026-05-02");
+    expect(row.amount).toBe(10);
+    expect(row.reward_type).toBe("challenger");
+  });
+
+  test("getByUserAndDate returns undefined when missing", async () => {
+    const row = await JankenDailyRewardLog.getByUserAndDate("U999", "2026-05-02");
+    expect(row).toBeUndefined();
+  });
+});

--- a/app/src/model/application/__tests__/JankenRating.test.js
+++ b/app/src/model/application/__tests__/JankenRating.test.js
@@ -1,0 +1,35 @@
+jest.mock("config", () => ({
+  get: jest.fn(key => {
+    if (key === "minigame.janken.elo.tiers") {
+      return [
+        { key: "beginner", name: "見習者", minElo: 0 },
+        { key: "challenger", name: "挑戰者", minElo: 1100 },
+        { key: "fighter", name: "強者", minElo: 1250 },
+        { key: "master", name: "達人", minElo: 1400 },
+        { key: "legend", name: "傳說", minElo: 1550 },
+      ];
+    }
+    if (key === "minigame.janken.elo.initial") return 1000;
+    return undefined;
+  }),
+}));
+
+const JankenRating = require("../JankenRating");
+
+describe("JankenRating tiers from config", () => {
+  test("returns fighter at 1250", () => {
+    expect(JankenRating.getRankTier(1250)).toBe("fighter");
+  });
+  test("returns master at 1400", () => {
+    expect(JankenRating.getRankTier(1400)).toBe("master");
+  });
+  test("returns challenger at 1100", () => {
+    expect(JankenRating.getRankTier(1100)).toBe("challenger");
+  });
+  test("returns beginner at 1099", () => {
+    expect(JankenRating.getRankTier(1099)).toBe("beginner");
+  });
+  test("getNextTierElo from challenger returns fighter floor", () => {
+    expect(JankenRating.getNextTierElo(1150)).toBe(1250);
+  });
+});

--- a/app/src/model/application/__tests__/JankenRating.test.js
+++ b/app/src/model/application/__tests__/JankenRating.test.js
@@ -1,6 +1,9 @@
 // Unit tests with mocked config — exercises getTiers() via the config-read path.
 // Companion integration tests (no mock, against real default.json) live at
 // app/__tests__/model/JankenRating.test.js.
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../../.env") });
+jest.unmock("../../../util/mysql");
+const mysql = jest.requireActual("../../../util/mysql");
 jest.mock("config", () => ({
   get: jest.fn(key => {
     if (key === "minigame.janken.elo.tiers") {
@@ -34,5 +37,61 @@ describe("JankenRating tiers from config", () => {
   });
   test("getNextTierElo from challenger returns fighter floor", () => {
     expect(JankenRating.getNextTierElo(1150)).toBe(1250);
+  });
+});
+
+describe("JankenRating.getTopByElo", () => {
+  beforeEach(async () => {
+    await mysql("janken_rating").delete();
+    await mysql("janken_rating").insert([
+      { user_id: "U_A", elo: 1500, rank_tier: "master", win_count: 10 },
+      { user_id: "U_B", elo: 1100, rank_tier: "challenger", win_count: 5 },
+      { user_id: "U_C", elo: 1700, rank_tier: "legend", win_count: 20 },
+    ]);
+  });
+
+  test("returns rows ordered by elo desc", async () => {
+    const rows = await JankenRating.getTopByElo(2);
+    expect(rows[0].user_id).toBe("U_C");
+    expect(rows[1].user_id).toBe("U_A");
+  });
+});
+
+describe("JankenRating.resetSeasonFields", () => {
+  beforeEach(async () => {
+    await mysql("janken_rating").delete();
+    await mysql("janken_rating").insert([
+      {
+        user_id: "U_X",
+        elo: 1500,
+        rank_tier: "master",
+        win_count: 30,
+        lose_count: 10,
+        draw_count: 5,
+        streak: 4,
+        max_streak: 9,
+        bounty: 100,
+        lifetime_win_count: 0,
+        lifetime_lose_count: 0,
+        lifetime_draw_count: 0,
+      },
+    ]);
+  });
+  afterAll(() => mysql.destroy());
+
+  test("rotates per-season fields into lifetime, zeros bounty/streak, leaves max_streak", async () => {
+    await JankenRating.resetSeasonFields();
+    const row = await mysql("janken_rating").where({ user_id: "U_X" }).first();
+    expect(row.elo).toBe(1000);
+    expect(row.rank_tier).toBe("beginner");
+    expect(row.win_count).toBe(0);
+    expect(row.lose_count).toBe(0);
+    expect(row.draw_count).toBe(0);
+    expect(row.streak).toBe(0);
+    expect(row.bounty).toBe(0);
+    expect(row.max_streak).toBe(9);
+    expect(row.lifetime_win_count).toBe(30);
+    expect(row.lifetime_lose_count).toBe(10);
+    expect(row.lifetime_draw_count).toBe(5);
   });
 });

--- a/app/src/model/application/__tests__/JankenRating.test.js
+++ b/app/src/model/application/__tests__/JankenRating.test.js
@@ -1,3 +1,6 @@
+// Unit tests with mocked config — exercises getTiers() via the config-read path.
+// Companion integration tests (no mock, against real default.json) live at
+// app/__tests__/model/JankenRating.test.js.
 jest.mock("config", () => ({
   get: jest.fn(key => {
     if (key === "minigame.janken.elo.tiers") {

--- a/app/src/model/application/__tests__/JankenSeason.test.js
+++ b/app/src/model/application/__tests__/JankenSeason.test.js
@@ -1,0 +1,35 @@
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../../.env") });
+jest.unmock("../../../util/mysql");
+const mysql = jest.requireActual("../../../util/mysql");
+const JankenSeason = require("../JankenSeason");
+
+describe("JankenSeason", () => {
+  beforeEach(async () => {
+    await mysql("janken_seasons").delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  test("getActive returns the row with status='active'", async () => {
+    await mysql("janken_seasons").insert([
+      { id: 1, started_at: new Date(), status: "closed", ended_at: new Date() },
+      { id: 2, started_at: new Date(), status: "active" },
+    ]);
+    const active = await JankenSeason.getActive();
+    expect(active.id).toBe(2);
+  });
+
+  test("close sets status=closed and ended_at", async () => {
+    await mysql("janken_seasons").insert({ id: 3, started_at: new Date(), status: "active" });
+    await JankenSeason.close(3);
+    const row = await mysql("janken_seasons").where({ id: 3 }).first();
+    expect(row.status).toBe("closed");
+    expect(row.ended_at).not.toBeNull();
+  });
+
+  test("openNew creates a new active season", async () => {
+    const id = await JankenSeason.openNew("test note");
+    const row = await mysql("janken_seasons").where({ id }).first();
+    expect(row.status).toBe("active");
+    expect(row.notes).toBe("test note");
+  });
+});

--- a/app/src/model/application/__tests__/JankenSeasonSnapshot.test.js
+++ b/app/src/model/application/__tests__/JankenSeasonSnapshot.test.js
@@ -1,0 +1,48 @@
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../../.env") });
+jest.unmock("../../../util/mysql");
+const mysql = jest.requireActual("../../../util/mysql");
+const JankenSeasonSnapshot = require("../JankenSeasonSnapshot");
+
+describe("JankenSeasonSnapshot", () => {
+  beforeEach(async () => {
+    await mysql("janken_season_snapshot").delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  test("bulkInsert + getBySeason round-trips", async () => {
+    await JankenSeasonSnapshot.bulkInsert(7, [
+      {
+        rank: 1,
+        user_id: "U1",
+        display_name: "A",
+        elo: 1500,
+        rank_tier: "master",
+        win_count: 30,
+        lose_count: 10,
+        draw_count: 5,
+        max_streak: 6,
+      },
+      {
+        rank: 2,
+        user_id: "U2",
+        display_name: "B",
+        elo: 1300,
+        rank_tier: "fighter",
+        win_count: 20,
+        lose_count: 15,
+        draw_count: 3,
+        max_streak: 4,
+      },
+    ]);
+    const rows = await JankenSeasonSnapshot.getBySeason(7);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].rank).toBe(1);
+    expect(rows[0].elo).toBe(1500);
+  });
+
+  test("bulkInsert with empty array is a no-op", async () => {
+    await expect(JankenSeasonSnapshot.bulkInsert(8, [])).resolves.toBeUndefined();
+    const rows = await JankenSeasonSnapshot.getBySeason(8);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/app/src/router/api.js
+++ b/app/src/router/api.js
@@ -427,6 +427,9 @@ const JankenController = require("../controller/application/JankenController");
 
 router.get("/janken/rankings", JankenController.api.rankings);
 router.get("/janken/recent-matches", JankenController.api.recentMatches);
+router.get("/janken/seasons", JankenController.api.seasons);
+router.get("/janken/seasons/:id/top", JankenController.api.seasonTop);
+router.get("/janken/me/today-reward", JankenController.api.todayReward);
 
 const RaceRouter = require("./race");
 router.use("/race", RaceRouter);

--- a/app/src/service/JankenRewardService.js
+++ b/app/src/service/JankenRewardService.js
@@ -69,21 +69,38 @@ exports.payoutDaily = async function (rewardDate) {
 
   let credited = 0;
   for (const c of candidates) {
-    const inserted = await JankenDailyRewardLog.tryInsert({
-      user_id: c.user_id,
-      reward_date: rewardDate,
-      season_id: season.id,
-      reward_type: c.reward_type,
-      amount: c.amount,
-    });
-    if (inserted && c.amount > 0) {
-      await inventory.increaseGodStone({
-        userId: c.user_id,
+    if (c.amount <= 0) {
+      // log a 0-amount row for audit — still gated by unique key
+      await JankenDailyRewardLog.tryInsert({
+        user_id: c.user_id,
+        reward_date: rewardDate,
+        season_id: season.id,
+        reward_type: c.reward_type,
         amount: c.amount,
-        note: "janken_daily_rank_reward",
       });
-      credited += c.amount;
+      continue;
     }
+    await mysql.transaction(async trx => {
+      const inserted = await JankenDailyRewardLog.tryInsert(
+        {
+          user_id: c.user_id,
+          reward_date: rewardDate,
+          season_id: season.id,
+          reward_type: c.reward_type,
+          amount: c.amount,
+        },
+        trx
+      );
+      if (inserted) {
+        await inventory.increaseGodStone({
+          userId: c.user_id,
+          amount: c.amount,
+          note: "janken_daily_rank_reward",
+          trx,
+        });
+        credited += c.amount;
+      }
+    });
   }
 
   DefaultLogger.info(
@@ -110,11 +127,11 @@ exports.payoutSeasonEnd = async function (snapshotRows, seasonId, trx) {
     if (!bucket) continue;
     const amount = rewards[bucket] || 0;
     if (amount <= 0) continue;
-    if (trx) inventory.setTransaction(trx);
     await inventory.increaseGodStone({
       userId: row.user_id,
       amount,
       note: "janken_season_end_reward",
+      trx,
     });
     paid += amount;
   }

--- a/app/src/service/JankenRewardService.js
+++ b/app/src/service/JankenRewardService.js
@@ -1,0 +1,122 @@
+const mysql = require("../util/mysql");
+const config = require("config");
+const JankenSeason = require("../model/application/JankenSeason");
+const JankenDailyRewardLog = require("../model/application/JankenDailyRewardLog");
+const { inventory } = require("../model/application/Inventory");
+const { DefaultLogger } = require("../util/Logger");
+
+function bucketByPosition(p, rankTier) {
+  if (p === 1) return "top1";
+  if (p === 2) return "top2";
+  if (p === 3) return "top3";
+  if (p <= 10) return "top4_10";
+  if (rankTier === "legend") return "legend";
+  if (rankTier === "master") return "master";
+  if (rankTier === "fighter") return "fighter";
+  if (rankTier === "challenger") return "challenger";
+  return "beginner";
+}
+exports.bucketByPosition = bucketByPosition;
+
+exports.payoutDaily = async function (rewardDate) {
+  const enabled = Boolean(config.get("minigame.janken.daily_reward.enableDailyRankReward"));
+  const amounts = config.get("minigame.janken.daily_reward.amounts") || {};
+  const season = await JankenSeason.getActive();
+  if (!season) {
+    DefaultLogger.warn("[JankenRewardService] no active season; skipping daily payout");
+    return { dryRun: !enabled, candidates: [], season: null };
+  }
+
+  const start = new Date(`${rewardDate}T00:00:00+08:00`);
+  const end = new Date(`${rewardDate}T23:59:59.999+08:00`);
+
+  const initiators = mysql("janken_records")
+    .distinct({ u: "user_id" })
+    .where("bet_amount", ">", 0)
+    .whereBetween("created_at", [start, end]);
+  const targets = mysql("janken_records")
+    .distinct({ u: "target_user_id" })
+    .where("bet_amount", ">", 0)
+    .whereBetween("created_at", [start, end]);
+  const activeRows = await initiators.union([targets]);
+  const activeIds = activeRows.map(r => r.u);
+
+  if (activeIds.length === 0) {
+    DefaultLogger.info(`[JankenRewardService] no active players for ${rewardDate}`);
+    return { dryRun: !enabled, candidates: [], season: season.id };
+  }
+
+  const ranked = await mysql("janken_rating")
+    .whereIn("user_id", activeIds)
+    .orderBy("elo", "desc")
+    .orderBy("win_count", "desc");
+
+  const candidates = ranked
+    .map((r, i) => ({
+      user_id: r.user_id,
+      position: i + 1,
+      rank_tier: r.rank_tier,
+      reward_type: bucketByPosition(i + 1, r.rank_tier),
+    }))
+    .map(c => ({ ...c, amount: amounts[c.reward_type] || 0 }));
+
+  if (!enabled) {
+    DefaultLogger.info(
+      `[JankenRewardService] DRY RUN ${rewardDate} season=${season.id} candidates=${candidates.length}`
+    );
+    return { dryRun: true, candidates, season: season.id };
+  }
+
+  let credited = 0;
+  for (const c of candidates) {
+    const inserted = await JankenDailyRewardLog.tryInsert({
+      user_id: c.user_id,
+      reward_date: rewardDate,
+      season_id: season.id,
+      reward_type: c.reward_type,
+      amount: c.amount,
+    });
+    if (inserted && c.amount > 0) {
+      await inventory.increaseGodStone({
+        userId: c.user_id,
+        amount: c.amount,
+        note: "janken_daily_rank_reward",
+      });
+      credited += c.amount;
+    }
+  }
+
+  DefaultLogger.info(
+    `[JankenRewardService] paid ${rewardDate} season=${season.id} credited=${credited} stones to ${candidates.length} players`
+  );
+  return { dryRun: false, candidates, season: season.id, credited };
+};
+
+exports.payoutSeasonEnd = async function (snapshotRows, seasonId, trx) {
+  const enabled = Boolean(config.get("minigame.janken.season.enableSeasonEndRewards"));
+  if (!enabled) {
+    DefaultLogger.info(`[JankenRewardService] season-end payout skipped (flag off)`);
+    return { dryRun: true, paid: 0 };
+  }
+  const rewards = config.get("minigame.janken.season.endRewards") || {};
+  let paid = 0;
+  for (const row of snapshotRows) {
+    let bucket = null;
+    if (row.rank === 1) bucket = "top1";
+    else if (row.rank === 2) bucket = "top2";
+    else if (row.rank === 3) bucket = "top3";
+    else if (row.rank <= 10) bucket = "top4_10";
+    else if (row.rank <= 50) bucket = "top11_50";
+    if (!bucket) continue;
+    const amount = rewards[bucket] || 0;
+    if (amount <= 0) continue;
+    if (trx) inventory.setTransaction(trx);
+    await inventory.increaseGodStone({
+      userId: row.user_id,
+      amount,
+      note: "janken_season_end_reward",
+    });
+    paid += amount;
+  }
+  return { dryRun: false, paid };
+};

--- a/app/src/service/JankenSeasonService.js
+++ b/app/src/service/JankenSeasonService.js
@@ -1,0 +1,63 @@
+const mysql = require("../util/mysql");
+const config = require("config");
+const JankenSeason = require("../model/application/JankenSeason");
+const JankenSeasonSnapshot = require("../model/application/JankenSeasonSnapshot");
+const JankenRating = require("../model/application/JankenRating");
+const JankenRewardService = require("./JankenRewardService");
+const { DefaultLogger } = require("../util/Logger");
+
+exports.endCurrentAndOpenNext = async function ({ note = null, payoutEnabled = false } = {}) {
+  const snapshotTopN = config.get("minigame.janken.season.snapshotTopN") || 50;
+  const enableSeasonEndRewards =
+    payoutEnabled && Boolean(config.get("minigame.janken.season.enableSeasonEndRewards"));
+
+  return mysql.transaction(async trx => {
+    const active = await JankenSeason.getActive(trx);
+    if (!active) throw new Error("Janken: no active season to close");
+
+    const top = await JankenRating.getTopByElo(snapshotTopN, trx);
+    const userIds = top.map(r => r.user_id);
+    const profiles = userIds.length
+      ? await trx("user").whereIn("platform_id", userIds).select("platform_id", "display_name")
+      : [];
+    const nameByUid = Object.fromEntries(profiles.map(p => [p.platform_id, p.display_name]));
+
+    const snapshotRows = top.map((r, i) => ({
+      rank: i + 1,
+      user_id: r.user_id,
+      display_name: nameByUid[r.user_id] || null,
+      elo: r.elo,
+      rank_tier: r.rank_tier,
+      win_count: r.win_count,
+      lose_count: r.lose_count,
+      draw_count: r.draw_count,
+      max_streak: r.max_streak,
+    }));
+    await JankenSeasonSnapshot.bulkInsert(active.id, snapshotRows, trx);
+
+    if (enableSeasonEndRewards) {
+      await JankenRewardService.payoutSeasonEnd(snapshotRows, active.id, trx);
+    } else {
+      DefaultLogger.info(
+        `[JankenSeasonService] season-end rewards skipped (payoutEnabled=${payoutEnabled}, flag=${config.get(
+          "minigame.janken.season.enableSeasonEndRewards"
+        )})`
+      );
+    }
+
+    await JankenSeason.close(active.id, trx);
+    await JankenRating.resetSeasonFields(trx);
+    const newSeasonId = await JankenSeason.openNew(note, trx);
+
+    DefaultLogger.info(
+      `[JankenSeasonService] season ${active.id} closed, ${snapshotRows.length} snapshotted, season ${newSeasonId} opened`
+    );
+
+    return {
+      closedSeasonId: active.id,
+      newSeasonId,
+      snapshotCount: snapshotRows.length,
+      payoutEnabled: enableSeasonEndRewards,
+    };
+  });
+};

--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -337,7 +337,8 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
     return { p1EloChange: 0, p2EloChange: 0, p1NewElo: null, p2NewElo: null };
   }
 
-  if (!betAmount || betAmount <= 0) {
+  const nonBetK = config.get("minigame.janken.elo.nonBetK");
+  if ((!betAmount || betAmount <= 0) && (!nonBetK || nonBetK <= 0)) {
     return { p1EloChange: 0, p2EloChange: 0, p1NewElo: null, p2NewElo: null };
   }
 
@@ -424,7 +425,14 @@ exports.getStreakMultiplier = function (streak) {
 
 exports.calculateEloChange = function (myElo, opponentElo, result, betAmount, { streak = 0 } = {}) {
   if (result === "draw") return 0;
-  const K = JankenRating.getKFactor(betAmount);
+  let K;
+  if (!betAmount || betAmount <= 0) {
+    const nonBetK = config.get("minigame.janken.elo.nonBetK");
+    if (!nonBetK || nonBetK <= 0) return 0;
+    K = nonBetK;
+  } else {
+    K = JankenRating.getKFactor(betAmount);
+  }
   const expected = exports.calculateExpectedWinRate(myElo, opponentElo);
   const actual = result === "win" ? 1 : 0;
   const raw = K * (actual - expected);

--- a/app/src/service/__tests__/JankenRewardService.test.js
+++ b/app/src/service/__tests__/JankenRewardService.test.js
@@ -15,6 +15,10 @@ describe("JankenRewardService.payoutDaily", () => {
     await mysql("janken_seasons").insert({ id: 1, started_at: new Date(), status: "active" });
   });
   afterAll(() => mysql.destroy());
+  afterEach(() => {
+    jest.dontMock("config");
+    jest.resetModules();
+  });
 
   test("dry-run when flag is false: no inventory, no log rows", async () => {
     await mysql("janken_rating").insert({ user_id: "U_T", elo: 1100, rank_tier: "challenger" });
@@ -65,6 +69,19 @@ describe("JankenRewardService.payoutDaily", () => {
       .where({ note: "janken_daily_rank_reward", userId: "U_FlagOn" })
       .first();
     expect(Number(stones.itemAmount)).toBe(500);
+  });
+  test("dry-run with no active players returns empty candidates", async () => {
+    // No janken_records inserted. Should return empty candidates with the active season id.
+    const result = await JankenRewardService.payoutDaily(yesterdayDateString());
+    expect(result.candidates).toEqual([]);
+    expect(result.season).toBe(1);
+  });
+
+  test("dry-run with no active season returns season:null", async () => {
+    await mysql("janken_seasons").update({ status: "closed", ended_at: new Date() });
+    const result = await JankenRewardService.payoutDaily(yesterdayDateString());
+    expect(result.season).toBeNull();
+    expect(result.candidates).toEqual([]);
   });
 });
 

--- a/app/src/service/__tests__/JankenRewardService.test.js
+++ b/app/src/service/__tests__/JankenRewardService.test.js
@@ -1,0 +1,81 @@
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../.env") });
+jest.unmock("../../util/mysql");
+const mysql = jest.requireActual("../../util/mysql");
+const JankenRewardService = require("../JankenRewardService");
+
+describe("JankenRewardService.payoutDaily", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      mysql("janken_daily_reward_log").delete(),
+      mysql("janken_records").delete(),
+      mysql("janken_rating").delete(),
+      mysql("Inventory").where({ note: "janken_daily_rank_reward" }).delete(),
+      mysql("janken_seasons").delete(),
+    ]);
+    await mysql("janken_seasons").insert({ id: 1, started_at: new Date(), status: "active" });
+  });
+  afterAll(() => mysql.destroy());
+
+  test("dry-run when flag is false: no inventory, no log rows", async () => {
+    await mysql("janken_rating").insert({ user_id: "U_T", elo: 1100, rank_tier: "challenger" });
+    await mysql("janken_records").insert({
+      id: "rec-1",
+      user_id: "U_T",
+      target_user_id: "U_O",
+      group_id: "G",
+      bet_amount: 100,
+      created_at: yesterdayLocal(),
+    });
+    const result = await JankenRewardService.payoutDaily(yesterdayDateString());
+    expect(result.dryRun).toBe(true);
+    expect(result.candidates).toHaveLength(1);
+    const stones = await mysql("Inventory").where({ note: "janken_daily_rank_reward" });
+    expect(stones).toHaveLength(0);
+    const logs = await mysql("janken_daily_reward_log");
+    expect(logs).toHaveLength(0);
+  });
+
+  test("flag-on: inserts log row + credits inventory", async () => {
+    jest.resetModules();
+    jest.doMock("config", () => {
+      const orig = jest.requireActual("config");
+      return {
+        get: jest.fn(key => {
+          if (key === "minigame.janken.daily_reward.enableDailyRankReward") return true;
+          return orig.get(key);
+        }),
+      };
+    });
+    const Service = require("../JankenRewardService");
+    const date = yesterdayDateString();
+    await mysql("janken_rating").insert({ user_id: "U_FlagOn", elo: 1700, rank_tier: "legend" });
+    await mysql("janken_records").insert({
+      id: "rec-flag",
+      user_id: "U_FlagOn",
+      target_user_id: "U_O",
+      group_id: "G",
+      bet_amount: 500,
+      created_at: yesterdayLocal(),
+    });
+    const result = await Service.payoutDaily(date);
+    expect(result.dryRun).toBe(false);
+    const log = await mysql("janken_daily_reward_log").where({ user_id: "U_FlagOn" }).first();
+    expect(log.amount).toBe(500); // top1
+    const stones = await mysql("Inventory")
+      .where({ note: "janken_daily_rank_reward", userId: "U_FlagOn" })
+      .first();
+    expect(Number(stones.itemAmount)).toBe(500);
+  });
+});
+
+function yesterdayLocal() {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+function yesterdayDateString() {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().slice(0, 10);
+}

--- a/app/src/service/__tests__/JankenSeasonService.test.js
+++ b/app/src/service/__tests__/JankenSeasonService.test.js
@@ -1,0 +1,90 @@
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../.env") });
+jest.unmock("../../util/mysql");
+const mysql = jest.requireActual("../../util/mysql");
+const JankenSeasonService = require("../JankenSeasonService");
+
+describe("JankenSeasonService.endCurrentAndOpenNext", () => {
+  beforeEach(async () => {
+    await mysql("janken_season_snapshot").delete();
+    await mysql("janken_seasons").delete();
+    await mysql("janken_rating").delete();
+    await mysql("janken_seasons").insert({
+      id: 1,
+      started_at: new Date(),
+      status: "active",
+      notes: "season 1",
+    });
+    await mysql("janken_rating").insert([
+      {
+        user_id: "U1",
+        elo: 1700,
+        rank_tier: "legend",
+        win_count: 50,
+        lose_count: 10,
+        draw_count: 5,
+        streak: 3,
+        max_streak: 8,
+        bounty: 0,
+      },
+      {
+        user_id: "U2",
+        elo: 1500,
+        rank_tier: "master",
+        win_count: 30,
+        lose_count: 12,
+        draw_count: 4,
+        streak: 0,
+        max_streak: 6,
+        bounty: 0,
+      },
+      {
+        user_id: "U3",
+        elo: 1100,
+        rank_tier: "challenger",
+        win_count: 12,
+        lose_count: 8,
+        draw_count: 2,
+        streak: 1,
+        max_streak: 3,
+        bounty: 0,
+      },
+    ]);
+  });
+  afterAll(() => mysql.destroy());
+
+  test("snapshots top, resets, opens next season", async () => {
+    const result = await JankenSeasonService.endCurrentAndOpenNext({
+      note: "test reset",
+      payoutEnabled: false,
+    });
+    expect(result.closedSeasonId).toBe(1);
+    expect(result.newSeasonId).toBeGreaterThan(1);
+    expect(result.snapshotCount).toBe(3);
+
+    const snapshots = await mysql("janken_season_snapshot").where({ season_id: 1 }).orderBy("rank");
+    expect(snapshots[0].user_id).toBe("U1");
+    expect(snapshots[0].rank).toBe(1);
+
+    const closed = await mysql("janken_seasons").where({ id: 1 }).first();
+    expect(closed.status).toBe("closed");
+    expect(closed.ended_at).not.toBeNull();
+
+    const newActive = await mysql("janken_seasons").where({ status: "active" }).first();
+    expect(newActive.id).toBe(result.newSeasonId);
+    expect(newActive.notes).toBe("test reset");
+
+    const u1 = await mysql("janken_rating").where({ user_id: "U1" }).first();
+    expect(u1.elo).toBe(1000);
+    expect(u1.rank_tier).toBe("beginner");
+    expect(u1.win_count).toBe(0);
+    expect(u1.lifetime_win_count).toBe(50);
+    expect(u1.max_streak).toBe(8);
+  });
+
+  test("aborts when no active season", async () => {
+    await mysql("janken_seasons").update({ status: "closed", ended_at: new Date() });
+    await expect(
+      JankenSeasonService.endCurrentAndOpenNext({ note: "x", payoutEnabled: false })
+    ).rejects.toThrow(/no active season/i);
+  });
+});

--- a/app/src/service/__tests__/JankenService.elo.test.js
+++ b/app/src/service/__tests__/JankenService.elo.test.js
@@ -1,0 +1,47 @@
+jest.mock("config", () => {
+  const data = {
+    "minigame.janken.elo.kFactorTiers": [
+      { minBet: 50000, k: 80 },
+      { minBet: 5000, k: 60 },
+      { minBet: 1000, k: 32 },
+      { minBet: 100, k: 20 },
+      { minBet: 0, k: 12 },
+    ],
+    "minigame.janken.elo.lossFactor": 0.5,
+    "minigame.janken.elo.nonBetK": 0,
+    "minigame.janken.elo.streakBonus": [
+      { minStreak: 7, multiplier: 2.0 },
+      { minStreak: 5, multiplier: 1.5 },
+      { minStreak: 3, multiplier: 1.25 },
+    ],
+    "minigame.janken.elo.initial": 1000,
+    "minigame.janken.elo.tiers": [{ key: "beginner", name: "見習者", minElo: 0 }],
+    "minigame.janken.bet.feeRate": 0.1,
+    "minigame.janken.bet.minAmount": 10,
+    "minigame.janken.streak.bountyMinBet": 1000,
+    "minigame.janken.streak.bountyClaimMultiplier": 5,
+    "redis.keys.jankenDecide": "jankenDecide",
+    "redis.keys.jankenChallenge": "jankenChallenge",
+  };
+  return { get: jest.fn(key => data[key]) };
+});
+
+const JankenService = require("../JankenService");
+
+describe("JankenService.calculateEloChange (rebalanced K table)", () => {
+  test("avg bet of 289 lands in K=20 tier (was K=8)", () => {
+    const change = JankenService.calculateEloChange(1000, 1000, "win", 289);
+    // K=20, expected=0.5, raw = 20 * 0.5 = 10; multiplier 1 (streak 0) → floor(10) = 10
+    expect(change).toBe(10);
+  });
+
+  test("loss at K=20 even matchup applies lossFactor 0.5", () => {
+    const change = JankenService.calculateEloChange(1000, 1000, "lose", 289);
+    // raw = 20 * (0 - 0.5) = -10; lossFactor 0.5 → ceil(-10 * 0.5) = -5
+    expect(change).toBe(-5);
+  });
+
+  test("non-bet match returns 0 when nonBetK=0", () => {
+    expect(JankenService.calculateEloChange(1000, 1000, "win", 0)).toBe(0);
+  });
+});

--- a/app/src/templates/application/Janken.js
+++ b/app/src/templates/application/Janken.js
@@ -792,7 +792,79 @@ exports.generateRankCard = ({
   serverRank,
   maxBet,
   baseUrl,
+  seasonId,
+  seasonStartedAt,
+  lifetime,
+  todayReward,
 }) => {
+  const seasonBlock = seasonId
+    ? {
+        type: "box",
+        layout: "horizontal",
+        contents: [
+          { type: "text", text: "賽季", color: HERO_SURFACE.textMuted, size: "xs", flex: 1 },
+          {
+            type: "text",
+            text: `第 ${seasonId} 賽季`,
+            color: HERO_SURFACE.text,
+            size: "xs",
+            align: "end",
+            flex: 2,
+          },
+        ],
+      }
+    : null;
+
+  const lifetimeBlock = lifetime
+    ? {
+        type: "box",
+        layout: "horizontal",
+        contents: [
+          {
+            type: "text",
+            text: "生涯戰績",
+            color: HERO_SURFACE.textMuted,
+            size: "xs",
+            flex: 1,
+          },
+          {
+            type: "text",
+            text: `${lifetime.win} 勝 / ${lifetime.lose} 敗 / ${lifetime.draw} 平`,
+            color: HERO_SURFACE.text,
+            size: "xs",
+            align: "end",
+            flex: 2,
+          },
+        ],
+      }
+    : null;
+
+  const todayRewardBlock = todayReward
+    ? {
+        type: "box",
+        layout: "horizontal",
+        contents: [
+          {
+            type: "text",
+            text: "今日獎勵",
+            color: HERO_SURFACE.textMuted,
+            size: "xs",
+            flex: 1,
+          },
+          {
+            type: "text",
+            text: `+${todayReward.amount} 女神石`,
+            color: HERO_SURFACE.textAccent,
+            size: "xs",
+            align: "end",
+            flex: 2,
+          },
+        ],
+      }
+    : null;
+
+  const newRows = [seasonBlock, lifetimeBlock, todayRewardBlock].filter(Boolean);
+
   const bodyContents = [
     {
       type: "box",
@@ -972,6 +1044,7 @@ exports.generateRankCard = ({
               },
             ]
           : []),
+        ...newRows,
       ],
       margin: "lg",
       spacing: "sm",

--- a/app/src/templates/application/Janken.js
+++ b/app/src/templates/application/Janken.js
@@ -793,7 +793,6 @@ exports.generateRankCard = ({
   maxBet,
   baseUrl,
   seasonId,
-  seasonStartedAt,
   lifetime,
   todayReward,
 }) => {

--- a/app/src/templates/application/__tests__/Janken.rankCard.test.js
+++ b/app/src/templates/application/__tests__/Janken.rankCard.test.js
@@ -1,0 +1,50 @@
+const tpl = require("../Janken");
+
+test("generateRankCard renders season block when seasonId provided", () => {
+  const card = tpl.generateRankCard({
+    rankLabel: "見習者 5",
+    rankImageKey: "rank_beginner",
+    elo: 1000,
+    winCount: 0,
+    loseCount: 0,
+    drawCount: 0,
+    winRate: 0,
+    streak: 0,
+    maxStreak: 0,
+    bounty: 0,
+    eloToNext: 100,
+    serverRank: 1,
+    maxBet: 50000,
+    baseUrl: "https://x",
+    seasonId: 2,
+    seasonStartedAt: new Date(),
+    lifetime: { win: 100, lose: 50, draw: 5 },
+    todayReward: { type: "top1", amount: 500 },
+  });
+  const rendered = JSON.stringify(card);
+  expect(rendered).toContain("第 2 賽季");
+  expect(rendered).toContain("100 勝 / 50 敗");
+  expect(rendered).toContain("+500 女神石");
+});
+
+test("generateRankCard hides season/lifetime/todayReward blocks when null", () => {
+  const card = tpl.generateRankCard({
+    rankLabel: "見習者 5",
+    rankImageKey: "rank_beginner",
+    elo: 1000,
+    winCount: 0,
+    loseCount: 0,
+    drawCount: 0,
+    winRate: 0,
+    streak: 0,
+    maxStreak: 0,
+    bounty: 0,
+    eloToNext: 100,
+    serverRank: 1,
+    maxBet: 50000,
+    baseUrl: "https://x",
+  });
+  const rendered = JSON.stringify(card);
+  expect(rendered).not.toContain("賽季");
+  expect(rendered).not.toContain("生涯戰績");
+});

--- a/app/src/util/date.js
+++ b/app/src/util/date.js
@@ -3,3 +3,6 @@ const moment = require("moment");
 const TPE_OFFSET_MIN = 480;
 
 exports.todayUtc8 = () => moment().utcOffset(TPE_OFFSET_MIN).format("YYYY-MM-DD");
+
+exports.yesterdayUtc8 = () =>
+  moment().utcOffset(TPE_OFFSET_MIN).subtract(1, "day").format("YYYY-MM-DD");

--- a/docs/superpowers/plans/2026-05-01-janken-season-rewards.md
+++ b/docs/superpowers/plans/2026-05-01-janken-season-rewards.md
@@ -1,0 +1,2066 @@
+# Janken Season Reset + Daily Rewards + ELO Rebalance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manual season-reset CLI, daily women-stone rewards by ELO ranking, and rebalance ELO/bet/bounty so honest play actually progresses through tiers.
+
+**Architecture:** New `janken_seasons` / `janken_season_snapshot` / `janken_daily_reward_log` tables; per-season fields on `janken_rating` rotate at reset, lifetime counters preserved. CLI for reset (ops-only, not LINE-driven), cron for daily rewards (kill-switched). ELO formula stays the same — only the K table, tier thresholds, bet/bounty caps, and a new `nonBetK` knob change. Phase 2 anti-farming is spec'd but not built (rewards stay off until that ships).
+
+**Tech Stack:** Node.js (CommonJS), Knex (MySQL), Jest, Bottender, Express, React (Vite). All edits inside `app/` workspace except the small frontend chip.
+
+**Spec:** [`docs/superpowers/specs/2026-05-01-janken-season-rewards-design.md`](../specs/2026-05-01-janken-season-rewards-design.md)
+
+**Branch:** `feat/janken-season-rewards` (already created, design doc committed).
+
+---
+
+## Design Principles
+
+- **Schema → config → model → service → bin → controller/api → frontend.** Linear dependency order.
+- **Every milestone leaves `yarn test:app` green.** No half-baked merges between milestones.
+- **Rewards default-off.** Both `enableSeasonEndRewards` and `enableDailyRankReward` ship as `false`; flip in a follow-up PR after Phase 2 anti-farming.
+- **Live data is preserved.** No destructive migration on existing `janken_rating` rows; the season-end CLI is the only path that mutates per-season fields.
+- **TDD where logic exists.** Migrations and config files don't get "tests first"; models, services, bin scripts, controllers, and template helpers do.
+
+---
+
+## File Map
+
+### Created
+
+- `app/migrations/<ts>_create_janken_seasons.js`
+- `app/migrations/<ts>_create_janken_season_snapshot.js`
+- `app/migrations/<ts>_create_janken_daily_reward_log.js`
+- `app/migrations/<ts>_add_lifetime_counts_to_janken_rating.js`
+- `app/migrations/<ts>_seed_janken_season_one.js`
+- `app/src/model/application/JankenSeason.js`
+- `app/src/model/application/JankenSeasonSnapshot.js`
+- `app/src/model/application/JankenDailyRewardLog.js`
+- `app/src/service/JankenSeasonService.js`
+- `app/src/service/JankenRewardService.js`
+- `app/bin/JankenSeasonEnd.js`
+- `app/bin/JankenDailyRewards.js`
+- `app/src/model/application/__tests__/JankenSeason.test.js`
+- `app/src/model/application/__tests__/JankenSeasonSnapshot.test.js`
+- `app/src/model/application/__tests__/JankenDailyRewardLog.test.js`
+- `app/src/service/__tests__/JankenSeasonService.test.js`
+- `app/src/service/__tests__/JankenRewardService.test.js`
+- `app/src/service/__tests__/JankenService.elo.test.js` (ELO rebalance tests)
+- `app/bin/__tests__/JankenSeasonEnd.test.js`
+- `app/bin/__tests__/JankenDailyRewards.test.js`
+
+### Modified
+
+- `app/config/default.json` — replace `minigame.janken` block (§5 of spec)
+- `app/src/model/application/JankenRating.js` — read tiers from config; add `getTopByElo(limit, trx)`, `resetSeasonFields(trx)`
+- `app/src/service/JankenService.js` — pull `lossFactor` / `nonBetK` from config; touch `updateElo` to honor `nonBetK`
+- `app/src/controller/application/JankenController.js` — extend `queryRank` payload; add 3 API handlers
+- `app/src/templates/application/Janken.js` — extend `generateRankCard` with season + lifetime + today-reward block
+- `app/src/router/api.js` — register 3 new routes
+- `app/config/crontab.config.js` — register `JankenDailyRewards`
+- `frontend/src/services/janken.js` — `getSeasons`, `getSeasonTop`, `getMyTodayReward`
+- `frontend/src/pages/Janken/index.jsx` — add season chip in header
+
+### Untouched (intentional)
+
+- `app/src/middleware/*` — no rate-limit / postback changes.
+- `app/src/model/application/JankenAutoFateLog.js` — auto-fate behavior unchanged.
+- `app/src/model/application/JankenRecords.js` / `JankenResult.js` — record schema unchanged.
+- LINE templates `generateDuelCard` / `generateArenaCard` / `generateResultCard` — unchanged (rank changes already render in result card via existing `getRankImageKey`).
+
+---
+
+## M1. Schema & Seed
+
+**Goal:** All new tables exist, lifetime columns added, season `id=1` row inserted. `yarn migrate` is idempotent.
+
+### Task 1.1: `janken_seasons` migration
+
+**Files:**
+- Create: `app/migrations/<ts>_create_janken_seasons.js`
+
+- [ ] **Step 1: Generate migration file**
+
+```bash
+cd app && yarn knex migrate:make create_janken_seasons
+```
+
+- [ ] **Step 2: Write migration body**
+
+```js
+exports.up = function (knex) {
+  return knex.schema.createTable("janken_seasons", table => {
+    table.increments("id").unsigned().primary();
+    table.dateTime("started_at").notNullable();
+    table.dateTime("ended_at").nullable();
+    table.enu("status", ["active", "closed"]).notNullable().defaultTo("active");
+    table.text("notes").nullable();
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("janken_seasons");
+};
+```
+
+- [ ] **Step 3: Run migration**
+
+Run: `cd app && yarn migrate`
+Expected: migration applied, no error.
+
+- [ ] **Step 4: Verify schema**
+
+Run: `docker exec redive_linebot-mysql-1 mysql -uroot -p$DB_PASSWORD Princess -e "DESCRIBE janken_seasons;"`
+Expected: 7 columns including `id`, `started_at`, `ended_at`, `status`, `notes`, `created_at`, `updated_at`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/migrations/*_create_janken_seasons.js
+git commit -m "feat(janken): create janken_seasons table"
+```
+
+### Task 1.2: `janken_season_snapshot` migration
+
+**Files:**
+- Create: `app/migrations/<ts>_create_janken_season_snapshot.js`
+
+- [ ] **Step 1: Generate migration file**
+
+```bash
+cd app && yarn knex migrate:make create_janken_season_snapshot
+```
+
+- [ ] **Step 2: Write migration body**
+
+```js
+exports.up = function (knex) {
+  return knex.schema.createTable("janken_season_snapshot", table => {
+    table.increments("id").unsigned().primary();
+    table.integer("season_id").unsigned().notNullable();
+    table.smallint("rank").unsigned().notNullable();
+    table.string("user_id", 33).notNullable();
+    table.string("display_name", 255).nullable();
+    table.integer("elo").notNullable();
+    table.string("rank_tier", 20).notNullable();
+    table.integer("win_count").notNullable().defaultTo(0);
+    table.integer("lose_count").notNullable().defaultTo(0);
+    table.integer("draw_count").notNullable().defaultTo(0);
+    table.integer("max_streak").notNullable().defaultTo(0);
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.index(["season_id", "rank"], "idx_season_rank");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("janken_season_snapshot");
+};
+```
+
+- [ ] **Step 3: Run + verify**
+
+Run: `cd app && yarn migrate`
+Verify: `DESCRIBE janken_season_snapshot;` shows 13 columns + composite index.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/migrations/*_create_janken_season_snapshot.js
+git commit -m "feat(janken): create janken_season_snapshot table"
+```
+
+### Task 1.3: `janken_daily_reward_log` migration
+
+**Files:**
+- Create: `app/migrations/<ts>_create_janken_daily_reward_log.js`
+
+- [ ] **Step 1: Generate**
+
+```bash
+cd app && yarn knex migrate:make create_janken_daily_reward_log
+```
+
+- [ ] **Step 2: Write migration body**
+
+```js
+exports.up = function (knex) {
+  return knex.schema.createTable("janken_daily_reward_log", table => {
+    table.increments("id").unsigned().primary();
+    table.string("user_id", 33).notNullable();
+    table.date("reward_date").notNullable();
+    table.integer("season_id").unsigned().notNullable();
+    table.string("reward_type", 20).notNullable();
+    table.integer("amount").notNullable().defaultTo(0);
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.unique(["user_id", "reward_date"], "uniq_user_date");
+    table.index("reward_date", "idx_reward_date");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("janken_daily_reward_log");
+};
+```
+
+- [ ] **Step 3: Run + verify unique key**
+
+Run: `cd app && yarn migrate`
+Verify: `SHOW INDEX FROM janken_daily_reward_log;` lists `uniq_user_date` UNIQUE.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/migrations/*_create_janken_daily_reward_log.js
+git commit -m "feat(janken): create janken_daily_reward_log with unique (user_id, reward_date)"
+```
+
+### Task 1.4: Add lifetime counters to `janken_rating`
+
+**Files:**
+- Create: `app/migrations/<ts>_add_lifetime_counts_to_janken_rating.js`
+
+- [ ] **Step 1: Generate**
+
+```bash
+cd app && yarn knex migrate:make add_lifetime_counts_to_janken_rating
+```
+
+- [ ] **Step 2: Write migration body**
+
+```js
+exports.up = function (knex) {
+  return knex.schema.alterTable("janken_rating", table => {
+    table.integer("lifetime_win_count").notNullable().defaultTo(0);
+    table.integer("lifetime_lose_count").notNullable().defaultTo(0);
+    table.integer("lifetime_draw_count").notNullable().defaultTo(0);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable("janken_rating", table => {
+    table.dropColumn("lifetime_win_count");
+    table.dropColumn("lifetime_lose_count");
+    table.dropColumn("lifetime_draw_count");
+  });
+};
+```
+
+> **Important:** do NOT backfill `lifetime_*` from existing `win_count`/`lose_count`/`draw_count`. The season-end CLI's `lifetime_* += win_count` step naturally captures pre-v2 totals. Backfilling here would double-count.
+
+- [ ] **Step 3: Run + verify**
+
+Run: `cd app && yarn migrate`
+Verify: `DESCRIBE janken_rating;` shows three new columns all defaulting to 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/migrations/*_add_lifetime_counts_to_janken_rating.js
+git commit -m "feat(janken): add lifetime_{win,lose,draw}_count to janken_rating"
+```
+
+### Task 1.5: Seed `janken_seasons` row id=1
+
+**Files:**
+- Create: `app/migrations/<ts>_seed_janken_season_one.js`
+
+A seed file would also work, but a migration guarantees the row exists exactly once across all environments and never re-runs.
+
+- [ ] **Step 1: Generate**
+
+```bash
+cd app && yarn knex migrate:make seed_janken_season_one
+```
+
+- [ ] **Step 2: Write migration body**
+
+```js
+exports.up = async function (knex) {
+  const existing = await knex("janken_seasons").first();
+  if (existing) return;
+
+  const oldest = await knex("janken_records")
+    .min({ ts: "created_at" })
+    .first();
+  const startedAt = (oldest && oldest.ts) || new Date();
+
+  await knex("janken_seasons").insert({
+    id: 1,
+    started_at: startedAt,
+    status: "active",
+    notes: "v1 retroactive — first season",
+  });
+};
+
+exports.down = async function (knex) {
+  await knex("janken_seasons").where({ id: 1 }).delete();
+};
+```
+
+- [ ] **Step 3: Run + verify**
+
+Run: `cd app && yarn migrate`
+Verify: `SELECT * FROM janken_seasons;` shows one row with `id=1`, `status=active`, `started_at` matching the oldest record.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/migrations/*_seed_janken_season_one.js
+git commit -m "feat(janken): seed initial active season row"
+```
+
+**Exit Criteria for M1:**
+- `yarn migrate` runs cleanly on a fresh DB.
+- All 4 new tables / column additions present.
+- `janken_seasons.id=1` exists with `status='active'`.
+
+---
+
+## M2. Configuration
+
+**Goal:** `default.json` carries the new tier thresholds, K-table, bet/bounty caps, and reward amounts. Code reads from config rather than constants. Existing janken behavior unchanged when new flags are at defaults.
+
+### Task 2.1: Replace `minigame.janken` block in `default.json`
+
+**Files:**
+- Modify: `app/config/default.json` (the `minigame.janken` object)
+
+- [ ] **Step 1: Replace the block verbatim with §5 of the spec**
+
+Open `app/config/default.json` and replace the entire `minigame.janken` value with:
+
+```json
+{
+  "paper": "🖐️",
+  "rock": "✊",
+  "scissors": "✌️",
+  "season": {
+    "snapshotTopN": 50,
+    "enableSeasonEndRewards": false,
+    "endRewards": {
+      "top1": 50000,
+      "top2": 30000,
+      "top3": 20000,
+      "top4_10": 5000,
+      "top11_50": 1000
+    }
+  },
+  "daily_reward": {
+    "enableDailyRankReward": false,
+    "amounts": {
+      "top1": 500,
+      "top2": 300,
+      "top3": 200,
+      "top4_10": 50,
+      "legend": 100,
+      "master": 50,
+      "fighter": 25,
+      "challenger": 10,
+      "beginner": 0
+    }
+  },
+  "bet": {
+    "minAmount": 10,
+    "maxAmountByRank": {
+      "beginner": 50000,
+      "challenger": 100000,
+      "fighter": 200000,
+      "master": 500000,
+      "legend": 1000000
+    },
+    "feeRate": 0.1
+  },
+  "streak": {
+    "maxBountyByRank": {
+      "beginner": 20000,
+      "challenger": 50000,
+      "fighter": 100000,
+      "master": 200000,
+      "legend": 300000
+    },
+    "bountyMinBet": 1000,
+    "bountyClaimMultiplier": 5
+  },
+  "elo": {
+    "initial": 1000,
+    "tiers": [
+      { "key": "beginner",   "name": "見習者", "minElo": 0    },
+      { "key": "challenger", "name": "挑戰者", "minElo": 1100 },
+      { "key": "fighter",    "name": "強者",   "minElo": 1250 },
+      { "key": "master",     "name": "達人",   "minElo": 1400 },
+      { "key": "legend",     "name": "傳說",   "minElo": 1550 }
+    ],
+    "kFactorTiers": [
+      { "minBet": 50000, "k": 80 },
+      { "minBet":  5000, "k": 60 },
+      { "minBet":  1000, "k": 32 },
+      { "minBet":   100, "k": 20 },
+      { "minBet":     0, "k": 12 }
+    ],
+    "lossFactor": 0.5,
+    "nonBetK": 0,
+    "streakBonus": [
+      { "minStreak": 7, "multiplier": 2.0 },
+      { "minStreak": 5, "multiplier": 1.5 },
+      { "minStreak": 3, "multiplier": 1.25 }
+    ]
+  },
+  "images": {
+    "rock": "/assets/janken/rock.png",
+    "scissors": "/assets/janken/scissors.png",
+    "paper": "/assets/janken/paper.png",
+    "win": "/assets/janken/win.png",
+    "lose": "/assets/janken/lose.png",
+    "draw": "/assets/janken/draw.png",
+    "vs": "/assets/janken/vs.png"
+  }
+}
+```
+
+- [ ] **Step 2: Validate JSON parses**
+
+Run: `cd app && node -e "JSON.parse(require('fs').readFileSync('config/default.json'))"` (no output = valid).
+
+- [ ] **Step 3: Validate config loader sees new keys**
+
+Run: `cd app && node -e "console.log(require('config').get('minigame.janken.elo.tiers').length)"`
+Expected: `5`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/config/default.json
+git commit -m "config(janken): introduce season + daily_reward + rebalanced ELO/bet caps"
+```
+
+### Task 2.2: `JankenRating` reads tiers from config
+
+**Files:**
+- Modify: `app/src/model/application/JankenRating.js`
+- Test: `app/src/model/application/__tests__/JankenRating.test.js` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `app/src/model/application/__tests__/JankenRating.test.js`:
+
+```js
+jest.mock("config", () => ({
+  get: jest.fn(key => {
+    if (key === "minigame.janken.elo.tiers") {
+      return [
+        { key: "beginner",   name: "見習者", minElo: 0    },
+        { key: "challenger", name: "挑戰者", minElo: 1100 },
+        { key: "fighter",    name: "強者",   minElo: 1250 },
+        { key: "master",     name: "達人",   minElo: 1400 },
+        { key: "legend",     name: "傳說",   minElo: 1550 },
+      ];
+    }
+    if (key === "minigame.janken.elo.initial") return 1000;
+    return undefined;
+  }),
+}));
+
+const JankenRating = require("../JankenRating");
+
+describe("JankenRating tiers from config", () => {
+  test("returns fighter at 1250", () => {
+    expect(JankenRating.getRankTier(1250)).toBe("fighter");
+  });
+  test("returns master at 1400", () => {
+    expect(JankenRating.getRankTier(1400)).toBe("master");
+  });
+  test("returns challenger at 1100", () => {
+    expect(JankenRating.getRankTier(1100)).toBe("challenger");
+  });
+  test("returns beginner at 1099", () => {
+    expect(JankenRating.getRankTier(1099)).toBe("beginner");
+  });
+  test("getNextTierElo from challenger returns fighter floor", () => {
+    expect(JankenRating.getNextTierElo(1150)).toBe(1250);
+  });
+});
+```
+
+> Place `jest.mock("config", ...)` BEFORE `require("../JankenRating")` — `transform: {}` in jest config means mocks are NOT hoisted (per `feedback_jest_mock_hoisting`).
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+Run: `cd app && yarn test JankenRating.test.js`
+Expected: FAIL — current code uses hard-coded `RANK_TIERS = [...minElo:1200,1400,1600,1800]`.
+
+- [ ] **Step 3: Refactor `JankenRating.js`**
+
+Replace the constants block at the top of `JankenRating.js`:
+
+```js
+const config = require("config");
+
+const FALLBACK_TIERS = [
+  { key: "beginner",   name: "見習者", minElo: 0    },
+  { key: "challenger", name: "挑戰者", minElo: 1100 },
+  { key: "fighter",    name: "強者",   minElo: 1250 },
+  { key: "master",     name: "達人",   minElo: 1400 },
+  { key: "legend",     name: "傳說",   minElo: 1550 },
+];
+
+function getTiers() {
+  try {
+    const tiers = config.get("minigame.janken.elo.tiers");
+    if (Array.isArray(tiers) && tiers.length > 0) return tiers;
+  } catch (_) { /* config miss → fallback */ }
+  return FALLBACK_TIERS;
+}
+
+exports.RANK_TIERS = FALLBACK_TIERS; // back-compat for any external import
+```
+
+Then change every read of the module-level `RANK_TIERS` constant to call `getTiers()` instead. Specifically:
+
+```js
+exports.getRankTier = function (elo) {
+  const tiers = getTiers();
+  for (let i = tiers.length - 1; i >= 0; i--) {
+    if (elo >= tiers[i].minElo) return tiers[i].key;
+  }
+  return "beginner";
+};
+
+exports.getRankInfo = function (elo) {
+  const tiers = getTiers();
+  for (let i = tiers.length - 1; i >= 0; i--) {
+    if (elo >= tiers[i].minElo) return tiers[i];
+  }
+  return tiers[0];
+};
+
+exports.getNextTierElo = function (elo) {
+  const tiers = getTiers();
+  const currentKey = exports.getRankTier(elo);
+  const idx = tiers.findIndex(t => t.key === currentKey);
+  if (idx >= tiers.length - 1) return null;
+  return tiers[idx + 1].minElo;
+};
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+Run: `cd app && yarn test JankenRating.test.js`
+Expected: PASS, 5/5.
+
+- [ ] **Step 5: Run full app tests, none regress**
+
+Run: `cd app && yarn test`
+Expected: full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/model/application/JankenRating.js app/src/model/application/__tests__/JankenRating.test.js
+git commit -m "refactor(janken): JankenRating tiers read from config with fallback"
+```
+
+### Task 2.3: `JankenService` reads `lossFactor` and `nonBetK` from config
+
+**Files:**
+- Modify: `app/src/service/JankenService.js`
+- Test: `app/src/service/__tests__/JankenService.elo.test.js` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `app/src/service/__tests__/JankenService.elo.test.js`:
+
+```js
+jest.mock("config", () => {
+  const data = {
+    "minigame.janken.elo.kFactorTiers": [
+      { minBet: 50000, k: 80 },
+      { minBet:  5000, k: 60 },
+      { minBet:  1000, k: 32 },
+      { minBet:   100, k: 20 },
+      { minBet:     0, k: 12 },
+    ],
+    "minigame.janken.elo.lossFactor": 0.5,
+    "minigame.janken.elo.nonBetK": 0,
+    "minigame.janken.elo.streakBonus": [
+      { minStreak: 7, multiplier: 2.0 },
+      { minStreak: 5, multiplier: 1.5 },
+      { minStreak: 3, multiplier: 1.25 },
+    ],
+    "minigame.janken.elo.initial": 1000,
+    "minigame.janken.elo.tiers": [
+      { key: "beginner", name: "見習者", minElo: 0 },
+    ],
+    "minigame.janken.bet.feeRate": 0.1,
+    "minigame.janken.bet.minAmount": 10,
+    "minigame.janken.streak.bountyMinBet": 1000,
+    "minigame.janken.streak.bountyClaimMultiplier": 5,
+    "redis.keys.jankenDecide": "jankenDecide",
+    "redis.keys.jankenChallenge": "jankenChallenge",
+  };
+  return { get: jest.fn(key => data[key]) };
+});
+
+const JankenService = require("../JankenService");
+
+describe("JankenService.calculateEloChange (rebalanced K table)", () => {
+  test("avg bet of 289 lands in K=20 tier (was K=8)", () => {
+    const change = JankenService.calculateEloChange(1000, 1000, "win", 289);
+    // K=20, expected=0.5, raw = 20 * 0.5 = 10; multiplier 1 (streak 0) → floor(10) = 10
+    expect(change).toBe(10);
+  });
+
+  test("loss at K=20 even matchup applies lossFactor 0.5", () => {
+    const change = JankenService.calculateEloChange(1000, 1000, "lose", 289);
+    // raw = 20 * (0 - 0.5) = -10; lossFactor 0.5 → ceil(-10 * 0.5) = -5
+    expect(change).toBe(-5);
+  });
+
+  test("non-bet match returns 0 when nonBetK=0", () => {
+    expect(JankenService.calculateEloChange(1000, 1000, "win", 0)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `cd app && yarn test JankenService.elo.test.js`
+Expected: FAIL — current `calculateEloChange` accepts `betAmount` but `updateElo` early-returns for `betAmount<=0`. The first two tests should already pass on rebalanced config; the third test passes only after we route nonBetK through.
+
+(In practice tests 1+2 pass once Task 2.1 ships — they're regression guards. Only test 3 needs new code.)
+
+- [ ] **Step 3: Update `calculateEloChange` to support `nonBetK`**
+
+In `app/src/service/JankenService.js`, replace `calculateEloChange`:
+
+```js
+exports.calculateEloChange = function (myElo, opponentElo, result, betAmount, { streak = 0 } = {}) {
+  if (result === "draw") return 0;
+  let K;
+  if (!betAmount || betAmount <= 0) {
+    const nonBetK = config.get("minigame.janken.elo.nonBetK");
+    if (!nonBetK || nonBetK <= 0) return 0;
+    K = nonBetK;
+  } else {
+    K = JankenRating.getKFactor(betAmount);
+  }
+  const expected = exports.calculateExpectedWinRate(myElo, opponentElo);
+  const actual = result === "win" ? 1 : 0;
+  const raw = K * (actual - expected);
+  if (raw >= 0) {
+    const multiplier = result === "win" ? exports.getStreakMultiplier(streak) : 1;
+    return Math.floor(raw * multiplier);
+  }
+  const lossFactor = config.get("minigame.janken.elo.lossFactor");
+  return Math.ceil(raw * lossFactor);
+};
+```
+
+Also update `updateElo` to NOT early-return on `betAmount<=0` when `nonBetK > 0`:
+
+```js
+exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
+  if (p1Result === "draw") {
+    // ... unchanged draw branch
+  }
+
+  const nonBetK = config.get("minigame.janken.elo.nonBetK");
+  if ((!betAmount || betAmount <= 0) && (!nonBetK || nonBetK <= 0)) {
+    return { p1EloChange: 0, p2EloChange: 0, p1NewElo: null, p2NewElo: null };
+  }
+  // ... rest unchanged (keep the draw branch's existing draw_count increment for bet only)
+};
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `cd app && yarn test JankenService.elo.test.js`
+Expected: PASS, 3/3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/service/JankenService.js app/src/service/__tests__/JankenService.elo.test.js
+git commit -m "feat(janken): nonBetK config knob (default 0) + ELO rebalance regression test"
+```
+
+**Exit Criteria for M2:**
+- `default.json` has new structure, JSON parses, `config.get('minigame.janken.elo.tiers')` returns 5 elements.
+- `JankenRating.getRankTier(1250) === 'fighter'`.
+- `JankenService.calculateEloChange(1000, 1000, 'win', 289) === 10`.
+- `yarn test:app` green.
+
+---
+
+## M3. Models
+
+**Goal:** Three new models present, with passing CRUD tests; `JankenRating` gains transactional helpers.
+
+### Task 3.1: `JankenSeason` model
+
+**Files:**
+- Create: `app/src/model/application/JankenSeason.js`
+- Test: `app/src/model/application/__tests__/JankenSeason.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const mysql = require("../../../util/mysql");
+const JankenSeason = require("../JankenSeason");
+
+describe("JankenSeason", () => {
+  beforeEach(async () => {
+    await mysql("janken_seasons").delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  test("getActive returns the row with status='active'", async () => {
+    await mysql("janken_seasons").insert([
+      { id: 1, started_at: new Date(), status: "closed", ended_at: new Date() },
+      { id: 2, started_at: new Date(), status: "active" },
+    ]);
+    const active = await JankenSeason.getActive();
+    expect(active.id).toBe(2);
+  });
+
+  test("close sets status=closed and ended_at", async () => {
+    await mysql("janken_seasons").insert({ id: 3, started_at: new Date(), status: "active" });
+    await JankenSeason.close(3);
+    const row = await mysql("janken_seasons").where({ id: 3 }).first();
+    expect(row.status).toBe("closed");
+    expect(row.ended_at).not.toBeNull();
+  });
+
+  test("openNew creates a new active season", async () => {
+    const id = await JankenSeason.openNew("test note");
+    const row = await mysql("janken_seasons").where({ id }).first();
+    expect(row.status).toBe("active");
+    expect(row.notes).toBe("test note");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`Cannot find module ../JankenSeason`).
+
+Run: `cd app && yarn test JankenSeason.test.js`
+
+- [ ] **Step 3: Implement model**
+
+```js
+const mysql = require("../../util/mysql");
+const TABLE = "janken_seasons";
+
+exports.getActive = async function (trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ status: "active" }).first();
+};
+
+exports.close = async function (id, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ id }).update({ status: "closed", ended_at: new Date() });
+};
+
+exports.openNew = async function (notes, trx) {
+  const db = trx || mysql;
+  const [id] = await db(TABLE).insert({
+    started_at: new Date(),
+    status: "active",
+    notes: notes || null,
+  });
+  return id;
+};
+
+exports.findById = async function (id, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ id }).first();
+};
+
+exports.list = async function (limit = 50, trx) {
+  const db = trx || mysql;
+  return db(TABLE).orderBy("id", "desc").limit(limit);
+};
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `cd app && yarn test JankenSeason.test.js`
+Expected: 3/3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/model/application/JankenSeason.js app/src/model/application/__tests__/JankenSeason.test.js
+git commit -m "feat(janken): JankenSeason model"
+```
+
+### Task 3.2: `JankenSeasonSnapshot` model
+
+**Files:**
+- Create: `app/src/model/application/JankenSeasonSnapshot.js`
+- Test: `app/src/model/application/__tests__/JankenSeasonSnapshot.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const mysql = require("../../../util/mysql");
+const JankenSeasonSnapshot = require("../JankenSeasonSnapshot");
+
+describe("JankenSeasonSnapshot", () => {
+  beforeEach(async () => {
+    await mysql("janken_season_snapshot").delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  test("bulkInsert + getBySeason round-trips", async () => {
+    await JankenSeasonSnapshot.bulkInsert(7, [
+      { rank: 1, user_id: "U1", display_name: "A", elo: 1500, rank_tier: "master",
+        win_count: 30, lose_count: 10, draw_count: 5, max_streak: 6 },
+      { rank: 2, user_id: "U2", display_name: "B", elo: 1300, rank_tier: "fighter",
+        win_count: 20, lose_count: 15, draw_count: 3, max_streak: 4 },
+    ]);
+    const rows = await JankenSeasonSnapshot.getBySeason(7);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].rank).toBe(1);
+    expect(rows[0].elo).toBe(1500);
+  });
+
+  test("bulkInsert with empty array is a no-op", async () => {
+    await expect(JankenSeasonSnapshot.bulkInsert(8, [])).resolves.toBeUndefined();
+    const rows = await JankenSeasonSnapshot.getBySeason(8);
+    expect(rows).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**.
+
+- [ ] **Step 3: Implement**
+
+```js
+const mysql = require("../../util/mysql");
+const TABLE = "janken_season_snapshot";
+
+exports.bulkInsert = async function (seasonId, rows, trx) {
+  if (!rows || rows.length === 0) return undefined;
+  const db = trx || mysql;
+  const data = rows.map(r => ({
+    season_id: seasonId,
+    rank: r.rank,
+    user_id: r.user_id,
+    display_name: r.display_name || null,
+    elo: r.elo,
+    rank_tier: r.rank_tier,
+    win_count: r.win_count || 0,
+    lose_count: r.lose_count || 0,
+    draw_count: r.draw_count || 0,
+    max_streak: r.max_streak || 0,
+  }));
+  await db(TABLE).insert(data);
+  return undefined;
+};
+
+exports.getBySeason = async function (seasonId, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ season_id: seasonId }).orderBy("rank", "asc");
+};
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `cd app && yarn test JankenSeasonSnapshot.test.js`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/model/application/JankenSeasonSnapshot.js app/src/model/application/__tests__/JankenSeasonSnapshot.test.js
+git commit -m "feat(janken): JankenSeasonSnapshot model with bulk insert"
+```
+
+### Task 3.3: `JankenDailyRewardLog` model
+
+**Files:**
+- Create: `app/src/model/application/JankenDailyRewardLog.js`
+- Test: `app/src/model/application/__tests__/JankenDailyRewardLog.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const mysql = require("../../../util/mysql");
+const JankenDailyRewardLog = require("../JankenDailyRewardLog");
+
+describe("JankenDailyRewardLog", () => {
+  beforeEach(async () => {
+    await mysql("janken_daily_reward_log").delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  test("tryInsert returns true on first insert, false on duplicate same-day", async () => {
+    const args = { user_id: "U1", reward_date: "2026-05-01", season_id: 1, reward_type: "top1", amount: 500 };
+    expect(await JankenDailyRewardLog.tryInsert(args)).toBe(true);
+    expect(await JankenDailyRewardLog.tryInsert(args)).toBe(false);
+    const count = await mysql("janken_daily_reward_log").count({ c: "*" }).first();
+    expect(count.c).toBe(1);
+  });
+
+  test("getByUserAndDate returns the row when present", async () => {
+    await JankenDailyRewardLog.tryInsert({
+      user_id: "U2", reward_date: "2026-05-02", season_id: 1, reward_type: "challenger", amount: 10,
+    });
+    const row = await JankenDailyRewardLog.getByUserAndDate("U2", "2026-05-02");
+    expect(row.amount).toBe(10);
+    expect(row.reward_type).toBe("challenger");
+  });
+
+  test("getByUserAndDate returns undefined when missing", async () => {
+    const row = await JankenDailyRewardLog.getByUserAndDate("U999", "2026-05-02");
+    expect(row).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**.
+
+- [ ] **Step 3: Implement**
+
+```js
+const mysql = require("../../util/mysql");
+const TABLE = "janken_daily_reward_log";
+
+exports.tryInsert = async function ({ user_id, reward_date, season_id, reward_type, amount }, trx) {
+  const db = trx || mysql;
+  try {
+    await db(TABLE).insert({ user_id, reward_date, season_id, reward_type, amount });
+    return true;
+  } catch (err) {
+    if (err && err.code === "ER_DUP_ENTRY") return false;
+    throw err;
+  }
+};
+
+exports.getByUserAndDate = async function (user_id, reward_date, trx) {
+  const db = trx || mysql;
+  return db(TABLE).where({ user_id, reward_date }).first();
+};
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `cd app && yarn test JankenDailyRewardLog.test.js`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/model/application/JankenDailyRewardLog.js app/src/model/application/__tests__/JankenDailyRewardLog.test.js
+git commit -m "feat(janken): JankenDailyRewardLog model with dup-key idempotency"
+```
+
+### Task 3.4: `JankenRating.getTopByElo` and `resetSeasonFields`
+
+**Files:**
+- Modify: `app/src/model/application/JankenRating.js`
+- Modify: `app/src/model/application/__tests__/JankenRating.test.js`
+
+- [ ] **Step 1: Add tests for the two new methods**
+
+Append to `JankenRating.test.js`:
+
+```js
+describe("JankenRating.getTopByElo", () => {
+  beforeEach(async () => {
+    await mysql("janken_rating").delete();
+    await mysql("janken_rating").insert([
+      { user_id: "U_A", elo: 1500, rank_tier: "master", win_count: 10 },
+      { user_id: "U_B", elo: 1100, rank_tier: "challenger", win_count: 5 },
+      { user_id: "U_C", elo: 1700, rank_tier: "legend", win_count: 20 },
+    ]);
+  });
+  afterAll(() => mysql.destroy());
+
+  test("returns rows ordered by elo desc", async () => {
+    const rows = await JankenRating.getTopByElo(2);
+    expect(rows[0].user_id).toBe("U_C");
+    expect(rows[1].user_id).toBe("U_A");
+  });
+});
+
+describe("JankenRating.resetSeasonFields", () => {
+  beforeEach(async () => {
+    await mysql("janken_rating").delete();
+    await mysql("janken_rating").insert([
+      { user_id: "U_X", elo: 1500, rank_tier: "master", win_count: 30, lose_count: 10,
+        draw_count: 5, streak: 4, max_streak: 9, bounty: 100,
+        lifetime_win_count: 0, lifetime_lose_count: 0, lifetime_draw_count: 0 },
+    ]);
+  });
+
+  test("rotates per-season fields into lifetime, zeros bounty/streak, leaves max_streak", async () => {
+    await JankenRating.resetSeasonFields();
+    const row = await mysql("janken_rating").where({ user_id: "U_X" }).first();
+    expect(row.elo).toBe(1000);
+    expect(row.rank_tier).toBe("beginner");
+    expect(row.win_count).toBe(0);
+    expect(row.lose_count).toBe(0);
+    expect(row.draw_count).toBe(0);
+    expect(row.streak).toBe(0);
+    expect(row.bounty).toBe(0);
+    expect(row.max_streak).toBe(9);
+    expect(row.lifetime_win_count).toBe(30);
+    expect(row.lifetime_lose_count).toBe(10);
+    expect(row.lifetime_draw_count).toBe(5);
+  });
+});
+```
+
+(Add `const mysql = require("../../../util/mysql");` near the top if not present.)
+
+- [ ] **Step 2: Run, expect FAIL**.
+
+- [ ] **Step 3: Implement both methods**
+
+In `JankenRating.js`:
+
+```js
+exports.getTopByElo = async function (limit = 50, trx) {
+  const db = trx || mysql;
+  return db(TABLE).orderBy("elo", "desc").orderBy("win_count", "desc").limit(limit);
+};
+
+exports.resetSeasonFields = async function (trx) {
+  const db = trx || mysql;
+  return db(TABLE).update({
+    lifetime_win_count: db.raw("lifetime_win_count + win_count"),
+    lifetime_lose_count: db.raw("lifetime_lose_count + lose_count"),
+    lifetime_draw_count: db.raw("lifetime_draw_count + draw_count"),
+    elo: 1000,
+    rank_tier: "beginner",
+    win_count: 0,
+    lose_count: 0,
+    draw_count: 0,
+    streak: 0,
+    bounty: 0,
+  });
+};
+```
+
+- [ ] **Step 4: Run, expect PASS**.
+
+Run: `cd app && yarn test JankenRating.test.js`
+
+- [ ] **Step 5: Update `fillable`**
+
+In `JankenRating.js`, extend the `fillable` array:
+
+```js
+const fillable = [
+  "user_id", "elo", "rank_tier",
+  "win_count", "lose_count", "draw_count",
+  "streak", "max_streak", "bounty",
+  "lifetime_win_count", "lifetime_lose_count", "lifetime_draw_count",
+];
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/model/application/JankenRating.js app/src/model/application/__tests__/JankenRating.test.js
+git commit -m "feat(janken): JankenRating.getTopByElo and resetSeasonFields"
+```
+
+**Exit Criteria for M3:**
+- All four model tests green.
+- Reset method correctly rotates lifetime totals and zeros per-season fields.
+
+---
+
+## M4. Services
+
+**Goal:** `JankenSeasonService.endCurrentAndOpenNext` performs a full atomic season transition. `JankenRewardService` exposes `payoutDaily` (cron) and `payoutSeasonEnd` (gated stub) with the kill-switch behavior.
+
+### Task 4.1: `JankenSeasonService.endCurrentAndOpenNext`
+
+**Files:**
+- Create: `app/src/service/JankenSeasonService.js`
+- Test: `app/src/service/__tests__/JankenSeasonService.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const mysql = require("../../util/mysql");
+const JankenSeasonService = require("../JankenSeasonService");
+
+describe("JankenSeasonService.endCurrentAndOpenNext", () => {
+  beforeEach(async () => {
+    await mysql("janken_season_snapshot").delete();
+    await mysql("janken_seasons").delete();
+    await mysql("janken_rating").delete();
+    await mysql("janken_seasons").insert({
+      id: 1, started_at: new Date(), status: "active", notes: "season 1",
+    });
+    await mysql("janken_rating").insert([
+      { user_id: "U1", elo: 1700, rank_tier: "legend",   win_count: 50, lose_count: 10, draw_count: 5, streak: 3, max_streak: 8, bounty: 0 },
+      { user_id: "U2", elo: 1500, rank_tier: "master",   win_count: 30, lose_count: 12, draw_count: 4, streak: 0, max_streak: 6, bounty: 0 },
+      { user_id: "U3", elo: 1100, rank_tier: "challenger", win_count: 12, lose_count: 8, draw_count: 2, streak: 1, max_streak: 3, bounty: 0 },
+    ]);
+  });
+  afterAll(() => mysql.destroy());
+
+  test("snapshots top, resets, opens next season", async () => {
+    const result = await JankenSeasonService.endCurrentAndOpenNext({ note: "test reset", payoutEnabled: false });
+    expect(result.closedSeasonId).toBe(1);
+    expect(result.newSeasonId).toBeGreaterThan(1);
+    expect(result.snapshotCount).toBe(3);
+
+    const snapshots = await mysql("janken_season_snapshot").where({ season_id: 1 }).orderBy("rank");
+    expect(snapshots[0].user_id).toBe("U1");
+    expect(snapshots[0].rank).toBe(1);
+
+    const closed = await mysql("janken_seasons").where({ id: 1 }).first();
+    expect(closed.status).toBe("closed");
+    expect(closed.ended_at).not.toBeNull();
+
+    const newActive = await mysql("janken_seasons").where({ status: "active" }).first();
+    expect(newActive.id).toBe(result.newSeasonId);
+    expect(newActive.notes).toBe("test reset");
+
+    const u1 = await mysql("janken_rating").where({ user_id: "U1" }).first();
+    expect(u1.elo).toBe(1000);
+    expect(u1.rank_tier).toBe("beginner");
+    expect(u1.win_count).toBe(0);
+    expect(u1.lifetime_win_count).toBe(50);
+    expect(u1.max_streak).toBe(8);
+  });
+
+  test("aborts when no active season", async () => {
+    await mysql("janken_seasons").update({ status: "closed", ended_at: new Date() });
+    await expect(JankenSeasonService.endCurrentAndOpenNext({ note: "x", payoutEnabled: false }))
+      .rejects.toThrow(/no active season/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**.
+
+- [ ] **Step 3: Implement**
+
+```js
+const mysql = require("../util/mysql");
+const config = require("config");
+const JankenSeason = require("../model/application/JankenSeason");
+const JankenSeasonSnapshot = require("../model/application/JankenSeasonSnapshot");
+const JankenRating = require("../model/application/JankenRating");
+const JankenRewardService = require("./JankenRewardService");
+const { DefaultLogger } = require("../util/Logger");
+
+exports.endCurrentAndOpenNext = async function ({ note = null, payoutEnabled = false } = {}) {
+  const snapshotTopN = config.get("minigame.janken.season.snapshotTopN") || 50;
+  const enableSeasonEndRewards =
+    payoutEnabled && Boolean(config.get("minigame.janken.season.enableSeasonEndRewards"));
+
+  return mysql.transaction(async trx => {
+    const active = await JankenSeason.getActive(trx);
+    if (!active) throw new Error("Janken: no active season to close");
+
+    const top = await JankenRating.getTopByElo(snapshotTopN, trx);
+    const userIds = top.map(r => r.user_id);
+    const profiles = userIds.length
+      ? await trx("user").whereIn("platform_id", userIds).select("platform_id", "display_name")
+      : [];
+    const nameByUid = Object.fromEntries(profiles.map(p => [p.platform_id, p.display_name]));
+
+    const snapshotRows = top.map((r, i) => ({
+      rank: i + 1,
+      user_id: r.user_id,
+      display_name: nameByUid[r.user_id] || null,
+      elo: r.elo,
+      rank_tier: r.rank_tier,
+      win_count: r.win_count,
+      lose_count: r.lose_count,
+      draw_count: r.draw_count,
+      max_streak: r.max_streak,
+    }));
+    await JankenSeasonSnapshot.bulkInsert(active.id, snapshotRows, trx);
+
+    if (enableSeasonEndRewards) {
+      await JankenRewardService.payoutSeasonEnd(snapshotRows, active.id, trx);
+    } else {
+      DefaultLogger.info(
+        `[JankenSeasonService] season-end rewards skipped (payoutEnabled=${payoutEnabled}, flag=${config.get(
+          "minigame.janken.season.enableSeasonEndRewards"
+        )})`
+      );
+    }
+
+    await JankenSeason.close(active.id, trx);
+    await JankenRating.resetSeasonFields(trx);
+    const newSeasonId = await JankenSeason.openNew(note, trx);
+
+    DefaultLogger.info(
+      `[JankenSeasonService] season ${active.id} closed, ${snapshotRows.length} snapshotted, season ${newSeasonId} opened`
+    );
+
+    return {
+      closedSeasonId: active.id,
+      newSeasonId,
+      snapshotCount: snapshotRows.length,
+      payoutEnabled: enableSeasonEndRewards,
+    };
+  });
+};
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `cd app && yarn test JankenSeasonService.test.js`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/service/JankenSeasonService.js app/src/service/__tests__/JankenSeasonService.test.js
+git commit -m "feat(janken): JankenSeasonService.endCurrentAndOpenNext"
+```
+
+### Task 4.2: `JankenRewardService.payoutDaily`
+
+**Files:**
+- Create: `app/src/service/JankenRewardService.js`
+- Test: `app/src/service/__tests__/JankenRewardService.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const mysql = require("../../util/mysql");
+const JankenRewardService = require("../JankenRewardService");
+
+describe("JankenRewardService.payoutDaily", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      mysql("janken_daily_reward_log").delete(),
+      mysql("janken_records").delete(),
+      mysql("janken_rating").delete(),
+      mysql("Inventory").where({ note: "janken_daily_rank_reward" }).delete(),
+      mysql("janken_seasons").delete(),
+    ]);
+    await mysql("janken_seasons").insert({ id: 1, started_at: new Date(), status: "active" });
+  });
+  afterAll(() => mysql.destroy());
+
+  test("dry-run when flag is false: no inventory, no log rows", async () => {
+    // flag is false in default.json — confirm shadow mode
+    await mysql("janken_rating").insert({ user_id: "U_T", elo: 1100, rank_tier: "challenger" });
+    await mysql("janken_records").insert({
+      id: "rec-1", user_id: "U_T", target_user_id: "U_O", group_id: "G", bet_amount: 100,
+      created_at: yesterdayLocal(),
+    });
+    const result = await JankenRewardService.payoutDaily(yesterdayDateString());
+    expect(result.dryRun).toBe(true);
+    expect(result.candidates).toHaveLength(1);
+    const stones = await mysql("Inventory").where({ note: "janken_daily_rank_reward" });
+    expect(stones).toHaveLength(0);
+    const logs = await mysql("janken_daily_reward_log");
+    expect(logs).toHaveLength(0);
+  });
+});
+
+function yesterdayLocal() {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+function yesterdayDateString() {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL**.
+
+- [ ] **Step 3: Implement**
+
+```js
+const mysql = require("../util/mysql");
+const config = require("config");
+const JankenSeason = require("../model/application/JankenSeason");
+const JankenRating = require("../model/application/JankenRating");
+const JankenDailyRewardLog = require("../model/application/JankenDailyRewardLog");
+const { inventory } = require("../model/application/Inventory");
+const { DefaultLogger } = require("../util/Logger");
+
+function bucketByPosition(p, rankTier) {
+  if (p === 1) return "top1";
+  if (p === 2) return "top2";
+  if (p === 3) return "top3";
+  if (p <= 10) return "top4_10";
+  if (rankTier === "legend") return "legend";
+  if (rankTier === "master") return "master";
+  if (rankTier === "fighter") return "fighter";
+  if (rankTier === "challenger") return "challenger";
+  return "beginner";
+}
+exports.bucketByPosition = bucketByPosition;
+
+exports.payoutDaily = async function (rewardDate) {
+  const enabled = Boolean(config.get("minigame.janken.daily_reward.enableDailyRankReward"));
+  const amounts = config.get("minigame.janken.daily_reward.amounts") || {};
+  const season = await JankenSeason.getActive();
+  if (!season) {
+    DefaultLogger.warn("[JankenRewardService] no active season; skipping daily payout");
+    return { dryRun: !enabled, candidates: [], season: null };
+  }
+
+  const start = new Date(`${rewardDate}T00:00:00+08:00`);
+  const end = new Date(`${rewardDate}T23:59:59.999+08:00`);
+  const initiators = mysql("janken_records")
+    .distinct({ u: "user_id" })
+    .where("bet_amount", ">", 0)
+    .whereBetween("created_at", [start, end]);
+  const targets = mysql("janken_records")
+    .distinct({ u: "target_user_id" })
+    .where("bet_amount", ">", 0)
+    .whereBetween("created_at", [start, end]);
+  const activeRows = await initiators.union([targets]);
+  const activeIds = activeRows.map(r => r.u);
+  if (activeIds.length === 0) {
+    DefaultLogger.info(`[JankenRewardService] no active players for ${rewardDate}`);
+    return { dryRun: !enabled, candidates: [], season: season.id };
+  }
+
+  const ranked = await mysql("janken_rating")
+    .whereIn("user_id", activeIds)
+    .orderBy("elo", "desc")
+    .orderBy("win_count", "desc");
+
+  const candidates = ranked.map((r, i) => ({
+    user_id: r.user_id,
+    position: i + 1,
+    rank_tier: r.rank_tier,
+    reward_type: bucketByPosition(i + 1, r.rank_tier),
+  })).map(c => ({ ...c, amount: amounts[c.reward_type] || 0 }));
+
+  if (!enabled) {
+    DefaultLogger.info(
+      `[JankenRewardService] DRY RUN ${rewardDate} season=${season.id} candidates=${candidates.length}`
+    );
+    return { dryRun: true, candidates, season: season.id };
+  }
+
+  let credited = 0;
+  for (const c of candidates) {
+    const inserted = await JankenDailyRewardLog.tryInsert({
+      user_id: c.user_id,
+      reward_date: rewardDate,
+      season_id: season.id,
+      reward_type: c.reward_type,
+      amount: c.amount,
+    });
+    if (inserted && c.amount > 0) {
+      await inventory.increaseGodStone({
+        userId: c.user_id, amount: c.amount, note: "janken_daily_rank_reward",
+      });
+      credited += c.amount;
+    }
+  }
+
+  DefaultLogger.info(
+    `[JankenRewardService] paid ${rewardDate} season=${season.id} credited=${credited} stones to ${candidates.length} players`
+  );
+  return { dryRun: false, candidates, season: season.id, credited };
+};
+
+exports.payoutSeasonEnd = async function (snapshotRows, seasonId, trx) {
+  const enabled = Boolean(config.get("minigame.janken.season.enableSeasonEndRewards"));
+  if (!enabled) {
+    DefaultLogger.info(`[JankenRewardService] season-end payout skipped (flag off)`);
+    return { dryRun: true, paid: 0 };
+  }
+  const rewards = config.get("minigame.janken.season.endRewards") || {};
+  let paid = 0;
+  for (const row of snapshotRows) {
+    let bucket = null;
+    if (row.rank === 1) bucket = "top1";
+    else if (row.rank === 2) bucket = "top2";
+    else if (row.rank === 3) bucket = "top3";
+    else if (row.rank <= 10) bucket = "top4_10";
+    else if (row.rank <= 50) bucket = "top11_50";
+    if (!bucket) continue;
+    const amount = rewards[bucket] || 0;
+    if (amount <= 0) continue;
+    if (trx) inventory.setTransaction(trx);
+    await inventory.increaseGodStone({
+      userId: row.user_id, amount, note: "janken_season_end_reward",
+    });
+    paid += amount;
+  }
+  return { dryRun: false, paid };
+};
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `cd app && yarn test JankenRewardService.test.js`
+
+- [ ] **Step 5: Add a "flag-on" payout test**
+
+Append to `JankenRewardService.test.js` a test that mocks `config.get("minigame.janken.daily_reward.enableDailyRankReward")` → `true` and asserts the inventory + log row appear:
+
+```js
+test("flag-on: inserts log row + credits inventory", async () => {
+  jest.resetModules();
+  jest.doMock("config", () => {
+    const orig = jest.requireActual("config");
+    return {
+      get: jest.fn(key => {
+        if (key === "minigame.janken.daily_reward.enableDailyRankReward") return true;
+        return orig.get(key);
+      }),
+    };
+  });
+  const Service = require("../JankenRewardService");
+  const date = yesterdayDateString();
+  await mysql("janken_rating").insert({ user_id: "U_FlagOn", elo: 1700, rank_tier: "legend" });
+  await mysql("janken_records").insert({
+    id: "rec-flag", user_id: "U_FlagOn", target_user_id: "U_O", group_id: "G",
+    bet_amount: 500, created_at: yesterdayLocal(),
+  });
+  const result = await Service.payoutDaily(date);
+  expect(result.dryRun).toBe(false);
+  const log = await mysql("janken_daily_reward_log").where({ user_id: "U_FlagOn" }).first();
+  expect(log.amount).toBe(500); // top1
+  const stones = await mysql("Inventory").where({ note: "janken_daily_rank_reward", userId: "U_FlagOn" }).first();
+  expect(Number(stones.itemAmount)).toBe(500);
+});
+```
+
+> Per `feedback_jest_mock_hoisting`: place `jest.doMock` BEFORE the `require()`; `jest.resetModules()` invalidates the existing cached `JankenRewardService`.
+
+- [ ] **Step 6: Run, expect PASS**.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/service/JankenRewardService.js app/src/service/__tests__/JankenRewardService.test.js
+git commit -m "feat(janken): JankenRewardService.payoutDaily + payoutSeasonEnd (kill-switched)"
+```
+
+**Exit Criteria for M4:**
+- Both service test files green.
+- Service correctly observes both kill-switches.
+
+---
+
+## M5. CLI + Cron
+
+**Goal:** `JankenSeasonEnd.js` runnable from `node`. Daily reward cron registered and idempotent on re-run.
+
+### Task 5.1: `app/bin/JankenSeasonEnd.js`
+
+**Files:**
+- Create: `app/bin/JankenSeasonEnd.js`
+- Test: `app/bin/__tests__/JankenSeasonEnd.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const SeasonEnd = require("../JankenSeasonEnd");
+
+describe("JankenSeasonEnd CLI", () => {
+  test("parseArgv parses --note and --enable-rewards", () => {
+    const args = SeasonEnd.parseArgv(["--note", "foo bar", "--enable-rewards"]);
+    expect(args.note).toBe("foo bar");
+    expect(args.enableRewards).toBe(true);
+  });
+  test("parseArgv defaults: note null, enableRewards false", () => {
+    expect(SeasonEnd.parseArgv([])).toEqual({ note: null, enableRewards: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**.
+
+- [ ] **Step 3: Implement**
+
+```js
+const JankenSeasonService = require("../src/service/JankenSeasonService");
+const { DefaultLogger } = require("../src/util/Logger");
+
+function parseArgv(argv) {
+  const out = { note: null, enableRewards: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--enable-rewards") out.enableRewards = true;
+    else if (a === "--note" && i + 1 < argv.length) {
+      out.note = argv[++i];
+    }
+  }
+  return out;
+}
+exports.parseArgv = parseArgv;
+
+async function main(argv = process.argv.slice(2)) {
+  const args = parseArgv(argv);
+  DefaultLogger.info(`[JankenSeasonEnd] starting: note=${args.note} enableRewards=${args.enableRewards}`);
+  const result = await JankenSeasonService.endCurrentAndOpenNext({
+    note: args.note,
+    payoutEnabled: args.enableRewards,
+  });
+  DefaultLogger.info(`[JankenSeasonEnd] done: ${JSON.stringify(result)}`);
+  return result;
+}
+exports.main = main;
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch(err => {
+      DefaultLogger.error("[JankenSeasonEnd] failed", err);
+      process.exit(1);
+    });
+}
+```
+
+- [ ] **Step 4: Run argv test, expect PASS**
+
+Run: `cd app && yarn test JankenSeasonEnd.test.js`
+
+- [ ] **Step 5: Smoke-run against the test DB**
+
+Run: `cd app && node bin/JankenSeasonEnd.js --note "smoke test"`
+Expected: prints "done: {...}" with snapshotCount, newSeasonId. Verify in MySQL:
+- `SELECT * FROM janken_seasons ORDER BY id DESC LIMIT 2;` → newest is active.
+- `SELECT COUNT(*) FROM janken_season_snapshot;` → expected snapshot rows for the just-closed season.
+- `SELECT user_id, elo, rank_tier FROM janken_rating LIMIT 5;` → all `elo=1000`.
+
+> CAUTION: This **mutates the local DB**. Use a clean local DB or restore from backup after testing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/bin/JankenSeasonEnd.js app/bin/__tests__/JankenSeasonEnd.test.js
+git commit -m "feat(janken): JankenSeasonEnd CLI (Node bin script)"
+```
+
+### Task 5.2: `app/bin/JankenDailyRewards.js` + cron registration
+
+**Files:**
+- Create: `app/bin/JankenDailyRewards.js`
+- Modify: `app/config/crontab.config.js`
+- Test: `app/bin/__tests__/JankenDailyRewards.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const DailyRewards = require("../JankenDailyRewards");
+
+describe("JankenDailyRewards CLI", () => {
+  test("computeRewardDate returns yesterday in YYYY-MM-DD (Asia/Taipei)", () => {
+    const now = new Date("2026-05-02T03:00:00+08:00");
+    expect(DailyRewards.computeRewardDate(now)).toBe("2026-05-01");
+  });
+  test("computeRewardDate around midnight TPE", () => {
+    const now = new Date("2026-05-02T00:10:00+08:00");
+    expect(DailyRewards.computeRewardDate(now)).toBe("2026-05-01");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**.
+
+- [ ] **Step 3: Implement**
+
+```js
+const JankenRewardService = require("../src/service/JankenRewardService");
+const { DefaultLogger } = require("../src/util/Logger");
+
+function computeRewardDate(now = new Date()) {
+  // Use Asia/Taipei calendar day; reward is for "yesterday in TPE"
+  const tpe = new Date(now.getTime() + (8 * 60 - now.getTimezoneOffset()) * 60 * 1000);
+  tpe.setUTCDate(tpe.getUTCDate() - 1);
+  return tpe.toISOString().slice(0, 10);
+}
+exports.computeRewardDate = computeRewardDate;
+
+async function main() {
+  const date = computeRewardDate();
+  DefaultLogger.info(`[JankenDailyRewards] running for ${date}`);
+  const result = await JankenRewardService.payoutDaily(date);
+  DefaultLogger.info(`[JankenDailyRewards] done: ${JSON.stringify(result)}`);
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch(err => {
+      DefaultLogger.error("[JankenDailyRewards] failed", err);
+      process.exit(1);
+    });
+}
+```
+
+- [ ] **Step 4: Run test, expect PASS**.
+
+- [ ] **Step 5: Register cron**
+
+Append to `app/config/crontab.config.js` array:
+
+```js
+{
+  name: "Janken Daily Rewards",
+  description: "credit daily women-stones to active janken players (kill-switched in config)",
+  period: ["0", "10", "0", "*", "*", "*"],
+  immediate: false,
+  require_path: "./bin/JankenDailyRewards",
+},
+```
+
+- [ ] **Step 6: Smoke-run cron locally**
+
+Run: `cd app && node bin/JankenDailyRewards.js`
+Expected: prints `done: {dryRun:true, candidates:[...], season: ...}` (because `enableDailyRankReward=false`). Verify `SELECT COUNT(*) FROM janken_daily_reward_log` is unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/bin/JankenDailyRewards.js app/bin/__tests__/JankenDailyRewards.test.js app/config/crontab.config.js
+git commit -m "feat(janken): JankenDailyRewards cron (00:10 TPE, dry-run by default)"
+```
+
+**Exit Criteria for M5:**
+- Both bin scripts executable, both tests green.
+- Cron entry visible in `crontab.config.js`.
+- Smoke run produces dry-run output without DB writes.
+
+---
+
+## M6. Controller / Template / API
+
+**Goal:** `/猜拳段位` rank card shows the season number, lifetime totals, and today's reward (if any). Three new HTTP routes serve seasons + today-reward to the frontend.
+
+### Task 6.1: Extend `queryRank` payload
+
+**Files:**
+- Modify: `app/src/controller/application/JankenController.js` (`queryRank` function)
+
+- [ ] **Step 1: Read the existing function** (already read in brainstorming — lines 32–68).
+
+- [ ] **Step 2: Add fetches for season + lifetime + today reward**
+
+Replace the body of `queryRank` to add:
+
+```js
+const JankenSeason = require("../../model/application/JankenSeason");
+const JankenDailyRewardLog = require("../../model/application/JankenDailyRewardLog");
+
+async function queryRank(context) {
+  const { userId } = context.event.source;
+  if (!userId) return;
+
+  const rating = await JankenRating.findOrCreate(userId);
+  const season = await JankenSeason.getActive();
+  // ... (existing rankLabel / rankImageKey / rankTier / etc. unchanged) ...
+
+  const today = new Date().toISOString().slice(0, 10);
+  const todayRewardRow = await JankenDailyRewardLog.getByUserAndDate(userId, today);
+  const todayReward = todayRewardRow ? { type: todayRewardRow.reward_type, amount: todayRewardRow.amount } : null;
+
+  const lifetime = {
+    win: rating.lifetime_win_count + rating.win_count,
+    lose: rating.lifetime_lose_count + rating.lose_count,
+    draw: rating.lifetime_draw_count + rating.draw_count,
+  };
+
+  const rankCard = jankenTemplate.generateRankCard({
+    // ... existing args ...
+    seasonId: season ? season.id : null,
+    seasonStartedAt: season ? season.started_at : null,
+    lifetime,
+    todayReward,
+  });
+  await context.replyFlex("猜拳段位", rankCard);
+}
+```
+
+- [ ] **Step 3: Smoke-test by replying to a fake event**
+
+Manual: in `yarn dev`, send `/猜拳段位` from a LINE group; verify the new lines render. Document in PR description.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/controller/application/JankenController.js
+git commit -m "feat(janken): rank card payload with season + lifetime + today reward"
+```
+
+### Task 6.2: Update `generateRankCard` template
+
+**Files:**
+- Modify: `app/src/templates/application/Janken.js#generateRankCard`
+
+- [ ] **Step 1: Add a "season + lifetime + today reward" block**
+
+Inside `generateRankCard`, accept the new `seasonId`, `seasonStartedAt`, `lifetime`, `todayReward` props and render an additional vertical box BEFORE the existing footer's separator. Keep the new block compact (3 rows max). Code:
+
+```js
+const seasonBlock = seasonId
+  ? {
+      type: "box",
+      layout: "horizontal",
+      contents: [
+        { type: "text", text: "賽季", color: HERO_SURFACE.textMuted, size: "xs", flex: 1 },
+        {
+          type: "text",
+          text: `第 ${seasonId} 賽季`,
+          color: HERO_SURFACE.text, size: "xs", align: "end", flex: 2,
+        },
+      ],
+    }
+  : null;
+
+const lifetimeBlock = lifetime
+  ? {
+      type: "box",
+      layout: "horizontal",
+      contents: [
+        { type: "text", text: "生涯戰績", color: HERO_SURFACE.textMuted, size: "xs", flex: 1 },
+        {
+          type: "text",
+          text: `${lifetime.win} 勝 / ${lifetime.lose} 敗 / ${lifetime.draw} 平`,
+          color: HERO_SURFACE.text, size: "xs", align: "end", flex: 2,
+        },
+      ],
+    }
+  : null;
+
+const todayRewardBlock = todayReward
+  ? {
+      type: "box",
+      layout: "horizontal",
+      contents: [
+        { type: "text", text: "今日獎勵", color: HERO_SURFACE.textMuted, size: "xs", flex: 1 },
+        {
+          type: "text",
+          text: `+${todayReward.amount} 女神石`,
+          color: HERO_SURFACE.textAccent, size: "xs", align: "end", flex: 2,
+        },
+      ],
+    }
+  : null;
+
+const newRows = [seasonBlock, lifetimeBlock, todayRewardBlock].filter(Boolean);
+```
+
+Insert these into `bodyContents` between the existing separator and the bounty/maxBet block (or as part of the same nested box).
+
+- [ ] **Step 2: Add a snapshot test for the template**
+
+Create `app/src/templates/application/__tests__/Janken.rankCard.test.js`:
+
+```js
+const tpl = require("../Janken");
+
+test("generateRankCard renders season block when seasonId provided", () => {
+  const card = tpl.generateRankCard({
+    rankLabel: "見習者 5", rankImageKey: "rank_beginner",
+    elo: 1000, winCount: 0, loseCount: 0, drawCount: 0, winRate: 0,
+    streak: 0, maxStreak: 0, bounty: 0, eloToNext: 100, serverRank: 1, maxBet: 50000,
+    baseUrl: "https://x", seasonId: 2, seasonStartedAt: new Date(),
+    lifetime: { win: 100, lose: 50, draw: 5 },
+    todayReward: { type: "top1", amount: 500 },
+  });
+  const rendered = JSON.stringify(card);
+  expect(rendered).toContain("第 2 賽季");
+  expect(rendered).toContain("100 勝 / 50 敗");
+  expect(rendered).toContain("+500 女神石");
+});
+
+test("generateRankCard hides season/lifetime/todayReward blocks when null", () => {
+  const card = tpl.generateRankCard({
+    rankLabel: "見習者 5", rankImageKey: "rank_beginner",
+    elo: 1000, winCount: 0, loseCount: 0, drawCount: 0, winRate: 0,
+    streak: 0, maxStreak: 0, bounty: 0, eloToNext: 100, serverRank: 1, maxBet: 50000,
+    baseUrl: "https://x",
+  });
+  const rendered = JSON.stringify(card);
+  expect(rendered).not.toContain("賽季");
+  expect(rendered).not.toContain("生涯戰績");
+});
+```
+
+- [ ] **Step 3: Run, expect PASS**.
+
+Run: `cd app && yarn test Janken.rankCard.test.js`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/templates/application/Janken.js app/src/templates/application/__tests__/Janken.rankCard.test.js
+git commit -m "feat(janken): rank card shows season + lifetime + today reward"
+```
+
+### Task 6.3: New API routes
+
+**Files:**
+- Modify: `app/src/controller/application/JankenController.js` (add `api.seasons`, `api.seasonTop`, `api.todayReward`)
+- Modify: `app/src/router/api.js` (register routes)
+
+- [ ] **Step 1: Implement handlers**
+
+Append to `JankenController.js`:
+
+```js
+const JankenSeason = require("../../model/application/JankenSeason");
+const JankenSeasonSnapshot = require("../../model/application/JankenSeasonSnapshot");
+
+exports.api.seasons = async (req, res) => {
+  try {
+    const seasons = await JankenSeason.list(50);
+    res.json(seasons);
+  } catch (err) {
+    console.error("[Janken Seasons API]", err);
+    res.status(500).json({ message: "Failed to fetch seasons" });
+  }
+};
+
+exports.api.seasonTop = async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!id) return res.status(400).json({ message: "Invalid season id" });
+    const rows = await JankenSeasonSnapshot.getBySeason(id);
+    res.json(rows);
+  } catch (err) {
+    console.error("[Janken Season Top API]", err);
+    res.status(500).json({ message: "Failed to fetch season top" });
+  }
+};
+
+exports.api.todayReward = async (req, res) => {
+  try {
+    const userId = req.query.userId;
+    if (!userId) return res.status(400).json({ message: "userId required" });
+    const today = new Date().toISOString().slice(0, 10);
+    const row = await JankenDailyRewardLog.getByUserAndDate(userId, today);
+    res.json(row || null);
+  } catch (err) {
+    console.error("[Janken Today Reward API]", err);
+    res.status(500).json({ message: "Failed to fetch today reward" });
+  }
+};
+```
+
+- [ ] **Step 2: Register in `app/src/router/api.js`**
+
+Add three lines near the existing `/api/janken/*` block:
+
+```js
+router.get("/janken/seasons", JankenController.api.seasons);
+router.get("/janken/seasons/:id/top", JankenController.api.seasonTop);
+router.get("/janken/me/today-reward", JankenController.api.todayReward);
+```
+
+- [ ] **Step 3: Smoke-test the routes**
+
+Run: `cd app && yarn dev`, then `curl localhost:9527/api/janken/seasons` (no auth — these endpoints are LIFF-friendly via cookie / token from `validation.js`; if the existing `/api/janken/rankings` returns 200, these will too).
+
+- [ ] **Step 4: Update `/api/janken/rankings` payload**
+
+Modify `JankenController.api.rankings` to include `seasonId` (read once at top of handler):
+
+```js
+const season = await JankenSeason.getActive();
+res.json({ seasonId: season ? season.id : null, items: result });
+// (was: res.json(result))
+```
+
+- [ ] **Step 5: Update frontend service signature**
+
+Modify `frontend/src/services/janken.js`:
+
+```js
+import api from "./api";
+export const getRankings = () => api.get("/api/janken/rankings").then(r => r.data);
+export const getRecentMatches = () => api.get("/api/janken/recent-matches").then(r => r.data);
+export const getSeasons = () => api.get("/api/janken/seasons").then(r => r.data);
+export const getSeasonTop = id => api.get(`/api/janken/seasons/${id}/top`).then(r => r.data);
+export const getMyTodayReward = userId => api.get(`/api/janken/me/today-reward`, { params: { userId } }).then(r => r.data);
+```
+
+> Frontend `Janken/index.jsx` currently does `setRankings(data)`. Update to `setRankings(data.items || []); setSeasonId(data.seasonId)` in Task 7.1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/controller/application/JankenController.js app/src/router/api.js frontend/src/services/janken.js
+git commit -m "feat(janken): API endpoints for seasons, season top, today reward"
+```
+
+**Exit Criteria for M6:**
+- `/猜拳段位` rank card renders season + lifetime + today reward (where present).
+- 3 new endpoints respond, plus `/api/janken/rankings` carries `seasonId`.
+
+---
+
+## M7. Frontend
+
+**Goal:** Surface the current season number on the existing `/janken` page header. Other surfaces (per-season hall of fame, today-reward indicator on the rank list) are out of scope for this PR.
+
+### Task 7.1: Season chip on `/janken` page
+
+**Files:**
+- Modify: `frontend/src/pages/Janken/index.jsx`
+
+- [ ] **Step 1: Adjust state + fetch**
+
+In `frontend/src/pages/Janken/index.jsx`:
+
+```jsx
+const [seasonId, setSeasonId] = useState(null);
+// ... inside fetchRankings:
+const data = await getRankings();
+setRankings(data.items || []);
+setSeasonId(data.seasonId || null);
+```
+
+- [ ] **Step 2: Render chip in header**
+
+```jsx
+<Stack direction="row" spacing={1} sx={{ alignItems: "center", mb: 0.5 }}>
+  <Typography variant="h5" sx={{ fontWeight: 700 }}>
+    猜拳競技場
+  </Typography>
+  {seasonId != null && (
+    <Chip
+      label={`第 ${seasonId} 賽季`}
+      size="small"
+      color="primary"
+      variant="outlined"
+    />
+  )}
+</Stack>
+```
+
+(Add `Chip`, `Stack` to MUI imports.)
+
+- [ ] **Step 3: Smoke-test in browser**
+
+Run: `yarn dev` from repo root (boots both bot + frontend).
+Open `http://localhost:3000/janken` → verify the chip renders next to the title.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/Janken/index.jsx
+git commit -m "feat(janken): show current season chip on /janken page"
+```
+
+**Exit Criteria for M7:**
+- `/janken` page header shows "第 N 賽季" chip alongside the title.
+- Existing rankings + battle feed unaffected.
+
+---
+
+## M8. Manual QA + Final Lint
+
+**Goal:** End-to-end sanity check on local infra before opening the PR.
+
+### Task 8.1: Local end-to-end run
+
+- [ ] **Step 1: Reset local DB to a known state**
+
+Run: `make infra` (ensures MySQL up) and `cd app && yarn migrate` (idempotent).
+
+- [ ] **Step 2: Verify schema**
+
+Run from a mysql client:
+
+```sql
+DESCRIBE janken_seasons;
+DESCRIBE janken_season_snapshot;
+DESCRIBE janken_daily_reward_log;
+DESCRIBE janken_rating;  -- expect lifetime_* present
+SELECT * FROM janken_seasons;
+```
+
+Expected: 1 active season seeded.
+
+- [ ] **Step 3: Run season-end CLI dry**
+
+Run: `cd app && node bin/JankenSeasonEnd.js --note "QA dry run"`
+Verify: snapshot rows for season 1, ratings reset, season 2 active.
+
+- [ ] **Step 4: Run daily cron dry**
+
+Run: `cd app && node bin/JankenDailyRewards.js`
+Verify: prints `dryRun:true`, no rows in `janken_daily_reward_log`, no inventory deltas.
+
+- [ ] **Step 5: Lint**
+
+Run: `cd app && yarn lint && cd ../frontend && yarn lint`
+Expected: zero errors.
+
+- [ ] **Step 6: Full test suite**
+
+Run: `cd app && yarn test`
+Expected: green.
+
+- [ ] **Step 7: Commit any lint fixups**
+
+```bash
+git add -p   # only lint-related changes
+git commit -m "chore: lint fixups"
+```
+
+### Task 8.2: Open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/janken-season-rewards
+```
+
+- [ ] **Step 2: Open PR**
+
+Title: `feat(janken): season reset + daily rank rewards + ELO rebalance`
+
+Body checklist:
+- Spec: `docs/superpowers/specs/2026-05-01-janken-season-rewards-design.md`
+- Impl plan: `docs/superpowers/plans/2026-05-01-janken-season-rewards.md`
+- ✅ Migrations idempotent on production DB (lifetime_* default 0; first reset captures existing per-season totals).
+- ✅ Rewards default-OFF (`enableSeasonEndRewards: false`, `enableDailyRankReward: false`); cron runs in dry-run mode until Phase 2 anti-farming ships.
+- ✅ Tier thresholds, K-table, and bet/bounty caps rebalanced.
+- ⚠️ Production deploy needs `yarn migrate` then a (separate, ops-run) `node app/bin/JankenSeasonEnd.js --note "v2 啟動"` to actually reset ELO.
+
+**Exit Criteria for M8:**
+- All migrations applied, both bin scripts smoke-run successfully.
+- `yarn lint` + `yarn test` green.
+- PR opened, branch pushed.
+
+---
+
+## Out of Scope (deliberate)
+
+The spec calls these out as Phase 2 — they ship in a follow-up PR after this one merges:
+
+- Per-day, per-opponent ELO cap (Redis `janken:elo_pair:*`).
+- Daily ELO ceiling (`daily_elo_gain` columns + 50-elo cap).
+- Diversity gate for daily reward eligibility (≥3 unique opponents in 7d).
+- `JankenSuspectReport` weekly cron.
+- Frontend "歷代賽季" tab.
+- `nonBetK > 0` activation (will land alongside per-day per-opponent ELO cap to prevent farming).
+
+When Phase 2 lands, flip both kill-switches in `default.json` and run another `JankenSeasonEnd` to start the first "real" reward season.
+
+## Self-Review
+
+Done while writing this plan:
+
+- **Spec coverage**: every spec section maps to a milestone (§1 Schema → M1, §2 Reset Flow → M4 + M5, §3 Daily Reward → M4 + M5, §4 ELO → M2, §5 Config → M2, §6 Code → M3 + M4 + M6 + M7, §7 Phase 2 → Out of Scope, §8 Economic estimate → informational, §9 Testing → embedded in TDD steps, §10 Rollout → M8).
+- **Placeholder scan**: no TBD/TODO; every step has the actual code or command.
+- **Type/name consistency**:
+  - `endCurrentAndOpenNext({ note, payoutEnabled })` consistent across Task 4.1, 5.1.
+  - `payoutDaily(rewardDate)` consistent across 4.2, 5.2.
+  - `bucketByPosition(p, rankTier)` exported and used in 4.2, with same signature.
+  - `JankenSeason.getActive()` / `.close(id, trx)` / `.openNew(notes, trx)` consistent across 3.1, 4.1.
+- **Cron format**: 6-field array (verified in repo: `["0","10","0","*","*","*"]`).
+- **Mock hoisting**: jest.mock placement noted (matches repo's `transform: {}` constraint per `feedback_jest_mock_hoisting`).

--- a/docs/superpowers/specs/2026-05-01-janken-season-rewards-design.md
+++ b/docs/superpowers/specs/2026-05-01-janken-season-rewards-design.md
@@ -1,0 +1,414 @@
+# Janken Season Reset + Daily Rank Rewards + ELO Rebalance
+
+**Date:** 2026-05-01
+**Status:** Draft — pending implementation
+**Branch:** `feat/janken-season-rewards` (planned)
+
+## Context
+
+Janken (`/猜拳`、`/決鬥`、`/猜拳擂台`) currently has an ELO ladder with 5 tiers (見習者/挑戰者/強者/達人/傳說) and a streak/bounty subsystem. After several months of operation the live data shows three structural problems:
+
+| Problem | Evidence (live snapshot, 2026-05-01) |
+|---|---|
+| **No tier progression** — only 1 strong-tier player exists, 0 達人/傳說 | `janken_rating` distribution: 80 beginner / 11 challenger / 1 fighter / 0 master / 0 legend |
+| **Self-collusion exploits the ladder** | Top-1 player has 74 bet matches in 30d against only **2 unique opponents** (74W/82% win rate, 100 max streak). Several others show 1–2 unique opponents over double-digit bet matches. |
+| **No reset mechanism** — exploited ELO is permanent | Schema has no `season_id` concept; `janken_rating` is single-row-per-user, lifetime. |
+
+Activity floor is small: **11 DAU / 31 WAU / 51 MAU** (counting users who initiated or received a bet match in the window). Of 47,130 total matches, only 2,583 (5.5%) carry bets — non-bet matches do not move ELO.
+
+The user (chat owner) wants to (a) reset the ladder, (b) add a daily 女神石 reward to incentivise climbing the new ladder, and (c) loosen the ELO formula so honest play actually progresses through tiers within a reasonable time window.
+
+## Goals
+
+- Introduce a manually-triggered season system that snapshots top-50 standings, hard-resets per-season fields on `janken_rating`, and preserves a small set of lifetime fields.
+- Add a daily cron-driven women-stone reward keyed to today's active-player ranking + tier, with config-driven amounts and a kill switch.
+- Rebalance ELO thresholds and K-factor table so honest play (avg bet ≈289) progresses through tiers in O(weeks) rather than O(years).
+- Lift bet/bounty caps roughly 2× to support higher-tier high-stakes play.
+- Specify (without implementing) Phase 2 anti-farming rules so the season-end and daily-reward switches can be flipped on later.
+- Operate the season reset via a Node CLI script (not a LINE admin command) so it cannot be triggered by accident.
+
+## Non-Goals
+
+- LINE push messages. The system is reply-only. Daily rewards are deposited via `inventory.increaseGodStone()`; users see them on next `/猜拳段位` call (rank card adds a "今日獎勵" line) — no push.
+- Rebuilding the `janken_records`/`janken_result` schema. Records are kept lifetime; only the rating row's per-season fields rotate.
+- Touching the bot's ratelimit, postback, or auto-fate subsystems beyond what the new fields require.
+- Frontend redesign of `/janken`. New API endpoints are added; the existing page is updated minimally to surface the season number and current-season standings.
+- Anti-farming **enforcement** at launch. The first season-end runs with rewards disabled because exploits exist. Phase 2 adds enforcement; rewards switch on after.
+
+## Design
+
+### 1. Schema
+
+Three new tables and column additions to `janken_rating`. Migration files will be created via `yarn knex migrate:make`.
+
+#### 1.1 `janken_seasons`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int unsigned PK auto-inc | Reads as the season number ("第 N 賽季"). |
+| `started_at` | datetime | Set when the season opens. |
+| `ended_at` | datetime nullable | NULL while active; set when closed. |
+| `status` | enum(`active`,`closed`) | Exactly one row has `active` at any time (enforced by app logic, not DB constraint). |
+| `notes` | text nullable | Free-form admin note ("v1 啟動", "修復自刷後重啟"). |
+| `created_at`, `updated_at` | timestamps | Standard. |
+
+The CLI script that opens season N+1 wraps the close/open transition in a single MySQL transaction.
+
+#### 1.2 `janken_season_snapshot`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int unsigned PK auto-inc | |
+| `season_id` | int unsigned FK → `janken_seasons.id` | Indexed. |
+| `rank` | smallint unsigned | 1-based, ordered by ELO desc at snapshot time. |
+| `user_id` | varchar(33) | LINE user id. |
+| `display_name` | varchar(255) nullable | Captured at snapshot via `user.display_name`; OK if NULL when not seen. |
+| `elo` | int | |
+| `rank_tier` | varchar(20) | |
+| `win_count`, `lose_count`, `draw_count` | int | Per-season counters at snapshot. |
+| `max_streak` | int | Carried for hall-of-fame display. |
+| `created_at` | timestamp | |
+
+Index: `(season_id, rank)`. Snapshot captures top 50 of each season (configurable; default 50). The frontend can later page across season snapshots.
+
+#### 1.3 `janken_daily_reward_log`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int unsigned PK auto-inc | |
+| `user_id` | varchar(33) | |
+| `reward_date` | date | The date the reward is for (cron run date in Asia/Taipei). |
+| `season_id` | int unsigned | Snapshot of which season the reward came from. |
+| `reward_type` | varchar(20) | `top1` / `top2` / `top3` / `top4_10` / `legend` / `master` / `fighter` / `challenger` / `beginner`. |
+| `amount` | int | Women stones credited. |
+| `created_at` | timestamp | |
+
+Unique key: `(user_id, reward_date)`. Re-running the cron same day is a no-op (insert ignore). This table doubles as the source of truth for the rank-card "今日獎勵" line.
+
+#### 1.4 `janken_rating` column additions
+
+Migration adds three lifetime counters. Migration also resets nothing — existing data is preserved.
+
+| Column | Type | Default | Purpose |
+|---|---|---|---|
+| `lifetime_win_count` | int | 0 | Sum of all per-season `win_count` rotations + current season's `win_count` after first reset. |
+| `lifetime_lose_count` | int | 0 | Same. |
+| `lifetime_draw_count` | int | 0 | Same. |
+
+`max_streak` is preserved across seasons (not rotated). Other fields (`elo`, `rank_tier`, `win_count`, `lose_count`, `draw_count`, `streak`, `bounty`) are per-season and reset.
+
+### 2. Season Reset Flow (Node CLI)
+
+`app/bin/JankenSeasonEnd.js`, invoked as `node app/bin/JankenSeasonEnd.js [--note "..."] [--enable-rewards]`. Not registered in `crontab.config.js` and not invoked by the bot — only by ops.
+
+Steps within a single MySQL transaction:
+
+1. Resolve the active season row (`status='active'`, must be exactly one). Abort with non-zero exit if zero or more than one.
+2. Snapshot top 50 rows from `janken_rating` (ordered by `elo` desc, ties broken by `win_count` desc) into `janken_season_snapshot` joined to `user.display_name` for display capture.
+3. **(If `--enable-rewards` AND `enableSeasonEndRewards: true` in config)** call `JankenRewardService.payoutSeasonEnd(snapshot)` → credits via `inventory.increaseGodStone({ note: "janken_season_end_reward", ... })` and logs achievements. The first run will be invoked **without** `--enable-rewards`; this stub exists in code but is gated.
+4. Update active season row → `status='closed'`, `ended_at=NOW()`.
+5. Reset every `janken_rating` row:
+   - `lifetime_win_count += win_count`, same for lose/draw
+   - `elo = 1000`, `rank_tier = 'beginner'`
+   - `win_count = lose_count = draw_count = 0`
+   - `streak = 0`, `bounty = 0`
+   - `max_streak` left untouched
+6. Insert new `janken_seasons` row with `status='active'`, `started_at=NOW()`, optional note.
+7. Commit. Print summary (season N closed, snapshot saved, M rows reset, season N+1 opened).
+
+A subsequent rollback CLI (`node app/bin/JankenSeasonRollback.js`) is **not** in scope. If a reset goes wrong, ops restore from MySQL backup.
+
+### 3. Daily Rank Reward Flow (cron)
+
+`app/bin/JankenDailyRewards.js`, scheduled in `crontab.config.js` with `period: ["0","10","0","*","*","*"]` (00:10 Asia/Taipei daily — after the existing 00:05 trial-expiry check, before the rest of the day's traffic).
+
+```text
+1. reward_date := date_sub(NOW(), 1 day) in Asia/Taipei  // pay yesterday's standings
+2. active := DISTINCT user_ids that initiated OR received a bet match
+              with bet_amount > 0 AND created_at within reward_date (00:00–24:00 TPE)
+3. If empty → log and exit.
+4. ranked := JankenRating where user_id IN active ORDER BY elo DESC
+5. For position p in [1..len(ranked)]:
+     reward_type := bucketByPosition(p, rank_tier)
+     amount := config.minigame.janken.daily_reward[reward_type]
+     INSERT IGNORE INTO janken_daily_reward_log (user_id, reward_date, season_id, reward_type, amount)
+     If insert affected 1 row AND amount > 0:
+       inventory.increaseGodStone({ userId, amount, note: "janken_daily_rank_reward" })
+6. Log totals: per-bucket counts and stone payout.
+```
+
+`bucketByPosition` (deterministic):
+
+```js
+function bucketByPosition(p, rank_tier) {
+  if (p === 1) return "top1";
+  if (p === 2) return "top2";
+  if (p === 3) return "top3";
+  if (p <= 10) return "top4_10";
+  if (rank_tier === "legend")     return "legend";
+  if (rank_tier === "master")     return "master";
+  if (rank_tier === "fighter")    return "fighter";
+  if (rank_tier === "challenger") return "challenger";
+  return "beginner"; // amount=0 — log row still inserted to mark eligibility check
+}
+```
+
+If `enableDailyRankReward: false` in config, the cron logs the candidates and computed buckets but skips both the INSERT and the stone credit. This lets us shadow-run before flipping the switch.
+
+### 4. ELO Rebalance
+
+#### 4.1 Tier thresholds
+
+Updated values stored under `minigame.janken.elo.tiers` (new key — currently the array lives in code at `JankenRating.RANK_TIERS`). Code reads from config; the array becomes a fallback.
+
+| Tier | Old `minElo` | New `minElo` |
+|---|---|---|
+| 見習者 (beginner) | 0 | 0 |
+| 挑戰者 (challenger) | 1200 | **1100** |
+| 強者 (fighter) | 1400 | **1250** |
+| 達人 (master) | 1600 | **1400** |
+| 傳說 (legend) | 1800 | **1550** |
+
+Sub-tier formula (`getSubTier`) keeps the 5-step / 40-elo internal structure unchanged.
+
+#### 4.2 K-factor table
+
+| `minBet` | Old `k` | New `k` |
+|---|---|---|
+| 50000 | (n/a) | **80** *(new tier)* |
+| 10000 | 40 | replaced by 5000:60 below |
+| 5000 | (n/a) | **60** |
+| 3000 | 24 | replaced by 1000:32 below |
+| 1000 | (n/a) | **32** |
+| 500 | 16 | replaced by 100:20 below |
+| 100 | (n/a) | **20** |
+| 0 | 8 | **12** |
+
+Net effect: a 289-stone average bet now sits in K=20 (was K=8). Loss-factor 0.5 unchanged. Expected ELO/match in even matchups rises from +1 to +2.5; honest 1000→1250 path (fighter) drops from ~400 bet matches to ~100.
+
+#### 4.3 Bet & bounty caps
+
+| Tier | Old max bet | New max bet | Old max bounty | New max bounty |
+|---|---|---|---|---|
+| beginner | 20,000 | **50,000** | 10,000 | **20,000** |
+| challenger | 50,000 | **100,000** | 25,000 | **50,000** |
+| fighter | 100,000 | **200,000** | 50,000 | **100,000** |
+| master | 200,000 | **500,000** | 80,000 | **200,000** |
+| legend | 500,000 | **1,000,000** | 120,000 | **300,000** |
+
+Stored in `minigame.janken.bet.maxAmountByRank` and `minigame.janken.streak.maxBountyByRank` — both already config-driven. No code change beyond editing `default.json`.
+
+#### 4.4 Non-bet matches (Phase 2 toggle)
+
+Currently `updateElo` returns 0 when `betAmount <= 0`. Phase 2 introduces `minigame.janken.elo.nonBetK` (default `0` = unchanged). When raised to e.g. `4`, `updateElo` runs the full ELO formula even on non-bet matches, with K=4. Default stays `0` until anti-farming Phase 2 ships, because non-bet matches are infinitely repeatable and would be the easiest farming surface.
+
+### 5. Configuration Block
+
+Final `default.json` shape under `minigame.janken`:
+
+```jsonc
+{
+  "paper": "🖐️", "rock": "✊", "scissors": "✌️",
+
+  "season": {
+    "snapshotTopN": 50,
+    "enableSeasonEndRewards": false,
+    "endRewards": {
+      "top1": 50000, "top2": 30000, "top3": 20000,
+      "top4_10": 5000, "top11_50": 1000
+    }
+  },
+
+  "daily_reward": {
+    "enableDailyRankReward": false,
+    "amounts": {
+      "top1": 500, "top2": 300, "top3": 200,
+      "top4_10": 50,
+      "legend": 100, "master": 50, "fighter": 25,
+      "challenger": 10, "beginner": 0
+    }
+  },
+
+  "bet": {
+    "minAmount": 10,
+    "maxAmountByRank": {
+      "beginner": 50000, "challenger": 100000, "fighter": 200000,
+      "master": 500000, "legend": 1000000
+    },
+    "feeRate": 0.1
+  },
+
+  "streak": {
+    "maxBountyByRank": {
+      "beginner": 20000, "challenger": 50000, "fighter": 100000,
+      "master": 200000, "legend": 300000
+    },
+    "bountyMinBet": 1000,
+    "bountyClaimMultiplier": 5
+  },
+
+  "elo": {
+    "initial": 1000,
+    "tiers": [
+      { "key": "beginner",   "name": "見習者", "minElo": 0    },
+      { "key": "challenger", "name": "挑戰者", "minElo": 1100 },
+      { "key": "fighter",    "name": "強者",   "minElo": 1250 },
+      { "key": "master",     "name": "達人",   "minElo": 1400 },
+      { "key": "legend",     "name": "傳說",   "minElo": 1550 }
+    ],
+    "kFactorTiers": [
+      { "minBet": 50000, "k": 80 },
+      { "minBet":  5000, "k": 60 },
+      { "minBet":  1000, "k": 32 },
+      { "minBet":   100, "k": 20 },
+      { "minBet":     0, "k": 12 }
+    ],
+    "lossFactor": 0.5,
+    "nonBetK": 0,
+    "streakBonus": [
+      { "minStreak": 7, "multiplier": 2.0 },
+      { "minStreak": 5, "multiplier": 1.5 },
+      { "minStreak": 3, "multiplier": 1.25 }
+    ]
+  },
+
+  "images": { "...": "unchanged" }
+}
+```
+
+### 6. Code Changes
+
+**Models**
+
+- `app/src/model/application/JankenSeason.js` — `getActive()`, `close(seasonId)`, `openNew(notes)`.
+- `app/src/model/application/JankenSeasonSnapshot.js` — `bulkInsert(seasonId, rows)`, `getBySeason(seasonId)`.
+- `app/src/model/application/JankenDailyRewardLog.js` — `tryInsert(...)`, `getByUserAndDate(userId, date)`.
+- `app/src/model/application/JankenRating.js` —
+  - Read tiers from config (fallback to existing constant).
+  - New `getTopByElo(limit)` accepting transaction.
+  - New `resetSeasonFields(trx)` updating every row to bump lifetime counters and zero per-season fields in one statement.
+
+**Services**
+
+- `app/src/service/JankenSeasonService.js` — orchestrates the CLI flow (steps 1–7 in §2). Pure logic, no Bottender import.
+- `app/src/service/JankenRewardService.js` — `payoutDaily(rewardDate)` (cron) and `payoutSeasonEnd(snapshot)` (CLI). Both honor their respective config flags.
+
+**Bin scripts**
+
+- `app/bin/JankenSeasonEnd.js` — argv parsing (`--note`, `--enable-rewards`), invokes `JankenSeasonService.endCurrentAndOpenNext(...)`. Exits 0 on success, 1 on any failure.
+- `app/bin/JankenDailyRewards.js` — registered in `app/config/crontab.config.js` with `period: ["0","10","0","*","*","*"]` (6-field [s m h dom mon dow], 00:10 daily, immediate=false).
+
+**Controller / templates / API**
+
+- `JankenController.queryRank`: extend rank-card payload with `seasonId`, `seasonStartedAt`, `lifetimeWLD`, and (if the user has a row in `janken_daily_reward_log` for today) `todayReward`.
+- `templates/application/Janken.js#generateRankCard`: render the new lines (one extra row block, gated on data presence).
+- `app/src/router/api.js` — three new routes:
+  - `GET /api/janken/seasons` — list seasons (id, status, started_at, ended_at, notes).
+  - `GET /api/janken/seasons/:id/top` — return `janken_season_snapshot` rows for that season.
+  - `GET /api/janken/me/today-reward?userId=…` — driven from `janken_daily_reward_log`. (LIFF-authenticated by the existing `validation.js`.)
+- Existing `/api/janken/rankings` adds `seasonId` to its response payload.
+
+**Frontend**
+
+- `frontend/src/pages/Janken/index.jsx`: add a small header chip "第 N 賽季 · 自 YYYY-MM-DD 開始".
+- (Out of scope, optional v2) "歷代賽季" tab — list seasons and load snapshots on click.
+
+### 7. Phase 2 — Anti-Farming (specified, not built)
+
+The first season ends with `enableSeasonEndRewards=false` and `enableDailyRankReward=false` precisely because of the exploits found below. Phase 2 ships these enforcement rules in a follow-up PR; the spec captures the intent so the surface area is stable.
+
+#### 7.1 Per-day, per-opponent ELO cap
+
+Add `daily_elo_pairs` Redis hash, keyed `janken:elo_pair:<sortedUserPair>:<YYYYMMDD>`, with TTL 48h. Within `updateElo`:
+
+```text
+if redis.GET(`janken:elo_pair:${sortedUserPair}:${today}`) exists:
+  K := 0   // repeat match against same opponent same day → no ELO movement
+else:
+  redis.SET(..., "1", EX=48h, NX=true)
+  K := <as computed>
+```
+
+The settlement (women-stone payout, streak, bounty) still runs — ELO simply does not move on repeats.
+
+#### 7.2 Daily ELO ceiling
+
+`janken_rating` gains `daily_elo_gain` (int) and `daily_elo_gain_date` (date). On match:
+
+```text
+if daily_elo_gain_date != today:
+  daily_elo_gain := 0; daily_elo_gain_date := today
+delta := computed_delta
+if delta > 0:
+  remaining := 50 - daily_elo_gain
+  delta := min(delta, max(0, remaining))
+  daily_elo_gain += delta
+elo := elo + delta
+```
+
+50 ELO per day cap is config-driven (`elo.dailyGainCap`).
+
+#### 7.3 Diversity gate for daily reward eligibility
+
+Replace "active = ≥1 bet match yesterday" with "active = ≥1 bet match yesterday AND ≥3 unique opponents over the trailing 7 days." The 7-day window prevents single-day farming dumps from qualifying for that day's reward. Threshold tunable.
+
+#### 7.4 Suspect report
+
+A weekly cron (`app/bin/JankenSuspectReport.js`) prints users with `unique_opponents/bet_matches < 0.2` over 30d; admins act manually. No automated punishment in this phase.
+
+### 8. Economic Estimate
+
+With current 11 DAU and the rebalanced thresholds, expected daily payout when rewards are flipped on:
+
+```
+top1 ........................500
+top2 ........................300
+top3 ........................200
+top4..top10 (7 ppl) ..7×50 = 350
+remaining (~1 person, mostly challenger) ............. ~10
+                                  ─────
+                  per day total ≈ 1,360
+                  per month     ≈ 40,800
+```
+
+For comparison: the lifetime women-stone flow through bet matches is ~746K (2,583 bets × 289 avg). The daily reward injects ≈ 41K/month new mint into the economy — meaningful but not order-of-magnitude inflationary. If DAU climbs to 30, daily payout climbs to ~1,650; at 100 DAU, ~2,800. Numbers stay in O(1k–3k)/day across plausible growth.
+
+If the user wants to dial this up later, all knobs are in `default.json#minigame.janken.daily_reward.amounts`. The spec recommends revisiting the dial after 2 full seasons of telemetry.
+
+### 9. Testing
+
+- **Unit tests** (Jest, alongside services) for: ELO change with new K table, tier resolution from new thresholds, `bucketByPosition`, `JankenSeasonService.endCurrentAndOpenNext` happy + failure paths, daily reward dedup via unique key.
+- **Integration tests** (real MySQL via Knex) for: snapshot insertion, full reset transaction (rollback on partial failure), cron idempotency across two runs same day.
+- **Manual QA** before flipping the switch:
+  - Run `JankenSeasonEnd.js --note "dry-run"` against a staging DB clone, verify snapshot row count, lifetime fields advance, all per-season fields zeroed.
+  - Run `JankenDailyRewards.js` cron with `enableDailyRankReward: false` for one day, eyeball the log, then flip on.
+
+### 10. Rollout Order
+
+1. Migrations: add tables and `lifetime_*` columns. `lifetime_*` default to 0 — **do not backfill from current per-season counts**; the first season-end reset's `lifetime_* += win_count/lose_count/draw_count` step naturally captures pre-v2 totals into lifetime, so backfilling would double-count. Insert season `id=1` row with `started_at = MIN(janken_records.created_at)` and `status='active'`.
+2. Code: models, services, bin scripts, API routes, frontend chip.
+3. Update `default.json` with the new tier thresholds, K table, and bet/bounty caps. Daily-reward and season-end-reward flags stay `false`.
+4. Deploy bot + worker. Daily cron starts shadow-running (logs only, no payouts).
+5. Run `node app/bin/JankenSeasonEnd.js --note "v1 啟動 — 修補刷分前重啟"` (no `--enable-rewards`). Season 1 closes, snapshot saved; season 2 opens with all ELO at 1000.
+6. Phase 2 PR: ship anti-farming (§7), then flip `enableDailyRankReward: true`. Subsequent season-end reset can include `--enable-rewards`.
+
+## Risks
+
+- **Snapshot/reset transaction size.** ~92 rating rows is trivial; even at 10× growth it's a single statement. Low risk.
+- **Cron run during reset.** If the season-end CLI runs at 00:09 and the daily cron at 00:10, both could be modifying state simultaneously. Mitigation: the season CLI prints a banner reminding ops to disable the worker for 1 minute. The daily cron also reads `JankenSeason.getActive()` and gracefully exits if it sees inconsistent state (no active season, or active season started < 1 minute ago).
+- **`active_users` definition mismatch.** The spec defines "active" via `bet_amount > 0`. If at some point we want non-bet activity to count, `JankenDailyRewards` query needs revising — call out in code comment.
+- **Lifetime backfill.** Migration 9.1 backfills lifetime fields from current per-season counts. If someone disputes, source of truth is `janken_records` (replayable). Document this in the migration's `up`.
+- **First reset wipes the only fighter.** Intentional — the lone fighter is the confirmed self-collusion case. The reset is the cleanup.
+
+## Open Questions
+
+None at spec time. All user-facing decisions resolved during brainstorming on 2026-05-01:
+
+- Cadence: **manual** (CLI).
+- Reset scope: hard-reset per-season fields, preserve `max_streak`, add `lifetime_*` counters.
+- Snapshot: top 50, kept indefinitely.
+- Season-end reward: pyramid; **off** for first reset, opt-in via CLI flag thereafter.
+- Daily reward: top-N + tier pyramid, gated on yesterday's bet activity, **off** until Phase 2 anti-farming is on.
+- Anti-farming: specified here, implemented in Phase 2.
+- ELO rebalance: tier thresholds compressed, K-table boosted, bet/bounty caps doubled.
+- Admin surface: Node CLI only, no LINE command, no admin frontend button.

--- a/frontend/src/pages/Janken/index.jsx
+++ b/frontend/src/pages/Janken/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Container, Typography, Divider, Alert } from "@mui/material";
+import { Container, Typography, Divider, Alert, Chip, Stack } from "@mui/material";
 import BattleFeed from "./BattleFeed";
 import RankingList from "./RankingList";
 import { getRankings, getRecentMatches } from "../../services/janken";
@@ -12,6 +12,7 @@ export default function Janken() {
   const [matches, setMatches] = useState([]);
   const [loadingRankings, setLoadingRankings] = useState(true);
   const [loadingMatches, setLoadingMatches] = useState(true);
+  const [seasonId, setSeasonId] = useState(null);
   const [error, setError] = useState(null);
   const matchTimerRef = useRef(null);
   const rankingTimerRef = useRef(null);
@@ -19,7 +20,8 @@ export default function Janken() {
   const fetchRankings = useCallback(async () => {
     try {
       const data = await getRankings();
-      setRankings(data);
+      setRankings(data.items || []);
+      setSeasonId(data.seasonId ?? null);
       setError(null);
     } catch (err) {
       console.error("Failed to fetch rankings", err);
@@ -77,9 +79,14 @@ export default function Janken() {
 
   return (
     <Container maxWidth="sm" sx={{ py: 3 }}>
-      <Typography variant="h5" sx={{ fontWeight: 700, mb: 0.5 }}>
-        猜拳競技場
-      </Typography>
+      <Stack direction="row" spacing={1} sx={{ alignItems: "center", mb: 0.5 }}>
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          猜拳競技場
+        </Typography>
+        {seasonId != null && (
+          <Chip label={`第 ${seasonId} 賽季`} size="small" color="primary" variant="outlined" />
+        )}
+      </Stack>
       <Typography
         variant="body2"
         sx={{

--- a/frontend/src/services/janken.js
+++ b/frontend/src/services/janken.js
@@ -2,3 +2,7 @@ import api from "./api";
 
 export const getRankings = () => api.get("/api/janken/rankings").then(r => r.data);
 export const getRecentMatches = () => api.get("/api/janken/recent-matches").then(r => r.data);
+export const getSeasons = () => api.get("/api/janken/seasons").then(r => r.data);
+export const getSeasonTop = id => api.get(`/api/janken/seasons/${id}/top`).then(r => r.data);
+export const getMyTodayReward = userId =>
+  api.get(`/api/janken/me/today-reward`, { params: { userId } }).then(r => r.data);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -21,6 +21,10 @@ export default defineConfig({
         changeOrigin: true,
         ws: true,
       },
+      "/bot-assets": {
+        target: "http://localhost:9527",
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/makefile
+++ b/makefile
@@ -19,9 +19,6 @@ logs: ## 查看基礎設施日誌
 bash-redis: ## 開啟 Redis CLI
 	@docker compose exec -t redis redis-cli
 
-ngrok-url: ## 查詢 ngrok 公開網址
-	@curl -s http://localhost:4040/api/tunnels | python3 -c "import sys,json;print(json.load(sys.stdin)['tunnels'][0]['public_url'])" 2>/dev/null || echo "ngrok is not running"
-
 get-webhook: ## 查詢目前 LINE webhook 設定
 	@TOKEN=$$(grep '^LINE_ACCESS_TOKEN=' .env | cut -d'=' -f2-) && \
 	curl -s https://api.line.me/v2/bot/channel/webhook/endpoint \
@@ -31,11 +28,6 @@ get-liff: ## 查詢目前 LIFF 設定
 	@TOKEN=$$(grep '^LINE_ACCESS_TOKEN=' .env | cut -d'=' -f2-) && \
 	curl -s https://api.line.me/liff/v1/apps \
 		-H "Authorization: Bearer $$TOKEN" | python3 -m json.tool
-
-tunnel: ## 一鍵設定 ngrok URL 到 LINE webhook + LIFF + APP_DOMAIN
-	@NGROK_URL=$$(curl -s http://localhost:4040/api/tunnels | python3 -c "import sys,json;print(json.load(sys.stdin)['tunnels'][0]['public_url'])" 2>/dev/null) && \
-	if [ -z "$$NGROK_URL" ]; then echo "❌ ngrok is not running"; exit 1; fi && \
-	$(MAKE) -s _sync-line URL="$$NGROK_URL"
 
 cf-up: ## 啟動 Cloudflare Quick Tunnel（背景執行，log 寫到 /tmp/cloudflared.log）
 	@if pgrep -x cloudflared > /dev/null; then echo "⚠️  cloudflared is already running"; exit 0; fi && \

--- a/makefile
+++ b/makefile
@@ -32,36 +32,10 @@ get-liff: ## 查詢目前 LIFF 設定
 	curl -s https://api.line.me/liff/v1/apps \
 		-H "Authorization: Bearer $$TOKEN" | python3 -m json.tool
 
-tunnel: ## 一鍵設定 ngrok URL 到 LINE webhook + LIFF
+tunnel: ## 一鍵設定 ngrok URL 到 LINE webhook + LIFF + APP_DOMAIN
 	@NGROK_URL=$$(curl -s http://localhost:4040/api/tunnels | python3 -c "import sys,json;print(json.load(sys.stdin)['tunnels'][0]['public_url'])" 2>/dev/null) && \
 	if [ -z "$$NGROK_URL" ]; then echo "❌ ngrok is not running"; exit 1; fi && \
-	TOKEN=$$(grep '^LINE_ACCESS_TOKEN=' .env | cut -d'=' -f2-) && \
-	if [ -z "$$TOKEN" ]; then echo "❌ LINE_ACCESS_TOKEN not found in .env"; exit 1; fi && \
-	WEBHOOK_URL="$$NGROK_URL/webhooks/line" && \
-	curl -s -X PUT https://api.line.me/v2/bot/channel/webhook/endpoint \
-		-H "Authorization: Bearer $$TOKEN" \
-		-H "Content-Type: application/json" \
-		-d "{\"endpoint\": \"$$WEBHOOK_URL\"}" > /dev/null && \
-	echo "✅ Webhook: $$WEBHOOK_URL" && \
-	LIFF_ID=$$(grep '^LINE_LIFF_ID=' .env | cut -d'=' -f2-) && \
-	LOGIN_ID=$$(grep '^LINE_LOGIN_CHANNEL_ID=' .env | cut -d'=' -f2-) && \
-	LOGIN_SECRET=$$(grep '^LINE_LOGIN_CHANNEL_SECRET=' .env | cut -d'=' -f2-) && \
-	if [ -n "$$LIFF_ID" ] && [ -n "$$LOGIN_ID" ] && [ -n "$$LOGIN_SECRET" ]; then \
-		LIFF_TOKEN=$$(curl -s -X POST https://api.line.me/oauth2/v3/token \
-			-d "grant_type=client_credentials&client_id=$$LOGIN_ID&client_secret=$$LOGIN_SECRET" \
-			| python3 -c "import sys,json;print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null) && \
-		if [ -n "$$LIFF_TOKEN" ]; then \
-			curl -s -X PUT "https://api.line.me/liff/v1/apps/$$LIFF_ID" \
-				-H "Authorization: Bearer $$LIFF_TOKEN" \
-				-H "Content-Type: application/json" \
-				-d "{\"view\":{\"type\":\"full\",\"url\":\"$$NGROK_URL\"}}" > /dev/null && \
-			echo "✅ LIFF:    $$NGROK_URL ($$LIFF_ID)"; \
-		else \
-			echo "❌ Failed to issue LINE Login token, check LINE_LOGIN_CHANNEL_ID/SECRET"; \
-		fi; \
-	else \
-		echo "⚠️  LIFF update skipped (missing LINE_LIFF_ID or LINE_LOGIN_CHANNEL_ID/SECRET)"; \
-	fi
+	$(MAKE) -s _sync-line URL="$$NGROK_URL"
 
 cf-up: ## 啟動 Cloudflare Quick Tunnel（背景執行，log 寫到 /tmp/cloudflared.log）
 	@if pgrep -x cloudflared > /dev/null; then echo "⚠️  cloudflared is already running"; exit 0; fi && \
@@ -81,12 +55,21 @@ cf-down: ## 停止 Cloudflare Quick Tunnel
 cf-url: ## 查詢目前 Cloudflare Tunnel 網址
 	@grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' /tmp/cloudflared.log 2>/dev/null | head -1 || echo "cloudflared is not running"
 
-cf-tunnel: ## 一鍵設定 Cloudflare URL 到 LINE webhook + LIFF
+cf-tunnel: ## 一鍵設定 Cloudflare URL 到 LINE webhook + LIFF + APP_DOMAIN
 	@CF_URL=$$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' /tmp/cloudflared.log 2>/dev/null | head -1) && \
 	if [ -z "$$CF_URL" ]; then echo "❌ cloudflared is not running (try: make cf-up)"; exit 1; fi && \
+	$(MAKE) -s _sync-line URL="$$CF_URL"
+
+cf-go: cf-up ## 啟動 cloudflared 並把 URL 同步給 LINE + .env
+	@sleep 1 && $(MAKE) -s cf-tunnel
+
+# Internal: sync a public tunnel URL to LINE webhook + LIFF endpoint + .env APP_DOMAIN.
+# Usage: make _sync-line URL=https://example.trycloudflare.com
+_sync-line:
+	@if [ -z "$(URL)" ]; then echo "❌ URL not provided"; exit 1; fi && \
 	TOKEN=$$(grep '^LINE_ACCESS_TOKEN=' .env | cut -d'=' -f2-) && \
 	if [ -z "$$TOKEN" ]; then echo "❌ LINE_ACCESS_TOKEN not found in .env"; exit 1; fi && \
-	WEBHOOK_URL="$$CF_URL/webhooks/line" && \
+	WEBHOOK_URL="$(URL)/webhooks/line" && \
 	curl -s -X PUT https://api.line.me/v2/bot/channel/webhook/endpoint \
 		-H "Authorization: Bearer $$TOKEN" \
 		-H "Content-Type: application/json" \
@@ -103,14 +86,21 @@ cf-tunnel: ## 一鍵設定 Cloudflare URL 到 LINE webhook + LIFF
 			curl -s -X PUT "https://api.line.me/liff/v1/apps/$$LIFF_ID" \
 				-H "Authorization: Bearer $$LIFF_TOKEN" \
 				-H "Content-Type: application/json" \
-				-d "{\"view\":{\"type\":\"full\",\"url\":\"$$CF_URL\"}}" > /dev/null && \
-			echo "✅ LIFF:    $$CF_URL ($$LIFF_ID)"; \
+				-d "{\"view\":{\"type\":\"full\",\"url\":\"$(URL)\"}}" > /dev/null && \
+			echo "✅ LIFF:    $(URL) ($$LIFF_ID)"; \
 		else \
 			echo "❌ Failed to issue LINE Login token, check LINE_LOGIN_CHANNEL_ID/SECRET"; \
 		fi; \
 	else \
 		echo "⚠️  LIFF update skipped (missing LINE_LIFF_ID or LINE_LOGIN_CHANNEL_ID/SECRET)"; \
-	fi
+	fi && \
+	HOST=$$(echo "$(URL)" | sed -E 's|^https?://||; s|/.*||') && \
+	if grep -q '^APP_DOMAIN=' .env; then \
+		sed -i.bak -E "s|^APP_DOMAIN=.*|APP_DOMAIN=$$HOST|" .env && rm -f .env.bak; \
+	else \
+		echo "APP_DOMAIN=$$HOST" >> .env; \
+	fi && \
+	echo "✅ APP_DOMAIN: $$HOST (.env updated — restart bot to apply)"
 
 help: ## 顯示所有可用指令
 	@sed \


### PR DESCRIPTION
## Summary

- **Season system**: introduces `janken_seasons` + `janken_season_snapshot` + `janken_daily_reward_log`; ratings reset to elo 1000 on season end with lifetime totals carried forward (+ max_streak preserved as career-best).
- **Daily rank rewards**: cron runs 00:10 TPE, pays goddess stones to top-ranked active players (top1/top2/top3/top4-10/legend/master/fighter/challenger). Idempotent via unique key `(user_id, reward_date)`. Kill-switched off until Phase 2 anti-farming ships.
- **ELO rebalance**: 5-tier ladder with thinner gates (1100/1250/1400/1550), 5-bracket K-factor (12/20/32/60/80) tied to bet size, lossFactor 0.5 makes climbing easier, `nonBetK` knob (default 0) optionally lets non-bet matches still move ELO.
- **Bet caps & streak bounty**: rebalanced per rank to spread engagement (50k → 1M cap, scaled bounty maxima).
- **Frontend**: `/janken` page shows current season chip; rank card surfaces season / lifetime / today reward rows. Three new APIs ready (`/api/janken/seasons`, `/api/janken/seasons/:id/top`, `/api/janken/me/today-reward`) — exported from frontend service but not yet wired into UI (history-page is a follow-up).
- **CLI**: \`bin/JankenSeasonEnd.js\` (manual, with optional --enable-rewards) and \`bin/JankenDailyRewards.js\` (cron). Both auto-load .env when run standalone.

## Operational safeguards

- **Two kill switches default OFF**:
  - \`minigame.janken.daily_reward.enableDailyRankReward\`
  - \`minigame.janken.season.enableSeasonEndRewards\`
- Both reward paths are protected by AND-gates (CLI flag + config flag) — accidental rewards require flipping both.
- Snapshot transaction is atomic (snapshot + payout + close + reset + open) — partial failure rolls back.
- Daily reward uses per-user mysql.transaction so log + inventory credit can never split.

## Deployment runbook (cutover)

> **TL;DR**: deploy → migrate → run season-end cutover (no rewards) → done. Rewards stay off until Phase 2.

1. **Deploy** (Portainer stack rebuild for \`redive_linebot\`).
2. **Run migrations inside the bot container**:
   \`\`\`bash
   docker exec redive_linebot-bot-1 yarn migrate
   \`\`\`
   This creates the three new tables, adds \`lifetime_{win,lose,draw}_count\` columns to \`janken_rating\`, seeds the initial active season row, and (defensively) heals any lingering \`utf8mb4_unicode_ci\` table drift.
3. **Cutover season-end (immediately, no rewards)** — closes the implicit \"season 1\" carrying legacy elo, snapshots it for history, resets all ratings to elo 1000 / beginner, opens \"season 2\" cleanly under the new rebalance:
   \`\`\`bash
   docker exec redive_linebot-bot-1 node bin/JankenSeasonEnd.js --note \"M8 cutover: legacy carry-over, no rewards\"
   \`\`\`
   Lifetime stats are preserved (career w/l/d carries forward), max_streak stays, but elo and rank tier reset cleanly so the new K-factor / lossFactor / tier thresholds take effect from a known baseline. Costs zero stones — neither flag is on.
4. **Verify**:
   \`\`\`sql
   SELECT id, status, started_at, notes FROM janken_seasons ORDER BY id DESC LIMIT 3;
   SELECT COUNT(*) FROM janken_season_snapshot WHERE season_id = (SELECT id FROM janken_seasons WHERE status='closed' ORDER BY id DESC LIMIT 1);
   SELECT COUNT(*) AS reset_ratings FROM janken_rating WHERE elo = 1000 AND rank_tier = 'beginner';
   \`\`\`
5. **Leave both reward kill switches OFF** until Phase 2 anti-farming ships. The cron will fire daily and dry-run as expected.

## Phase 2 carry-over (NOT in this PR)

These are intentionally deferred — track separately:

- Anti-farming detection before \`enableDailyRankReward\` flips on (rate limits, sybil/collusion checks, opt-in groups).
- Centralize TPE-yesterday helper between \`JankenDailyRewards.computeRewardDate\` and \`util/date.yesterdayUtc8\` (one currently uses date arithmetic, one uses moment).
- Frontend UI for season history (APIs + service helpers exist, just no page yet).
- Ops runbook entry under \`docs/ops/\` once Phase 2 is on the table.
- Stone Ledger Refactor folding new \`janken_daily_rank_reward\` / \`janken_season_end_reward\` audit notes into the standardized inventory ledger.

## Test plan

- [x] Unit + integration: 643/643 tests passing under \`--runInBand\`
- [x] Lint: 0 errors (app + frontend)
- [x] Frontend build: success
- [x] **E2E daily-reward flow** (manual, real DB): dry-run candidate selection, real-run credit, log + inventory rows match, idempotent rerun nets \`credited: 0\`
- [x] **E2E season-end flow** (manual, real DB): with and without --enable-rewards, snapshot frozen correctly, top1/top2/top3 buckets paid 50k/30k/20k, AND-gate verified for skip path, max_streak + lifetime preserved, ratings reset to elo 1000 / beginner
- [x] Standalone CLI invocation (post-fix): both \`bin/Janken*.js\` auto-load .env when invoked directly
- [x] Collation drift (\`Inventory\`/\`user\` × \`janken_*\` joins) self-heals on migration

## Branch hygiene during M8 (post-spec fixes)

- \`4fd6f421\` heal collation drift breaking recent-matches API
- \`0b377f1c\` rank images now load in browser (relative path + Vite \`/bot-assets\` proxy)
- \`d4682858\` \`make tunnel\` / \`make cf-tunnel\` also rewrite \`.env\`'s \`APP_DOMAIN\`
- \`627bc660\` drop ngrok flow, cloudflared is the only dev tunnel
- \`b7b076ca\` bin scripts auto-load .env when run standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)