### PR TITLE
fix(observability): unwrap dialog loop inside wrapChain so total= log fires

### DIFF
--- a/app/src/middleware/__tests__/timing.test.js
+++ b/app/src/middleware/__tests__/timing.test.js
@@ -1,0 +1,85 @@
+// Use the real bottender chain (setup.js stubs it for other suites).
+const { chain } = jest.requireActual("bottender");
+const { withTiming, wrapChain } = require("../timing");
+const { DefaultLogger } = require("../../util/Logger");
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+function makeContext() {
+  return { event: { isText: true, text: "test" }, client: null };
+}
+
+// Faithful copy of bottender Bot.run's dialog driver loop. Bottender's
+// `chain()` is a builder, not a runner: it returns the first bound action,
+// and Bot.run is what unwraps the dialog chain. Tests must do the same.
+async function runDialog(action, context) {
+  let next = await action(context, {});
+  while (typeof next === "function") {
+    next = await next(context, {});
+  }
+  return next;
+}
+
+function getInfoLogs() {
+  return DefaultLogger.info.mock.calls.map(args => args[0]);
+}
+
+describe("timing middleware", () => {
+  beforeEach(() => {
+    DefaultLogger.info.mockClear();
+  });
+
+  describe("wrapChain", () => {
+    it("logs total= after the chain actually finishes (regression: chain is a builder, not a runner)", async () => {
+      const ctx = makeContext();
+      const wrapped = wrapChain(
+        chain([
+          withTiming("m1", async (_c, p) => {
+            await sleep(80);
+            return p.next;
+          }),
+          withTiming("m2", async (_c, p) => {
+            await sleep(60);
+            return p.next;
+          }),
+          () => null,
+        ])
+      );
+
+      await runDialog(wrapped, ctx);
+
+      const totalLog = getInfoLogs().find(l => l.startsWith("[timing] total="));
+      expect(totalLog).toBeDefined();
+
+      const total = Number(totalLog.match(/total=(\d+)ms/)[1]);
+      expect(total).toBeGreaterThanOrEqual(120);
+
+      expect(totalLog).toMatch(/m1=\d+/);
+      expect(totalLog).toMatch(/m2=\d+/);
+    });
+
+    it("propagates the chain's terminal value back to the caller", async () => {
+      const ctx = makeContext();
+      const sentinel = { done: true };
+      const wrapped = wrapChain(
+        chain([withTiming("only", async (_c, p) => p.next), () => sentinel])
+      );
+
+      const result = await runDialog(wrapped, ctx);
+      expect(result).toBe(sentinel);
+    });
+  });
+
+  describe("withTiming", () => {
+    it("logs stage= when a stage exceeds the slow threshold", async () => {
+      const ctx = makeContext();
+      const slow = withTiming("slow-stage", async () => {
+        await sleep(80);
+      });
+
+      await slow(ctx, {});
+
+      expect(getInfoLogs().some(l => l.startsWith("[timing] stage=slow-stage"))).toBe(true);
+    });
+  });
+});

--- a/app/src/middleware/timing.js
+++ b/app/src/middleware/timing.js
@@ -64,7 +64,14 @@ function wrapChain(chainAction) {
     const entry = ensureEntry(context);
     if (context && context.client) patchLineClient(context.client);
     try {
-      return await chainAction(context, props);
+      // Bottender's `chain()` is a builder, not a runner: it returns the
+      // first bound action and Bot.run drives the dialog loop. Replicate
+      // that loop here so this finally observes the real total.
+      let nextDialog = await chainAction(context, props);
+      while (typeof nextDialog === "function") {
+        nextDialog = await nextDialog(context, {});
+      }
+      return nextDialog;
     } finally {
       const total = performance.now() - entry.start;
       const stagesSum = entry.stages.reduce((sum, [, d]) => sum + d, 0);


### PR DESCRIPTION
## Summary

Bottender's `chain()` is a **builder, not a runner** — it returns the first bound action and `Bot.run` drives the dialog loop by repeatedly calling the function each step returns. Our `wrapChain` was awaiting `chain(context, props)` directly, which resolved synchronously with `boundActions[0]` (a function) **before any middleware ran**. The `finally` then computed `total` against an empty `entry.stages` (sub-millisecond) and logged nothing, because the chain only executed afterwards under `Bot.run`'s while loop.

Replicate the dialog loop inside `wrapChain` so the chain runs to completion before the finally measures total. Behaviorally identical from `Bot.run`'s perspective: it just receives the chain's terminal value instead of a function it would have unwrapped itself.

## Why stage logs were unaffected

Each `withTiming` wrapper has its own `try/finally`, so per-stage `[timing] stage=...` logs were always correct. Only the chain-level summary log was affected. Symptom in production: setProfile p50=134.9ms / p95=325.4ms appearing in stage logs but **zero `[timing] total=` lines** in 24h despite `SLOW_TOTAL_MS=50ms`.

## Local repro before the fix

```
$ TIMING_SLOW_TOTAL_MS=50 TIMING_SLOW_STAGE_MS=30 node timing-repro.js
[timing] stage=m1 dur=79.7ms event=text:repro
[timing] stage=m2 dur=60.6ms event=text:repro
--- repro done ---
```

Total of 140ms but no `total=` line. After the fix:

```
[timing] stage=m1 dur=80.6ms event=text:repro
[timing] stage=m2 dur=61.0ms event=text:repro
[timing] total=143ms unaccounted=2ms event=text:repro | m1=81 m2=61
--- repro done ---
```

## Test plan

- [x] `yarn test src/middleware/__tests__/timing.test.js` — 3/3 pass
  - `wrapChain` logs `total=` after the chain actually finishes (regression: chain is a builder, not a runner)
  - `wrapChain` propagates the chain's terminal value back to the caller
  - `withTiming` logs `stage=` when a stage exceeds the slow threshold
- [x] `yarn lint` — clean
- [x] Full `yarn test` — no new failures (16 pre-existing `ECONNREFUSED 127.0.0.1:3306` are local-infra-only, unrelated)
- [ ] After deploy, confirm `[timing] total=` lines appear in worker/bot logs at expected rate (any webhook with stages summing >50ms should produce one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)