### PR TITLE
feat(observability): per-stage timing middleware for webhook chain

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -35,6 +35,7 @@ const SubscribeController = require("./controller/application/SubscribeControlle
 const OpenaiController = require("./controller/application/OpenaiController");
 const JobController = require("./controller/application/JobController");
 const { transfer } = require("./middleware/dcWebhook");
+const { withTiming, wrapChain } = require("./middleware/timing");
 const redis = require("./util/redis");
 const i18n = require("./util/i18n");
 const traffic = require("./util/traffic");
@@ -409,24 +410,26 @@ function Nothing(context) {
 
 async function App(context) {
   traffic.recordPeople(context);
-  return chain([
-    setProfile, // 設置各式用戶資料
-    statistics, // 數據蒐集
-    recordLatestGroupUser, // 紀錄最近群組用戶
-    lineEvent, // 事件處理
-    config, // 設置群組設定檔
-    transfer, // Discord Webhook轉發
-    HandlePostback, // 處理postback事件
-    rateLimit, // 限制使用者指令速度
-    alias,
-    umamiTrack, // Umami 事件追蹤
-    GlobalOrderBase, // 全群指令分析
-    OrderBased, // 指令分析
-    CustomerOrderBased, // 自訂指令分析
-    interactWithBot, // 標記機器人回應
-    OpenaiController.recordSession, // 記錄對話
-    Nothing, // 無符合事件
-  ]);
+  return wrapChain(
+    chain([
+      withTiming("setProfile", setProfile),
+      withTiming("statistics", statistics),
+      withTiming("recordLatestGroupUser", recordLatestGroupUser),
+      withTiming("lineEvent", lineEvent),
+      withTiming("config", config),
+      withTiming("transfer", transfer),
+      withTiming("HandlePostback", HandlePostback),
+      withTiming("rateLimit", rateLimit),
+      withTiming("alias", alias),
+      withTiming("umamiTrack", umamiTrack),
+      withTiming("GlobalOrderBase", GlobalOrderBase),
+      withTiming("OrderBased", OrderBased),
+      withTiming("CustomerOrderBased", CustomerOrderBased),
+      withTiming("interactWithBot", interactWithBot),
+      withTiming("recordSession", OpenaiController.recordSession),
+      Nothing,
+    ])
+  );
 }
 
 module.exports = App;

--- a/app/src/middleware/timing.js
+++ b/app/src/middleware/timing.js
@@ -1,0 +1,106 @@
+const { performance } = require("perf_hooks");
+const { DefaultLogger } = require("../util/Logger");
+
+const ENABLED = process.env.TIMING_DISABLED !== "1";
+const SLOW_STAGE_MS = Number(process.env.TIMING_SLOW_STAGE_MS || 50);
+const SLOW_TOTAL_MS = Number(process.env.TIMING_SLOW_TOTAL_MS || 150);
+const SLOW_API_MS = Number(process.env.TIMING_SLOW_API_MS || 200);
+const STAGE_REPORT_THRESHOLD_MS = 5;
+
+const timingMap = new WeakMap();
+const PATCHED = Symbol("timing.patched");
+
+function getEventLabel(context) {
+  try {
+    const ev = context.event;
+    if (ev.isText) return `text:${(ev.text || "").slice(0, 24)}`;
+    if (ev.isPayload) {
+      try {
+        const action = JSON.parse(ev.payload).action;
+        return `postback:${action || "?"}`;
+      } catch {
+        return "postback";
+      }
+    }
+    return (ev._rawEvent && ev._rawEvent.type) || "event";
+  } catch {
+    return "event";
+  }
+}
+
+function ensureEntry(context) {
+  let entry = timingMap.get(context);
+  if (!entry) {
+    entry = { start: performance.now(), stages: [] };
+    timingMap.set(context, entry);
+  }
+  return entry;
+}
+
+function withTiming(name, mw) {
+  if (!ENABLED) return mw;
+  return async (context, props) => {
+    const entry = ensureEntry(context);
+    const start = performance.now();
+    try {
+      return await mw(context, props);
+    } finally {
+      const dur = performance.now() - start;
+      entry.stages.push([name, dur]);
+      if (dur >= SLOW_STAGE_MS) {
+        DefaultLogger.info(
+          `[timing] stage=${name} dur=${dur.toFixed(1)}ms event=${getEventLabel(context)}`
+        );
+      }
+    }
+  };
+}
+
+function wrapChain(chainAction) {
+  if (!ENABLED) return chainAction;
+  return async (context, props) => {
+    const entry = ensureEntry(context);
+    if (context && context.client) patchLineClient(context.client);
+    try {
+      return await chainAction(context, props);
+    } finally {
+      const total = performance.now() - entry.start;
+      const stagesSum = entry.stages.reduce((sum, [, d]) => sum + d, 0);
+      const unaccounted = total - stagesSum;
+      if (total >= SLOW_TOTAL_MS) {
+        const breakdown = entry.stages
+          .filter(([, d]) => d >= STAGE_REPORT_THRESHOLD_MS)
+          .map(([n, d]) => `${n}=${d.toFixed(0)}`)
+          .join(" ");
+        DefaultLogger.info(
+          `[timing] total=${total.toFixed(0)}ms unaccounted=${unaccounted.toFixed(0)}ms event=${getEventLabel(context)} | ${breakdown}`
+        );
+      }
+    }
+  };
+}
+
+function patchLineClient(client) {
+  if (!ENABLED || !client || client[PATCHED]) return;
+  client[PATCHED] = true;
+
+  const wrap = methodName => {
+    const original = client[methodName];
+    if (typeof original !== "function") return;
+    client[methodName] = async function (...args) {
+      const start = performance.now();
+      try {
+        return await original.apply(this, args);
+      } finally {
+        const dur = performance.now() - start;
+        if (dur >= SLOW_API_MS) {
+          DefaultLogger.info(`[timing] line-api=${methodName} dur=${dur.toFixed(0)}ms`);
+        }
+      }
+    };
+  };
+
+  ["replyMessage", "pushMessage", "multicast", "broadcast"].forEach(wrap);
+}
+
+module.exports = { withTiming, wrapChain, patchLineClient };


### PR DESCRIPTION
## Summary
- 加一支 `withTiming(name, mw)` middleware 包裝器，把 Bottender chain 內每一層 (`setProfile`、`statistics`、`config`、`OrderBased`…) 的耗時印到 log
- `wrapChain` 包整條，回報總耗時 + per-stage breakdown + `unaccounted` 欄位（差距大致就是 LINE reply API 與 framework overhead）
- Lazy patch `LineClient.replyMessage` / `pushMessage` / `multicast` / `broadcast` — LINE API 自身的延遲也獨立印出
- 預設只印超過閾值的訊息（stage 50ms / total 150ms / api 200ms），閾值與開關都用環境變數控制

## 動機
最近 reply 有感變慢，但完全沒有 per-stage 計時可以指認瓶頸。現有 `statistics` middleware 在每則文字訊息同步 await 多個 `AchievementEngine.evaluate`（hot path #2），是頭號嫌犯，但需要實際 log 證據才能斷言。這支 middleware 是最低成本的 instrumentation，跑一兩天就能定位。

## Log 格式範例
```
[timing] stage=statistics dur=87.3ms event=text:#我的狀態
[timing] line-api=replyMessage dur=243ms
[timing] total=410ms unaccounted=80ms event=text:#我的狀態 | setProfile=12 statistics=87 config=18 OrderBased=213
```

## 環境變數
| Var | Default | 用途 |
|---|---|---|
| `TIMING_DISABLED=1` | off | 全關 |
| `TIMING_SLOW_STAGE_MS` | 50 | per-stage 超過才印 |
| `TIMING_SLOW_TOTAL_MS` | 150 | 總時間超過才印 breakdown |
| `TIMING_SLOW_API_MS` | 200 | LINE API call 超過才印 |

## Test plan
- [x] `yarn lint` 過
- [x] `node -c` syntax check 過
- [x] 本地 smoke test 確認 `withTiming` / `wrapChain` 數值正確、return value 正確傳遞
- [ ] Merge 後在本地 `yarn dev` 戳幾個指令，確認 log 真的有出現
- [ ] Production 跑一兩天觀察 `stage=statistics` 與 `unaccounted` 欄位
- [ ] 根據觀察結果決定下一步（最可能是把 `AchievementEngine.evaluate` 改 fire-and-forget）

🤖 Generated with [Claude Code](https://claude.com/claude-code)