### PR TITLE
perf(statistics): fire-and-forget achievement evaluation + tune timing thresholds

### DIFF
--- a/app/src/middleware/statistics.js
+++ b/app/src/middleware/statistics.js
@@ -3,72 +3,80 @@ const { io } = require("../util/connection");
 const redis = require("../util/redis");
 const AchievementEngine = require("../service/AchievementEngine");
 const { notifyUnlocks } = require("../service/achievementNotifier");
+const { DefaultLogger } = require("../util/Logger");
 const MessageIO = io.of("/admin/messages");
 
 const COMMAND_PREFIX_RE = /^[/#.]\p{L}/u;
 
-/**
- * 數據紀錄
- * @param {Context} context
- * @param {Object} props
- */
+// 解鎖通知與主指令回應同樣依賴 LINE reply token，原本同步 await 會在
+// 「指令訊息又同時觸發成就解鎖」的少數情境下用掉 token，導致主指令回應失敗。
+// 改為 fire-and-forget 後失敗模式翻轉：主指令一定能回，少數成就通知可能丟。
+// 換來的好處是每則訊息的 reply 不再被成就 DB 評估卡住（觀察 p50 ~200ms）。
 const statistics = async (context, props) => {
   eventFire(context);
+  runBackground(context).catch(err => DefaultLogger.error("statistics background error:", err));
+  return props.next;
+};
+
+async function runBackground(context) {
   await eventEnqueue(context);
+  if (!context.event.isText) return;
 
-  if (context.event.isText) {
-    const userId = context.event.source.userId;
-    const groupId = context.event.source.groupId;
-    if (userId) {
-      const mentionees = get(context, "event.message.mention.mentionees", []);
-      const mentionedUserIds = mentionees.map(m => m && m.userId).filter(Boolean);
-      const text = context.event.text || "";
+  const userId = context.event.source.userId;
+  const groupId = context.event.source.groupId;
+  if (!userId) return;
 
-      const unlocksByUser = { [userId]: [] };
-      const evaluations = [
-        AchievementEngine.evaluate(userId, "chat_message", { groupId, text, feature: "chat" })
-          .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
-          .catch(() => {}),
-      ];
-      if (COMMAND_PREFIX_RE.test(text)) {
-        evaluations.push(
-          AchievementEngine.evaluate(userId, "command_use", {})
-            .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
-            .catch(() => {})
-        );
-      }
-      if (mentionedUserIds.length) {
-        evaluations.push(
-          AchievementEngine.evaluate(userId, "mention_keyword", {
-            mentionedUserIds,
-            text,
-          })
-            .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
-            .catch(() => {})
-        );
-        for (const mentioneeId of mentionedUserIds) {
-          unlocksByUser[mentioneeId] = unlocksByUser[mentioneeId] || [];
-          evaluations.push(
-            AchievementEngine.evaluate(mentioneeId, "received_mention", {
-              mentionedByUserId: userId,
-              text,
-              groupId,
-            })
-              .then(r => unlocksByUser[mentioneeId].push(...((r && r.unlocked) || [])))
-              .catch(() => {})
-          );
-        }
-      }
+  const mentionees = get(context, "event.message.mention.mentionees", []);
+  const mentionedUserIds = mentionees.map(m => m && m.userId).filter(Boolean);
+  const text = context.event.text || "";
 
-      await Promise.all(evaluations);
-      for (const [uid, unlocked] of Object.entries(unlocksByUser)) {
-        if (unlocked.length) await notifyUnlocks(context, uid, unlocked);
-      }
+  const unlocksByUser = { [userId]: [] };
+  const evaluations = [
+    AchievementEngine.evaluate(userId, "chat_message", { groupId, text, feature: "chat" })
+      .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
+      .catch(() => {}),
+  ];
+  if (COMMAND_PREFIX_RE.test(text)) {
+    evaluations.push(
+      AchievementEngine.evaluate(userId, "command_use", {})
+        .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
+        .catch(() => {})
+    );
+  }
+  if (mentionedUserIds.length) {
+    evaluations.push(
+      AchievementEngine.evaluate(userId, "mention_keyword", {
+        mentionedUserIds,
+        text,
+      })
+        .then(r => unlocksByUser[userId].push(...((r && r.unlocked) || [])))
+        .catch(() => {})
+    );
+    for (const mentioneeId of mentionedUserIds) {
+      unlocksByUser[mentioneeId] = unlocksByUser[mentioneeId] || [];
+      evaluations.push(
+        AchievementEngine.evaluate(mentioneeId, "received_mention", {
+          mentionedByUserId: userId,
+          text,
+          groupId,
+        })
+          .then(r => unlocksByUser[mentioneeId].push(...((r && r.unlocked) || [])))
+          .catch(() => {})
+      );
     }
   }
 
-  return props.next;
-};
+  await Promise.all(evaluations);
+  for (const [uid, unlocked] of Object.entries(unlocksByUser)) {
+    if (unlocked.length) {
+      try {
+        await notifyUnlocks(context, uid, unlocked);
+      } catch (err) {
+        DefaultLogger.error("notifyUnlocks failed:", err);
+      }
+    }
+  }
+}
 
 module.exports = statistics;
 

--- a/app/src/middleware/statistics.js
+++ b/app/src/middleware/statistics.js
@@ -8,10 +8,9 @@ const MessageIO = io.of("/admin/messages");
 
 const COMMAND_PREFIX_RE = /^[/#.]\p{L}/u;
 
-// 解鎖通知與主指令回應同樣依賴 LINE reply token，原本同步 await 會在
-// 「指令訊息又同時觸發成就解鎖」的少數情境下用掉 token，導致主指令回應失敗。
-// 改為 fire-and-forget 後失敗模式翻轉：主指令一定能回，少數成就通知可能丟。
-// 換來的好處是每則訊息的 reply 不再被成就 DB 評估卡住（觀察 p50 ~200ms）。
+// 成就評估在 background 跑，避免主回應被 DB 工作擋住。
+// Trade-off: 當指令訊息同時解鎖成就時，成就通知會與主回應搶同一個 reply token；
+// 這時通知會丟失，但主回應一定能送出（我們接受失去通知，不接受失去主回應）。
 const statistics = async (context, props) => {
   eventFire(context);
   runBackground(context).catch(err => DefaultLogger.error("statistics background error:", err));
@@ -68,13 +67,7 @@ async function runBackground(context) {
 
   await Promise.all(evaluations);
   for (const [uid, unlocked] of Object.entries(unlocksByUser)) {
-    if (unlocked.length) {
-      try {
-        await notifyUnlocks(context, uid, unlocked);
-      } catch (err) {
-        DefaultLogger.error("notifyUnlocks failed:", err);
-      }
-    }
+    if (unlocked.length) await notifyUnlocks(context, uid, unlocked);
   }
 }
 

--- a/app/src/middleware/timing.js
+++ b/app/src/middleware/timing.js
@@ -3,8 +3,12 @@ const { DefaultLogger } = require("../util/Logger");
 
 const ENABLED = process.env.TIMING_DISABLED !== "1";
 const SLOW_STAGE_MS = Number(process.env.TIMING_SLOW_STAGE_MS || 50);
-const SLOW_TOTAL_MS = Number(process.env.TIMING_SLOW_TOTAL_MS || 150);
-const SLOW_API_MS = Number(process.env.TIMING_SLOW_API_MS || 200);
+// 觀察期間預設 150ms 太高（setProfile 單一 stage 就常常 130ms+），導致 total
+// breakdown 永遠不印；降到 50ms 與 stage 對齊，這樣只要任何 stage 觸發就一定看到 total。
+const SLOW_TOTAL_MS = Number(process.env.TIMING_SLOW_TOTAL_MS || 50);
+// LINE reply API 在群組 reply 通常 50–150ms，舊閾值 200ms 幾乎不會觸發；
+// 降到 100ms 後可以及早發現 LINE 端慢化。
+const SLOW_API_MS = Number(process.env.TIMING_SLOW_API_MS || 100);
 const STAGE_REPORT_THRESHOLD_MS = 5;
 
 const timingMap = new WeakMap();

--- a/app/src/middleware/timing.js
+++ b/app/src/middleware/timing.js
@@ -3,11 +3,9 @@ const { DefaultLogger } = require("../util/Logger");
 
 const ENABLED = process.env.TIMING_DISABLED !== "1";
 const SLOW_STAGE_MS = Number(process.env.TIMING_SLOW_STAGE_MS || 50);
-// 觀察期間預設 150ms 太高（setProfile 單一 stage 就常常 130ms+），導致 total
-// breakdown 永遠不印；降到 50ms 與 stage 對齊，這樣只要任何 stage 觸發就一定看到 total。
+// 與 SLOW_STAGE_MS 對齊：任何 stage 觸發時，總時間 breakdown 也會印出。
 const SLOW_TOTAL_MS = Number(process.env.TIMING_SLOW_TOTAL_MS || 50);
-// LINE reply API 在群組 reply 通常 50–150ms，舊閾值 200ms 幾乎不會觸發；
-// 降到 100ms 後可以及早發現 LINE 端慢化。
+// LINE reply 在群組通常 50–150ms，超過此閾值代表 LINE 端疑似有延遲。
 const SLOW_API_MS = Number(process.env.TIMING_SLOW_API_MS || 100);
 const STAGE_REPORT_THRESHOLD_MS = 5;
 


### PR DESCRIPTION
## Summary
- 把 `statistics` middleware 內的 `eventEnqueue` + 多個 `AchievementEngine.evaluate` + `notifyUnlocks` 全部移到 background promise，不再 await。reply chain 立刻往下走。
- 配套：`timing` middleware 的 `SLOW_TOTAL_MS` 預設 150 → 50、`SLOW_API_MS` 預設 200 → 100，讓 total/LINE API 的延遲更容易被觀察到。

## 為什麼
觀察 agent 報告的 timing log 顯示 `stage=statistics` p50 ≈ 207ms，p95 ≈ 257ms。每則文字訊息的 reply 都被卡在成就 DB 評估上。

## 已知 trade-off（重要）
原本的程式碼在「指令訊息又同時觸發成就解鎖」的少數情境下其實已經是壞的：
- 舊行為：`statistics` 先打 `notifyUnlocks` → 用掉 reply token → 後續 `OrderBased` 的主回應靜默失敗
- 新行為：主回應一定能打成功 → 背景 `notifyUnlocks` 落後幾百 ms 才送，reply token 已被用 → 成就通知靜默失敗

換句話說失敗模式翻轉了，但翻向我們更不在意的那一邊（沒人會抱怨「沒收到成就通知」，但會抱怨「指令沒回應」）。**真正乾淨的解法是把成就通知 batch 進主回應**，那是更大的重構，留給未來 PR。

## 副作用：CRLF → LF
`app/src/middleware/statistics.js` 原本是 CRLF（middleware/ 目錄下唯一一個），現在被正規化為 LF 與其他檔案一致。實際邏輯變更只有約 30 行：

```bash
git diff -w main..perf/statistics-fire-and-forget app/src/middleware/statistics.js
```

## Test plan
- [x] `yarn lint` 過
- [x] `node -c` syntax check 過
- [ ] Merge 後本地 `yarn dev`，發訊息驗證 `[timing] stage=statistics` p50 顯著下降
- [ ] 跑一兩天觀察 `[timing] total=` 是否能穩定看到（threshold 已調低）
- [ ] 手動測試：指令訊息能正常回應；解成就的訊息（首次發言）能看到通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)