### PR TITLE
feat(janken): pair dampening + same-opponent streak gate

### DIFF
--- a/app/__tests__/service/JankenService.test.js
+++ b/app/__tests__/service/JankenService.test.js
@@ -426,7 +426,11 @@ describe("JankenService", () => {
     });
 
     it("dampens winner Elo gain when the same pair has a one-sided history", () => {
-      const dampening = JankenService.calculatePairDampening({ matches: 10, a_wins: 10, b_wins: 0 });
+      const dampening = JankenService.calculatePairDampening({
+        matches: 10,
+        a_wins: 10,
+        b_wins: 0,
+      });
       const baseline = JankenService.calculateEloChange(1000, 1000, "win", 1000);
       const dampened = JankenService.calculateEloChange(1000, 1000, "win", 1000, {
         pairDampening: dampening,
@@ -447,7 +451,11 @@ describe("JankenService", () => {
     });
 
     it("dampens loss path symmetrically so the loser's Elo is preserved too", () => {
-      const dampening = JankenService.calculatePairDampening({ matches: 10, a_wins: 10, b_wins: 0 });
+      const dampening = JankenService.calculatePairDampening({
+        matches: 10,
+        a_wins: 10,
+        b_wins: 0,
+      });
       const baselineLoss = JankenService.calculateEloChange(1000, 1000, "lose", 1000);
       const dampenedLoss = JankenService.calculateEloChange(1000, 1000, "lose", 1000, {
         pairDampening: dampening,

--- a/app/__tests__/service/JankenService.test.js
+++ b/app/__tests__/service/JankenService.test.js
@@ -381,4 +381,182 @@ describe("JankenService", () => {
       expect(highBet).toBe(16);
     });
   });
+
+  describe("calculatePairDampening", () => {
+    it("returns 1 when below the matches threshold", () => {
+      expect(JankenService.calculatePairDampening({ matches: 0, a_wins: 0, b_wins: 0 })).toBe(1);
+      expect(JankenService.calculatePairDampening({ matches: 2, a_wins: 2, b_wins: 0 })).toBe(1);
+    });
+
+    it("returns 1 for balanced (50/50) pairs regardless of match count", () => {
+      expect(JankenService.calculatePairDampening({ matches: 10, a_wins: 5, b_wins: 5 })).toBe(1);
+      expect(JankenService.calculatePairDampening({ matches: 100, a_wins: 50, b_wins: 50 })).toBe(
+        1
+      );
+    });
+
+    it("decreases as a one-sided pair plays more matches (self-farm signature)", () => {
+      const d3 = JankenService.calculatePairDampening({ matches: 3, a_wins: 3, b_wins: 0 });
+      const d10 = JankenService.calculatePairDampening({ matches: 10, a_wins: 10, b_wins: 0 });
+      const d20 = JankenService.calculatePairDampening({ matches: 20, a_wins: 20, b_wins: 0 });
+      expect(d3).toBeCloseTo(1 / 1.6); // 0.625
+      expect(d10).toBeCloseTo(1 / 3); // 0.333
+      expect(d20).toBeCloseTo(1 / 5); // 0.2
+      expect(d20).toBeLessThan(d10);
+      expect(d10).toBeLessThan(d3);
+    });
+
+    it("only mildly dampens moderately skewed pairs (e.g. 67% winner)", () => {
+      // 4 wins / 6 matches = 67% winRate, bias = 2*(0.67-0.5) ≈ 0.333
+      const damp = JankenService.calculatePairDampening({ matches: 6, a_wins: 4, b_wins: 2 });
+      // 1 / (1 + 6 * 0.2 * 0.333) = 1 / 1.4 ≈ 0.714
+      expect(damp).toBeGreaterThan(0.7);
+      expect(damp).toBeLessThan(0.8);
+    });
+  });
+
+  describe("calculateEloChange with pairStats", () => {
+    beforeEach(() => {
+      JankenRating.getKFactor.mockImplementation(betAmount => {
+        if (betAmount >= 10000) return 32;
+        if (betAmount >= 3000) return 16;
+        if (betAmount >= 500) return 8;
+        return 2;
+      });
+    });
+
+    it("dampens winner Elo gain when the same pair has a one-sided history", () => {
+      const baseline = JankenService.calculateEloChange(1000, 1000, "win", 1000);
+      const dampened = JankenService.calculateEloChange(1000, 1000, "win", 1000, {
+        pairStats: { matches: 10, a_wins: 10, b_wins: 0 },
+      });
+      // baseline = floor(8 * 0.5) = 4
+      // dampened = floor(4 * 0.333) = 1
+      expect(baseline).toBe(4);
+      expect(dampened).toBeLessThan(baseline);
+      expect(dampened).toBe(1);
+    });
+
+    it("does not change Elo for balanced pairs (50/50 dampening = 1)", () => {
+      const baseline = JankenService.calculateEloChange(1000, 1000, "win", 1000);
+      const balanced = JankenService.calculateEloChange(1000, 1000, "win", 1000, {
+        pairStats: { matches: 20, a_wins: 10, b_wins: 10 },
+      });
+      expect(balanced).toBe(baseline);
+    });
+
+    it("dampens loss path symmetrically so the loser's Elo is preserved too", () => {
+      const baselineLoss = JankenService.calculateEloChange(1000, 1000, "lose", 1000);
+      const dampenedLoss = JankenService.calculateEloChange(1000, 1000, "lose", 1000, {
+        pairStats: { matches: 10, a_wins: 10, b_wins: 0 },
+      });
+      // baseline = ceil(-4 * 0.5) = -2; dampened = ceil(-1.333) = 0 (Math.ceil → -0 in JS)
+      expect(baselineLoss).toBe(-2);
+      expect(dampenedLoss).toBeGreaterThanOrEqual(baselineLoss);
+      expect(Math.abs(dampenedLoss)).toBe(0);
+    });
+  });
+
+  describe("updateStreaks opponent-switch gating", () => {
+    let mockFirst;
+
+    beforeEach(() => {
+      mockFirst = jest.fn();
+      mockTrxQuery.mockImplementation(() => ({
+        where: jest.fn(() => ({
+          forUpdate: jest.fn(() => ({
+            first: mockFirst,
+          })),
+          update: mockUpdate,
+        })),
+      }));
+    });
+
+    it("does NOT increment streak when winner beats the same opponent as last streak win", () => {
+      JankenRating.findOrCreate.mockResolvedValue(undefined);
+      mockFirst
+        .mockResolvedValueOnce({
+          user_id: "winner",
+          streak: 5,
+          max_streak: 5,
+          bounty: 100,
+          rank_tier: "beginner",
+          last_won_opponent_id: "loser",
+        })
+        .mockResolvedValueOnce({ user_id: "loser", streak: 0, max_streak: 2, bounty: 0 });
+
+      return JankenService.updateStreaks("winner", "loser", "win", {
+        betAmount: 1000,
+        fee: 200,
+      }).then(result => {
+        expect(result.winnerStreak).toBe(5); // gated
+      });
+    });
+
+    it("DOES increment streak when winner beats a different opponent", () => {
+      JankenRating.findOrCreate.mockResolvedValue(undefined);
+      mockFirst
+        .mockResolvedValueOnce({
+          user_id: "winner",
+          streak: 5,
+          max_streak: 5,
+          bounty: 100,
+          rank_tier: "beginner",
+          last_won_opponent_id: "previousLoser",
+        })
+        .mockResolvedValueOnce({ user_id: "newLoser", streak: 0, max_streak: 2, bounty: 0 });
+
+      return JankenService.updateStreaks("winner", "newLoser", "win", {
+        betAmount: 1000,
+        fee: 200,
+      }).then(result => {
+        expect(result.winnerStreak).toBe(6);
+      });
+    });
+
+    it("starts a fresh streak (1) after a previous loss reset, even against the same opponent", () => {
+      JankenRating.findOrCreate.mockResolvedValue(undefined);
+      mockFirst
+        .mockResolvedValueOnce({
+          user_id: "winner",
+          streak: 0, // streak got reset by an earlier loss
+          max_streak: 5,
+          bounty: 0,
+          rank_tier: "beginner",
+          last_won_opponent_id: null, // also cleared on loss
+        })
+        .mockResolvedValueOnce({ user_id: "loser", streak: 0, max_streak: 0, bounty: 0 });
+
+      return JankenService.updateStreaks("winner", "loser", "win", {
+        betAmount: 1000,
+        fee: 200,
+      }).then(result => {
+        expect(result.winnerStreak).toBe(1);
+      });
+    });
+
+    it("gated repeat win does not accumulate bounty (streak < 2 trigger is preserved at the gate)", () => {
+      JankenRating.findOrCreate.mockResolvedValue(undefined);
+      // Winner has streak=1 from a single previous win against this same opponent.
+      // Repeat win should keep streak at 1, so bounty should NOT accumulate (needs streak >= 2).
+      mockFirst
+        .mockResolvedValueOnce({
+          user_id: "winner",
+          streak: 1,
+          max_streak: 1,
+          bounty: 0,
+          rank_tier: "beginner",
+          last_won_opponent_id: "loser",
+        })
+        .mockResolvedValueOnce({ user_id: "loser", streak: 0, max_streak: 0, bounty: 0 });
+
+      return JankenService.updateStreaks("winner", "loser", "win", {
+        betAmount: 5000,
+        fee: 1000,
+      }).then(result => {
+        expect(result.winnerStreak).toBe(1);
+        expect(result.winnerBounty).toBe(0); // gated → no bounty
+      });
+    });
+  });
 });

--- a/app/__tests__/service/JankenService.test.js
+++ b/app/__tests__/service/JankenService.test.js
@@ -415,7 +415,7 @@ describe("JankenService", () => {
     });
   });
 
-  describe("calculateEloChange with pairStats", () => {
+  describe("calculateEloChange with pairDampening", () => {
     beforeEach(() => {
       JankenRating.getKFactor.mockImplementation(betAmount => {
         if (betAmount >= 10000) return 32;
@@ -426,9 +426,10 @@ describe("JankenService", () => {
     });
 
     it("dampens winner Elo gain when the same pair has a one-sided history", () => {
+      const dampening = JankenService.calculatePairDampening({ matches: 10, a_wins: 10, b_wins: 0 });
       const baseline = JankenService.calculateEloChange(1000, 1000, "win", 1000);
       const dampened = JankenService.calculateEloChange(1000, 1000, "win", 1000, {
-        pairStats: { matches: 10, a_wins: 10, b_wins: 0 },
+        pairDampening: dampening,
       });
       // baseline = floor(8 * 0.5) = 4
       // dampened = floor(4 * 0.333) = 1
@@ -440,15 +441,16 @@ describe("JankenService", () => {
     it("does not change Elo for balanced pairs (50/50 dampening = 1)", () => {
       const baseline = JankenService.calculateEloChange(1000, 1000, "win", 1000);
       const balanced = JankenService.calculateEloChange(1000, 1000, "win", 1000, {
-        pairStats: { matches: 20, a_wins: 10, b_wins: 10 },
+        pairDampening: 1,
       });
       expect(balanced).toBe(baseline);
     });
 
     it("dampens loss path symmetrically so the loser's Elo is preserved too", () => {
+      const dampening = JankenService.calculatePairDampening({ matches: 10, a_wins: 10, b_wins: 0 });
       const baselineLoss = JankenService.calculateEloChange(1000, 1000, "lose", 1000);
       const dampenedLoss = JankenService.calculateEloChange(1000, 1000, "lose", 1000, {
-        pairStats: { matches: 10, a_wins: 10, b_wins: 0 },
+        pairDampening: dampening,
       });
       // baseline = ceil(-4 * 0.5) = -2; dampened = ceil(-1.333) = 0 (Math.ceil → -0 in JS)
       expect(baselineLoss).toBe(-2);

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -116,6 +116,10 @@
           { "minStreak": 5, "multiplier": 1.5 },
           { "minStreak": 3, "multiplier": 1.25 }
         ]
+      },
+      "pairDampening": {
+        "matchesThreshold": 3,
+        "biasMultiplier": 0.2
       }
     }
   },

--- a/app/migrations/20260502165624_create_janken_pair_stats.js
+++ b/app/migrations/20260502165624_create_janken_pair_stats.js
@@ -1,0 +1,31 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.createTable("janken_pair_stats", table => {
+    table.string("player_a", 33).notNullable();
+    table.string("player_b", 33).notNullable();
+    table.integer("matches").notNullable().defaultTo(0);
+    table.integer("a_wins").notNullable().defaultTo(0);
+    table.integer("b_wins").notNullable().defaultTo(0);
+    table.integer("draws").notNullable().defaultTo(0);
+    table.timestamp("last_match_at").notNullable().defaultTo(knex.fn.now());
+    table.primary(["player_a", "player_b"]);
+  });
+
+  await knex.schema.alterTable("janken_rating", table => {
+    table.string("last_won_opponent_id", 33).nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable("janken_rating", table => {
+    table.dropColumn("last_won_opponent_id");
+  });
+  await knex.schema.dropTable("janken_pair_stats");
+};

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -16,6 +16,10 @@ const { notifyUnlocks } = require("../../service/achievementNotifier");
 const baseUrl = `https://${process.env.APP_DOMAIN}`;
 const ASSET_VERSION = Date.now();
 const jankenAsset = name => `${baseUrl}/bot-assets/janken/${name}?v=${ASSET_VERSION}`;
+// Relative-path variant for browser-facing API responses. Same-origin in
+// dev (via Vite proxy) and prod (via Traefik), so it dodges the DNS issue
+// when APP_DOMAIN is a non-resolvable local hostname like `redivebot.local`.
+const webJankenAsset = name => `/bot-assets/janken/${name}?v=${ASSET_VERSION}`;
 const BountySender = { name: "懸賞官", iconUrl: jankenAsset("bounty.png") };
 
 exports.router = [
@@ -520,7 +524,7 @@ exports.api.rankings = async (req, res) => {
         displayName: r.display_name || `玩家${index + 1}`,
         rankLabel: JankenRating.getRankLabel(r.elo),
         rankTier: r.rank_tier,
-        rankImage: jankenAsset(`${JankenRating.getRankImageKey(r.elo)}.png`),
+        rankImage: webJankenAsset(`${JankenRating.getRankImageKey(r.elo)}.png`),
         elo: r.elo,
         winCount: r.win_count,
         loseCount: r.lose_count,

--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -16,7 +16,11 @@ const FEE_RATE = config.get("minigame.janken.bet.feeRate");
 const MIN_BET = config.get("minigame.janken.bet.minAmount");
 const BOUNTY_MIN_BET = config.get("minigame.janken.streak.bountyMinBet");
 const BOUNTY_CLAIM_MULTIPLIER = config.get("minigame.janken.streak.bountyClaimMultiplier");
+const PAIR_DAMP_THRESHOLD = config.get("minigame.janken.pairDampening.matchesThreshold");
+const PAIR_DAMP_BIAS_MULTIPLIER = config.get("minigame.janken.pairDampening.biasMultiplier");
 const MATCH_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+
+const orderedPair = (uA, uB) => (uA < uB ? [uA, uB] : [uB, uA]);
 
 const RESULT_MAP = {
   rock: { rock: "draw", paper: "lose", scissors: "win" },
@@ -101,7 +105,12 @@ exports.updateStreaks = async function (
       trx("janken_rating").where({ user_id: loserId }).forUpdate().first(),
     ]);
 
-    const newStreak = winnerRating.streak + 1;
+    // Streak only grows when the winner beats a different opponent than their previous streak win.
+    // This is the core anti-self-farm gate for streak/bounty: hammering the same alt account
+    // keeps the streak stuck.
+    const sameOpponentAsLastStreakWin =
+      winnerRating.streak > 0 && winnerRating.last_won_opponent_id === loserId;
+    const newStreak = sameOpponentAsLastStreakWin ? winnerRating.streak : winnerRating.streak + 1;
     const newMaxStreak = Math.max(newStreak, winnerRating.max_streak);
     // Bounty funded from match fee — no new money created
     const bountyIncrement =
@@ -116,10 +125,12 @@ exports.updateStreaks = async function (
         streak: newStreak,
         max_streak: newMaxStreak,
         bounty: newBounty,
+        last_won_opponent_id: loserId,
       }),
       trx("janken_rating").where({ user_id: loserId }).update({
         streak: 0,
         bounty: 0,
+        last_won_opponent_id: null,
       }),
     ]);
 
@@ -324,6 +335,15 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
           JankenRating.findOrCreate(p1UserId, trx),
           JankenRating.findOrCreate(p2UserId, trx),
         ]);
+        const [playerA, playerB] = orderedPair(p1UserId, p2UserId);
+        await trx.raw(
+          "INSERT INTO janken_pair_stats (player_a, player_b, matches, draws, last_match_at) " +
+            "VALUES (?, ?, 1, 1, NOW()) " +
+            "ON DUPLICATE KEY UPDATE matches = matches + 1, " +
+            "draws = draws + 1, " +
+            "last_match_at = VALUES(last_match_at)",
+          [playerA, playerB]
+        );
         await Promise.all([
           trx("janken_rating")
             .where({ user_id: p1UserId })
@@ -349,6 +369,12 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
       JankenRating.findOrCreate(p2UserId, trx),
     ]);
 
+    const [playerA, playerB] = orderedPair(p1UserId, p2UserId);
+    const priorPairStats = (await trx("janken_pair_stats")
+      .where({ player_a: playerA, player_b: playerB })
+      .forUpdate()
+      .first()) || { matches: 0, a_wins: 0, b_wins: 0, draws: 0 };
+
     const [p1Rating, p2Rating] = await Promise.all([
       trx("janken_rating").where({ user_id: p1UserId }).forUpdate().first(),
       trx("janken_rating").where({ user_id: p2UserId }).forUpdate().first(),
@@ -363,6 +389,7 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
       betAmount,
       {
         streak: p1Streak,
+        pairStats: priorPairStats,
       }
     );
     const p2Result = p1Result === "win" ? "lose" : "win";
@@ -373,6 +400,7 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
       betAmount,
       {
         streak: p2Streak,
+        pairStats: priorPairStats,
       }
     );
 
@@ -381,6 +409,18 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
 
     const p1WinKey = p1Result === "win" ? "win_count" : "lose_count";
     const p2WinKey = p1Result === "win" ? "lose_count" : "win_count";
+
+    const winnerIsA =
+      (p1Result === "win" && p1UserId === playerA) || (p1Result === "lose" && p2UserId === playerA);
+    await trx.raw(
+      "INSERT INTO janken_pair_stats (player_a, player_b, matches, a_wins, b_wins, last_match_at) " +
+        "VALUES (?, ?, 1, ?, ?, NOW()) " +
+        "ON DUPLICATE KEY UPDATE matches = matches + 1, " +
+        "a_wins = a_wins + VALUES(a_wins), " +
+        "b_wins = b_wins + VALUES(b_wins), " +
+        "last_match_at = VALUES(last_match_at)",
+      [playerA, playerB, winnerIsA ? 1 : 0, winnerIsA ? 0 : 1]
+    );
 
     await Promise.all([
       trx("janken_rating")
@@ -422,18 +462,45 @@ exports.getStreakMultiplier = function (streak) {
   return 1;
 };
 
-exports.calculateEloChange = function (myElo, opponentElo, result, betAmount, { streak = 0 } = {}) {
+/**
+ * Same-pair Elo dampening factor in [0, 1].
+ * Pure function of prior pair history (not including the current match).
+ * Returns 1 when the pair is below the threshold or play is balanced;
+ * shrinks toward 0 as the same pair plays more matches with one side dominating.
+ *
+ * Stats fields are pre-current-match.
+ *
+ * @param {{ matches?: number, a_wins?: number, b_wins?: number }} stats
+ * @returns {number}
+ */
+exports.calculatePairDampening = function ({ matches = 0, a_wins = 0, b_wins = 0 } = {}) {
+  if (matches < PAIR_DAMP_THRESHOLD) return 1;
+  const decided = a_wins + b_wins;
+  if (decided === 0) return 1;
+  const winRate = Math.max(a_wins, b_wins) / decided;
+  const winRateBias = Math.max(0, winRate * 2 - 1); // 0.5 → 0, 1.0 → 1.0
+  return 1 / (1 + matches * PAIR_DAMP_BIAS_MULTIPLIER * winRateBias);
+};
+
+exports.calculateEloChange = function (
+  myElo,
+  opponentElo,
+  result,
+  betAmount,
+  { streak = 0, pairStats = null } = {}
+) {
   if (result === "draw") return 0;
   const K = JankenRating.getKFactor(betAmount);
   const expected = exports.calculateExpectedWinRate(myElo, opponentElo);
   const actual = result === "win" ? 1 : 0;
   const raw = K * (actual - expected);
+  const pairDamp = exports.calculatePairDampening(pairStats || {});
   if (raw >= 0) {
     const multiplier = result === "win" ? exports.getStreakMultiplier(streak) : 1;
-    return Math.floor(raw * multiplier);
+    return Math.floor(raw * multiplier * pairDamp);
   }
   const lossFactor = config.get("minigame.janken.elo.lossFactor");
-  return Math.ceil(raw * lossFactor);
+  return Math.ceil(raw * lossFactor * pairDamp);
 };
 
 exports.submitArenaChallenge = async function (groupId, holderUserId, challengerUserId, choice) {

--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -20,7 +20,20 @@ const PAIR_DAMP_THRESHOLD = config.get("minigame.janken.pairDampening.matchesThr
 const PAIR_DAMP_BIAS_MULTIPLIER = config.get("minigame.janken.pairDampening.biasMultiplier");
 const MATCH_WINDOW_SECONDS = 7 * 24 * 60 * 60;
 
+// LINE userIds are fixed-length (`U` + 32 hex chars), so byte-order ordering is canonical.
 const orderedPair = (uA, uB) => (uA < uB ? [uA, uB] : [uB, uA]);
+
+const upsertPairStats = (trx, playerA, playerB, { aWins = 0, bWins = 0, draws = 0 }) =>
+  trx.raw(
+    "INSERT INTO janken_pair_stats (player_a, player_b, matches, a_wins, b_wins, draws, last_match_at) " +
+      "VALUES (?, ?, 1, ?, ?, ?, NOW()) " +
+      "ON DUPLICATE KEY UPDATE matches = matches + 1, " +
+      "a_wins = a_wins + VALUES(a_wins), " +
+      "b_wins = b_wins + VALUES(b_wins), " +
+      "draws = draws + VALUES(draws), " +
+      "last_match_at = VALUES(last_match_at)",
+    [playerA, playerB, aWins, bWins, draws]
+  );
 
 const RESULT_MAP = {
   rock: { rock: "draw", paper: "lose", scissors: "win" },
@@ -336,14 +349,7 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
           JankenRating.findOrCreate(p2UserId, trx),
         ]);
         const [playerA, playerB] = orderedPair(p1UserId, p2UserId);
-        await trx.raw(
-          "INSERT INTO janken_pair_stats (player_a, player_b, matches, draws, last_match_at) " +
-            "VALUES (?, ?, 1, 1, NOW()) " +
-            "ON DUPLICATE KEY UPDATE matches = matches + 1, " +
-            "draws = draws + 1, " +
-            "last_match_at = VALUES(last_match_at)",
-          [playerA, playerB]
-        );
+        await upsertPairStats(trx, playerA, playerB, { draws: 1 });
         await Promise.all([
           trx("janken_rating")
             .where({ user_id: p1UserId })
@@ -370,10 +376,11 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
     ]);
 
     const [playerA, playerB] = orderedPair(p1UserId, p2UserId);
-    const priorPairStats = (await trx("janken_pair_stats")
+    const priorPairStats = await trx("janken_pair_stats")
       .where({ player_a: playerA, player_b: playerB })
       .forUpdate()
-      .first()) || { matches: 0, a_wins: 0, b_wins: 0, draws: 0 };
+      .first();
+    const pairDampening = exports.calculatePairDampening(priorPairStats);
 
     const [p1Rating, p2Rating] = await Promise.all([
       trx("janken_rating").where({ user_id: p1UserId }).forUpdate().first(),
@@ -387,10 +394,7 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
       p2Rating.elo,
       p1Result,
       betAmount,
-      {
-        streak: p1Streak,
-        pairStats: priorPairStats,
-      }
+      { streak: p1Streak, pairDampening }
     );
     const p2Result = p1Result === "win" ? "lose" : "win";
     const p2EloChange = exports.calculateEloChange(
@@ -398,10 +402,7 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
       p1Rating.elo,
       p2Result,
       betAmount,
-      {
-        streak: p2Streak,
-        pairStats: priorPairStats,
-      }
+      { streak: p2Streak, pairDampening }
     );
 
     const p1NewElo = Math.max(0, p1Rating.elo + p1EloChange);
@@ -412,15 +413,10 @@ exports.updateElo = async function (p1UserId, p2UserId, p1Result, betAmount) {
 
     const winnerIsA =
       (p1Result === "win" && p1UserId === playerA) || (p1Result === "lose" && p2UserId === playerA);
-    await trx.raw(
-      "INSERT INTO janken_pair_stats (player_a, player_b, matches, a_wins, b_wins, last_match_at) " +
-        "VALUES (?, ?, 1, ?, ?, NOW()) " +
-        "ON DUPLICATE KEY UPDATE matches = matches + 1, " +
-        "a_wins = a_wins + VALUES(a_wins), " +
-        "b_wins = b_wins + VALUES(b_wins), " +
-        "last_match_at = VALUES(last_match_at)",
-      [playerA, playerB, winnerIsA ? 1 : 0, winnerIsA ? 0 : 1]
-    );
+    await upsertPairStats(trx, playerA, playerB, {
+      aWins: winnerIsA ? 1 : 0,
+      bWins: winnerIsA ? 0 : 1,
+    });
 
     await Promise.all([
       trx("janken_rating")
@@ -487,20 +483,19 @@ exports.calculateEloChange = function (
   opponentElo,
   result,
   betAmount,
-  { streak = 0, pairStats = null } = {}
+  { streak = 0, pairDampening = 1 } = {}
 ) {
   if (result === "draw") return 0;
   const K = JankenRating.getKFactor(betAmount);
   const expected = exports.calculateExpectedWinRate(myElo, opponentElo);
   const actual = result === "win" ? 1 : 0;
   const raw = K * (actual - expected);
-  const pairDamp = exports.calculatePairDampening(pairStats || {});
   if (raw >= 0) {
     const multiplier = result === "win" ? exports.getStreakMultiplier(streak) : 1;
-    return Math.floor(raw * multiplier * pairDamp);
+    return Math.floor(raw * multiplier * pairDampening);
   }
   const lossFactor = config.get("minigame.janken.elo.lossFactor");
-  return Math.ceil(raw * lossFactor * pairDamp);
+  return Math.ceil(raw * lossFactor * pairDampening);
 };
 
 exports.submitArenaChallenge = async function (groupId, holderUserId, challengerUserId, choice) {


### PR DESCRIPTION
## Summary

兩道互補的反自刷機制，僅在「同一對玩家反覆對戰且勝負一面倒」時觸發；正常 50/50 重複對戰完全無感。

- **`janken_pair_stats` 表**（新）+ `calculatePairDampening`：依該對歷史場數與勝率偏差，把 Elo 變動縮放至 [0, 1]。50/50 一定回傳 1。場數低於門檻（預設 3）也回傳 1。
- **`janken_rating.last_won_opponent_id`**（新欄位）：贏家若打的對象與上一場連勝對手相同，`streak` 不增加（連帶 bounty 也不會累積）；輸家 `streak` 歸零時同步清掉這欄。

## 為什麼

從 production 賽季首日資料抓到一對玩家在 3 分 29 秒內以 100/0 比分打 22 場 bet 對戰，把主帳號從 Elo 1000 一路推到 1208 / challenger / 22 連勝，佔當日全站對戰 69%。

## 行為對照

| 場景 | 影響 |
|---|---|
| 正常 50/50 反覆挑戰 | 無感（dampening = 1） |
| 同對手連續挑戰但勝率均衡 | 無感 |
| 偶爾有人連續贏同對手 1–2 場 | 無感（threshold gate） |
| 持續單向洗（10 場 100/0） | Elo 變動 ×0.33 |
| 持續單向洗（20 場 100/0） | Elo 變動 ×0.20 |
| 任何同對手連勝 | streak 不再累積 → bounty 不再累積 |

## 設定

```json
"minigame.janken.pairDampening": {
  "matchesThreshold": 3,
  "biasMultiplier": 0.2
}
```

## Test plan

- [x] `yarn lint` 全乾淨
- [x] `yarn test` — 622 passed（其中 janken: 48 passed，含 11 條新測試覆蓋 `calculatePairDampening`、套用 dampening 後的 `calculateEloChange`、`updateStreaks` 對手切換閘）
- [ ] 部署後跑 `yarn migrate`（新增表 + alter column，janken_rating 規模小，預期秒級完成）
- [ ] 賽季排行榜上現有自刷污染資料須另行 SQL 清理（不在這個 PR 範圍）

🤖 Generated with [Claude Code](https://claude.com/claude-code)