### PR TITLE
fix(frontend): use DeleteOutlined icon for MUI v9 compat

### DIFF
--- a/frontend/src/components/OrderDialog.jsx
+++ b/frontend/src/components/OrderDialog.jsx
@@ -27,7 +27,7 @@ import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutlined";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const IMG_RE = /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)(\?.*)?$/i;


### PR DESCRIPTION
## Summary

- `@mui/icons-material@9` (pinned in `yarn.lock` as `9.0.0`) dropped the standalone `DeleteOutline` icon — only the `*Outlined` family is shipped now.
- `frontend/src/components/OrderDialog.jsx:30` still imported `@mui/icons-material/DeleteOutline`, so the CI `frontend` Docker build failed on `rolldown:vite-resolve` after PR #713 merged to `main`.
- Switched the import to `DeleteOutlined`, matching the existing usage in `DebugOverlay.jsx`.

CI failure log (run 25608534506):
```
[rolldown:vite-resolve] Error: ...
"./DeleteOutline" is not exported under the conditions ["module", "browser", "production", "import"]
from package /app/node_modules/@mui/icons-material
```

Local `node_modules` was stale on v7 (which still shipped `DeleteOutline`), so the issue only surfaced once CI did a fresh `--frozen-lockfile` install on v9.

## Test plan

- [x] `yarn install --frozen-lockfile && yarn build` in `frontend/` (v9 actually installed) — build succeeds.
- [x] Cross-checked every other `@mui/icons-material/*` import in `frontend/src` against the v9 tarball — no other missing icons.
- [ ] CI `redive linebot CI` workflow goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)