### PR TITLE
fix(worker): hoist bottender getClient to stop ioredis socket leak

### DIFF
--- a/app/bin/BroadcastQueueDrainer.js
+++ b/app/bin/BroadcastQueueDrainer.js
@@ -6,6 +6,12 @@ const replyTokenQueue = require("../src/util/replyTokenQueue");
 
 const KEY_PREFIX = "BROADCAST_QUEUE_";
 
+// bottender 1.x getClient() is NOT memoized — every call constructs a fresh
+// LineBot whose RedisSessionStore opens a new ioredis socket that's never
+// quit() when the bot reference is GC'd. Resolve once at module load so each
+// 30s drainAll tick doesn't leak a connection.
+const lineClient = getClient("line");
+
 let running = false;
 
 async function main() {
@@ -21,7 +27,6 @@ async function main() {
 }
 
 async function drainAll() {
-  const lineClient = getClient("line");
   const iterator = redis.scanIterator({ MATCH: `${KEY_PREFIX}*`, COUNT: 100 });
 
   for await (const key of iterator) {

--- a/app/bin/EventDequeue.js
+++ b/app/bin/EventDequeue.js
@@ -5,6 +5,12 @@ const replyTokenQueue = require("../src/util/replyTokenQueue");
 const broadcastQueue = require("../src/util/broadcastQueue");
 const { getClient } = require("bottender");
 
+// bottender 1.x getClient() is NOT memoized — every call constructs a fresh
+// LineBot whose RedisSessionStore opens a new ioredis socket that's never
+// quit() when the bot reference is GC'd. Resolve once at module load so the
+// hot per-event path doesn't leak a connection per call.
+const lineClient = getClient("line");
+
 module.exports = main;
 
 let running = false;
@@ -66,7 +72,6 @@ function tryDrainBroadcast(event) {
   const { type } = event.source;
   if (type !== "group" && type !== "room") return;
   const sourceId = event.source[`${type}Id`];
-  const lineClient = getClient("line");
   broadcastQueue
     .drain(sourceId, { lineClient, replyTokenQueue, logger: DefaultLogger })
     .catch(err => console.error("[EventDequeue.tryDrainBroadcast]", err));

--- a/app/bin/__tests__/BroadcastQueueDrainer.test.js
+++ b/app/bin/__tests__/BroadcastQueueDrainer.test.js
@@ -1,0 +1,29 @@
+// Regression: bottender@1.5.5 `getClient()` is not memoized — each call opens
+// a fresh ioredis session-store socket that's never quit() when the bot
+// reference is GC'd. drainAll runs every 30s from cron, so calling getClient
+// inside its body would leak a Redis connection per tick.
+
+describe("bin/BroadcastQueueDrainer ioredis leak guard", () => {
+  let mockBottender;
+  let main;
+
+  beforeAll(() => {
+    jest.resetModules();
+    mockBottender = require("bottender");
+    const mockRedis = require("../../src/util/redis");
+    mockRedis.scanIterator = jest.fn(() => (async function* () {})());
+    main = require("../BroadcastQueueDrainer");
+  });
+
+  it("requires getClient exactly once at module load", () => {
+    expect(mockBottender.getClient).toHaveBeenCalledTimes(1);
+    expect(mockBottender.getClient).toHaveBeenCalledWith("line");
+  });
+
+  it("never reinvokes getClient when main runs repeatedly", async () => {
+    for (let i = 0; i < 10; i++) {
+      await main();
+    }
+    expect(mockBottender.getClient).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/bin/__tests__/EventDequeue.test.js
+++ b/app/bin/__tests__/EventDequeue.test.js
@@ -1,0 +1,37 @@
+// Regression: bottender@1.5.5 `getClient()` is not memoized — each call opens
+// a fresh ioredis session-store socket that's never quit() when the bot
+// reference is GC'd. The worker's `tryDrainBroadcast` runs per inbound
+// group/room message, so calling getClient inside the function body leaks
+// a Redis connection per event (production: ~10k connections in 18h →
+// maxclients ceiling). This test guards the hoist to module load.
+
+describe("bin/EventDequeue ioredis leak guard", () => {
+  let mockBottender;
+  let bin;
+
+  beforeAll(() => {
+    jest.resetModules();
+    // Grab the fresh mock factory instance AFTER resetModules — the bin
+    // script will receive the same instance because both requires happen
+    // post-reset.
+    mockBottender = require("bottender");
+    bin = require("../EventDequeue");
+  });
+
+  it("requires getClient exactly once at module load", () => {
+    expect(mockBottender.getClient).toHaveBeenCalledTimes(1);
+    expect(mockBottender.getClient).toHaveBeenCalledWith("line");
+  });
+
+  it("never reinvokes getClient when tryDrainBroadcast fires repeatedly", () => {
+    const event = {
+      source: { type: "group", groupId: "Cabcdef0123456789abcdef0123456789" },
+    };
+
+    for (let i = 0; i < 50; i++) {
+      bin.__testing.tryDrainBroadcast(event);
+    }
+
+    expect(mockBottender.getClient).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

bottender@1.5.5 `getClient()` is **not memoized** — every call constructs a fresh `LineBot` whose `RedisSessionStore` opens a new ioredis socket that is never `quit()` when the bot reference is GC'd.

The worker had two hot paths calling it inside a function body:

- `bin/EventDequeue.js#tryDrainBroadcast` — fires per inbound group/room message
- `bin/BroadcastQueueDrainer.js#drainAll` — fires every 30s from cron

Hoisting `getClient("line")` to module top so each bin script creates exactly one ioredis instance for the worker process lifetime (same contract the 14 `src/` call sites already follow).

## Production observation

- Steady-state leak: **~5–6 ioredis connections / min** in low-traffic period (matches BroadcastQueueDrainer 2/min + group messages 4/min). Higher under chat peak.
- `redive_linebot-worker-1` hit Redis `maxclients` (~10000) after ~18 hours, taking down bot + every other Redis-dependent service.
- `CLIENT LIST` fingerprint of leaked instances: `cmd=info, idle≈age` — created during ioredis `_readyCheck`, then orphaned (never reused).
- The 5–6k EPIPE/min "storm" observed at the ceiling was a **symptom**, not the cause: every leaked instance simultaneously retried its readyCheck once Redis refused new connections. Restart freed the FDs and the storm cleared in <10 min, while the underlying leak continued at 5–6/min until this fix.

## Test plan

- [x] `yarn test bin/__tests__/EventDequeue.test.js bin/__tests__/BroadcastQueueDrainer.test.js` — 4/4 pass
- [x] `yarn lint` — clean
- [x] `node --check` on both patched bin scripts — syntax OK
- [x] Full `yarn test` — no new failures (16 pre-existing `ECONNREFUSED 127.0.0.1:3306` are local-infra-only, unrelated)
- [ ] After deploy, confirm worker connection count is stable: `docker exec infra-redis-1 redis-cli -a "$REDIS_PASSWORD" CLIENT LIST | grep -c worker` should plateau at ~15–20 (one per top-level `getClient` call site loaded into the worker process), not grow over time
- [ ] Verify zero EPIPE storm in worker logs over the next 24h: `docker logs redive_linebot-worker-1 --since 24h 2>&1 | grep -ci epipe`

## Out of scope

- Long-term `bottender` 1.x → 2.x upgrade (separate effort — large API surface change)
- Hardening `app/src/util/redis.js` with explicit `reconnectStrategy` / `pingInterval` / `keepAlive` (good to have, but unrelated to this leak; was the wrong root cause in the original investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)