### PR TITLE
feat(observability): knex query profiler + inline step timing

### DIFF
--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -19,6 +19,7 @@ const commonTemplate = require("../../templates/common");
 const { notifyUnlocks } = require("../../service/achievementNotifier");
 const GachaService = require("../../service/GachaService");
 const { play, filterPool, summarizePool, fmtRate } = require("../../service/gachaDrawUtil");
+const { time } = require("../../middleware/timing");
 
 function GachaException(message, code) {
   this.message = message;
@@ -93,7 +94,9 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
 
   // Europe banner pre-check — service will re-fetch internally, but controller
   // needs the cost for the stone-balance gate and the early-return text.
-  const allActiveBanners = await GachaBanner.getActiveBannersWithCharacters();
+  const allActiveBanners = await time("gacha.banners", () =>
+    GachaBanner.getActiveBannersWithCharacters()
+  );
   const europeBanners = allActiveBanners.filter(b => b.type === "europe");
   const rateUpBanners = allActiveBanners.filter(b => b.type === "rate_up");
 
@@ -123,7 +126,7 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     return;
   }
 
-  const gachaPool = await GachaModel.getDatabasePool();
+  const gachaPool = await time("gacha.pool", () => GachaModel.getDatabasePool());
   const filteredPool = filterPool(gachaPool, tag);
   // 是否為公主池
   const isPrincessPool = filteredPool.findIndex(pool => pool.isPrincess == 0) === -1;
@@ -156,7 +159,7 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
       rareCount,
       hasCooldown: type === "group",
     });
-    return context.replyFlex("轉蛋結果", bubble);
+    return time("gacha.reply.normal", () => context.replyFlex("轉蛋結果", bubble));
   };
   // 非公主轉蛋池，無法進行每日一抽，直接抽完並且發送結果
   if (!isPrincessPool) {
@@ -189,7 +192,9 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
 
   let result;
   try {
-    result = await GachaService.runDailyDraw(userId, { tag, pickup, ensure, europe });
+    result = await time("gacha.runDaily", () =>
+      GachaService.runDailyDraw(userId, { tag, pickup, ensure, europe })
+    );
   } catch (err) {
     DefaultLogger.warn(`[gacha] runDailyDraw failed for ${userId}: ${err.message}`);
     console.log(err);
@@ -211,7 +216,9 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     })
   );
 
-  const allCharactersCount = await GachaModel.getPrincessCharacterCount();
+  const allCharactersCount = await time("gacha.allChars", () =>
+    GachaModel.getPrincessCharacterCount()
+  );
 
   bubbles.unshift(
     GachaTemplate.line.generateDailyGachaInfo({
@@ -224,12 +231,14 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     })
   );
 
-  await notifyUnlocks(context, userId, result.unlocks);
+  await time("gacha.notify", () => notifyUnlocks(context, userId, result.unlocks));
 
-  return context.replyFlex("每日一抽結果", {
-    type: "carousel",
-    contents: bubbles,
-  });
+  return time("gacha.reply.daily", () =>
+    context.replyFlex("每日一抽結果", {
+      type: "carousel",
+      contents: bubbles,
+    })
+  );
 }
 
 /**

--- a/app/src/middleware/timing.js
+++ b/app/src/middleware/timing.js
@@ -1,5 +1,7 @@
+const { AsyncLocalStorage } = require("async_hooks");
 const { performance } = require("perf_hooks");
 const { DefaultLogger } = require("../util/Logger");
+const queryProfiler = require("../util/queryProfiler");
 
 const ENABLED = process.env.TIMING_DISABLED !== "1";
 const SLOW_STAGE_MS = Number(process.env.TIMING_SLOW_STAGE_MS || 50);
@@ -10,6 +12,7 @@ const SLOW_API_MS = Number(process.env.TIMING_SLOW_API_MS || 100);
 const STAGE_REPORT_THRESHOLD_MS = 5;
 
 const timingMap = new WeakMap();
+const timingAls = new AsyncLocalStorage();
 const PATCHED = Symbol("timing.patched");
 
 function getEventLabel(context) {
@@ -33,7 +36,12 @@ function getEventLabel(context) {
 function ensureEntry(context) {
   let entry = timingMap.get(context);
   if (!entry) {
-    entry = { start: performance.now(), stages: [] };
+    entry = {
+      start: performance.now(),
+      stages: [],
+      steps: [],
+      label: getEventLabel(context),
+    };
     timingMap.set(context, entry);
   }
   return entry;
@@ -58,34 +66,78 @@ function withTiming(name, mw) {
   };
 }
 
-function wrapChain(chainAction) {
-  if (!ENABLED) return chainAction;
-  return async (context, props) => {
-    const entry = ensureEntry(context);
-    if (context && context.client) patchLineClient(context.client);
-    try {
-      // Bottender's `chain()` is a builder, not a runner: it returns the
-      // first bound action and Bot.run drives the dialog loop. Replicate
-      // that loop here so this finally observes the real total.
-      let nextDialog = await chainAction(context, props);
-      while (typeof nextDialog === "function") {
-        nextDialog = await nextDialog(context, {});
-      }
-      return nextDialog;
-    } finally {
-      const total = performance.now() - entry.start;
-      const stagesSum = entry.stages.reduce((sum, [, d]) => sum + d, 0);
-      const unaccounted = total - stagesSum;
-      if (total >= SLOW_TOTAL_MS) {
-        const breakdown = entry.stages
-          .filter(([, d]) => d >= STAGE_REPORT_THRESHOLD_MS)
-          .map(([n, d]) => `${n}=${d.toFixed(0)}`)
-          .join(" ");
-        DefaultLogger.info(
-          `[timing] total=${total.toFixed(0)}ms unaccounted=${unaccounted.toFixed(0)}ms event=${getEventLabel(context)} | ${breakdown}`
-        );
-      }
+/**
+ * 在 chain stage 內部對更細的 await 段落計時。
+ * 與 withTiming 不同：steps 不參與 unaccounted 計算（避免巢狀重複），
+ * 純粹做為 breakdown 輔助線。
+ *
+ * @param {string} label
+ * @param {() => Promise<T> | T} fn
+ * @returns {Promise<T>}
+ */
+async function time(label, fn) {
+  if (!ENABLED) return fn();
+  const store = timingAls.getStore();
+  const entry = store && store.entry;
+  if (!entry) return fn();
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    const dur = performance.now() - start;
+    entry.steps.push([label, dur]);
+    if (dur >= SLOW_STAGE_MS) {
+      DefaultLogger.info(`[timing] step=${label} dur=${dur.toFixed(1)}ms event=${entry.label}`);
     }
+  }
+}
+
+function wrapChain(chainAction) {
+  if (!ENABLED && !queryProfiler.ENABLED) return chainAction;
+  return async (context, props) => {
+    const body = async () => {
+      const entry = ENABLED ? ensureEntry(context) : null;
+      if (ENABLED && context && context.client) patchLineClient(context.client);
+      const runChain = async () => {
+        try {
+          // Bottender's `chain()` is a builder, not a runner: it returns the
+          // first bound action and Bot.run drives the dialog loop. Replicate
+          // that loop here so this finally observes the real total.
+          let nextDialog = await chainAction(context, props);
+          while (typeof nextDialog === "function") {
+            nextDialog = await nextDialog(context, {});
+          }
+          return nextDialog;
+        } finally {
+          const label = getEventLabel(context);
+          if (ENABLED && entry) {
+            const total = performance.now() - entry.start;
+            const stagesSum = entry.stages.reduce((sum, [, d]) => sum + d, 0);
+            const unaccounted = total - stagesSum;
+            if (total >= SLOW_TOTAL_MS) {
+              const breakdown = entry.stages
+                .filter(([, d]) => d >= STAGE_REPORT_THRESHOLD_MS)
+                .map(([n, d]) => `${n}=${d.toFixed(0)}`)
+                .join(" ");
+              const stepsBreakdown =
+                entry.steps.length > 0
+                  ? " | steps: " +
+                    entry.steps
+                      .filter(([, d]) => d >= STAGE_REPORT_THRESHOLD_MS)
+                      .map(([n, d]) => `${n}=${d.toFixed(0)}`)
+                      .join(" ")
+                  : "";
+              DefaultLogger.info(
+                `[timing] total=${total.toFixed(0)}ms unaccounted=${unaccounted.toFixed(0)}ms event=${label} | ${breakdown}${stepsBreakdown}`
+              );
+            }
+          }
+          queryProfiler.emitSummary(label);
+        }
+      };
+      return ENABLED && entry ? timingAls.run({ entry }, runChain) : runChain();
+    };
+    return queryProfiler.ENABLED ? queryProfiler.run(body) : body();
   };
 }
 
@@ -112,4 +164,4 @@ function patchLineClient(client) {
   ["replyMessage", "pushMessage", "multicast", "broadcast"].forEach(wrap);
 }
 
-module.exports = { withTiming, wrapChain, patchLineClient };
+module.exports = { withTiming, wrapChain, patchLineClient, time };

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -26,6 +26,7 @@ const {
 } = require("./gachaDrawUtil");
 const i18n = require("../util/i18n");
 const { DefaultLogger } = require("../util/Logger");
+const { time } = require("../middleware/timing");
 
 async function handleSignin(userId) {
   const userData = await signModel.first({ filter: { user_id: userId } });
@@ -144,12 +145,14 @@ async function runDailyDraw(userId, opts = {}) {
   const { tag, pickup = false, ensure = false, europe = false } = opts;
   const times = 10;
 
-  const allActiveBanners = await GachaBanner.getActiveBannersWithCharacters();
+  const allActiveBanners = await time("rd.banners", () =>
+    GachaBanner.getActiveBannersWithCharacters()
+  );
   const rateUpBanners = allActiveBanners.filter(b => b.type === "rate_up");
   const europeBanners = allActiveBanners.filter(b => b.type === "europe");
   const activeEuropeBanner = europe && europeBanners.length > 0 ? europeBanners[0] : null;
 
-  const gachaPool = await GachaModel.getDatabasePool();
+  const gachaPool = await time("rd.pool", () => GachaModel.getDatabasePool());
   const filteredPool = filterPool(gachaPool, tag);
   const dailyPool = buildDailyPool(filteredPool, rateUpBanners, { pickup, ensure, europe });
 
@@ -225,11 +228,13 @@ async function runDailyDraw(userId, opts = {}) {
   const rawRewardIds = rewards.map(r => r.id);
   const rewardIds = uniq(rawRewardIds);
 
-  const ownItems = await inventory.knex
-    .where({ userId })
-    .select("itemId")
-    .andWhereNot("itemId", 999)
-    .orderBy("itemId", "asc");
+  const ownItems = await time("rd.inventory", () =>
+    inventory.knex
+      .where({ userId })
+      .select("itemId")
+      .andWhereNot("itemId", 999)
+      .orderBy("itemId", "asc")
+  );
   const ownItemIds = ownItems.map(item => item.itemId);
   const ownCharactersCount = ownItemIds.length;
 
@@ -243,83 +248,88 @@ async function runDailyDraw(userId, opts = {}) {
   const repeatReward = computeRepeatReward(uniqRewards, duplicateItems);
   const newCharacters = uniqRewards.filter(r => newItemIds.includes(r.id));
 
-  const trx = await inventory.transaction();
-  let gachaRecordId;
-  try {
-    if (cost.amount > 0) {
-      await trx(inventory.table).insert({
-        userId,
-        itemId: 999,
-        itemAmount: -1 * cost.amount,
-        note: cost.note,
-      });
-    }
-
-    if (newCharacters.length > 0) {
-      await trx(inventory.table).insert(
-        newCharacters.map(character => ({
+  await time("rd.tx", async () => {
+    const trx = await inventory.transaction();
+    try {
+      if (cost.amount > 0) {
+        await trx(inventory.table).insert({
           userId,
-          itemId: character.id,
-          itemAmount: 1,
-          attributes: JSON.stringify([{ key: "star", value: parseInt(character.star) }]),
-          note: i18n.__("message.gacha.new_character_note"),
-        }))
-      );
-    }
+          itemId: 999,
+          itemAmount: -1 * cost.amount,
+          note: cost.note,
+        });
+      }
 
-    if (repeatReward > 0) {
-      await trx(inventory.table).insert({
-        userId,
-        itemId: 999,
-        itemAmount: repeatReward,
-        note: i18n.__("message.gacha.repeat_reward_note"),
+      if (newCharacters.length > 0) {
+        await trx(inventory.table).insert(
+          newCharacters.map(character => ({
+            userId,
+            itemId: character.id,
+            itemAmount: 1,
+            attributes: JSON.stringify([{ key: "star", value: parseInt(character.star) }]),
+            note: i18n.__("message.gacha.new_character_note"),
+          }))
+        );
+      }
+
+      if (repeatReward > 0) {
+        await trx(inventory.table).insert({
+          userId,
+          itemId: 999,
+          itemAmount: repeatReward,
+          note: i18n.__("message.gacha.repeat_reward_note"),
+        });
+      }
+
+      const [insertedId] = await trx(GachaRecord.table).insert({
+        user_id: userId,
+        silver: rareCount[1] || 0,
+        gold: rareCount[2] || 0,
+        rainbow: rareCount[3] || 0,
+        has_new: newCharacters.length > 0 ? 1 : 0,
       });
+      const gachaRecordId = insertedId;
+
+      if (rewards.length > 0 && gachaRecordId) {
+        const newIdSet = new Set(newCharacters.map(c => c.id));
+        await trx(GachaRecordDetail.table).insert(
+          rewards.map(r => ({
+            gacha_record_id: gachaRecordId,
+            user_id: userId,
+            character_id: r.id,
+            star: parseInt(r.star),
+            is_new: newIdSet.has(r.id) ? 1 : 0,
+          }))
+        );
+      }
+
+      await trx.commit();
+    } catch (err) {
+      await trx.rollback();
+      throw err;
     }
-
-    const [insertedId] = await trx(GachaRecord.table).insert({
-      user_id: userId,
-      silver: rareCount[1] || 0,
-      gold: rareCount[2] || 0,
-      rainbow: rareCount[3] || 0,
-      has_new: newCharacters.length > 0 ? 1 : 0,
-    });
-    gachaRecordId = insertedId;
-
-    if (rewards.length > 0 && gachaRecordId) {
-      const newIdSet = new Set(newCharacters.map(c => c.id));
-      await trx(GachaRecordDetail.table).insert(
-        rewards.map(r => ({
-          gacha_record_id: gachaRecordId,
-          user_id: userId,
-          character_id: r.id,
-          star: parseInt(r.star),
-          is_new: newIdSet.has(r.id) ? 1 : 0,
-        }))
-      );
-    }
-
-    await trx.commit();
-  } catch (err) {
-    await trx.rollback();
-    throw err;
-  }
-
-  await Promise.all([
-    handleSignin(userId),
-    EventCenterService.add(EventCenterService.getEventName("daily_quest"), { userId }),
-  ]);
-
-  const { unlocked } = await AchievementEngine.evaluate(userId, "gacha_pull", {
-    threeStarCount: rareCount[3] || 0,
-    uniqueCount: ownCharactersCount + newCharacters.length,
-    pullType: europe ? "europe" : ensure ? "ensure" : pickup ? "pickup" : undefined,
-    feature: "gacha",
-  }).catch(err => {
-    DefaultLogger.warn(
-      `GachaService.runDailyDraw achievement.evaluate failed user=${userId}: ${err && err.message}`
-    );
-    return { unlocked: [] };
   });
+
+  await time("rd.side", () =>
+    Promise.all([
+      handleSignin(userId),
+      EventCenterService.add(EventCenterService.getEventName("daily_quest"), { userId }),
+    ])
+  );
+
+  const { unlocked } = await time("rd.achievement", () =>
+    AchievementEngine.evaluate(userId, "gacha_pull", {
+      threeStarCount: rareCount[3] || 0,
+      uniqueCount: ownCharactersCount + newCharacters.length,
+      pullType: europe ? "europe" : ensure ? "ensure" : pickup ? "pickup" : undefined,
+      feature: "gacha",
+    }).catch(err => {
+      DefaultLogger.warn(
+        `GachaService.runDailyDraw achievement.evaluate failed user=${userId}: ${err && err.message}`
+      );
+      return { unlocked: [] };
+    })
+  );
 
   return {
     rewards,

--- a/app/src/util/mysql.js
+++ b/app/src/util/mysql.js
@@ -10,6 +10,8 @@ const knex = require("knex")({
   pool: { min: 0, max: 10 },
 });
 
+require("./queryProfiler").attach(knex);
+
 /**
  * @returns { import("knex").Knex }
  */

--- a/app/src/util/queryProfiler.js
+++ b/app/src/util/queryProfiler.js
@@ -1,0 +1,103 @@
+const { AsyncLocalStorage } = require("async_hooks");
+const { performance } = require("perf_hooks");
+const { DefaultLogger } = require("./Logger");
+
+const ENABLED = process.env.QUERY_LOG === "1";
+const VERBOSE = process.env.QUERY_LOG_VERBOSE === "1";
+const MIN_COUNT = Number(process.env.QUERY_LOG_MIN_COUNT || 1);
+const MIN_TOTAL_MS = Number(process.env.QUERY_LOG_MIN_TOTAL_MS || 0);
+const TOP_N = Number(process.env.QUERY_LOG_TOP_N || 5);
+
+const als = new AsyncLocalStorage();
+const ATTACHED = Symbol("queryProfiler.attached");
+
+function attach(knex) {
+  if (!ENABLED || knex[ATTACHED]) return;
+  knex[ATTACHED] = true;
+
+  knex.on("query", q => {
+    const store = als.getStore();
+    if (!store) return;
+    store.pending.set(q.__knexQueryUid, {
+      sql: q.sql,
+      start: performance.now(),
+    });
+  });
+
+  knex.on("query-response", (_response, q) => finish(q, false));
+  knex.on("query-error", (_err, q) => finish(q, true));
+}
+
+function finish(q, errored) {
+  const store = als.getStore();
+  if (!store) return;
+  const uid = q && q.__knexQueryUid;
+  const pending = store.pending.get(uid);
+  if (!pending) return;
+  store.pending.delete(uid);
+  const dur = performance.now() - pending.start;
+  store.completed.push({ sql: pending.sql, dur, errored });
+  if (VERBOSE) {
+    DefaultLogger.info(
+      `[query] +${dur.toFixed(0)}ms ${errored ? "[ERR] " : ""}${shortSql(pending.sql)}`
+    );
+  }
+}
+
+function run(fn) {
+  if (!ENABLED) return fn();
+  return als.run({ pending: new Map(), completed: [] }, fn);
+}
+
+function emitSummary(label) {
+  if (!ENABLED) return;
+  const store = als.getStore();
+  if (!store) return;
+  const queries = store.completed;
+  const count = queries.length;
+  if (count < MIN_COUNT) return;
+
+  const total = queries.reduce((s, q) => s + q.dur, 0);
+  if (total < MIN_TOTAL_MS) return;
+
+  const fpCounts = new Map();
+  for (const q of queries) {
+    const fp = fingerprint(q.sql);
+    fpCounts.set(fp, (fpCounts.get(fp) || 0) + 1);
+  }
+  const dups = [...fpCounts.entries()]
+    .filter(([, n]) => n >= 2)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([fp, n]) => `${shortSql(fp, 60)}×${n}`)
+    .join(" | ");
+
+  const top = queries
+    .slice()
+    .sort((a, b) => b.dur - a.dur)
+    .slice(0, TOP_N)
+    .map(q => `  ${q.dur.toFixed(0).padStart(4)}ms ${shortSql(q.sql, 100)}`)
+    .join("\n");
+
+  DefaultLogger.info(
+    `[query] event=${label} count=${count} db=${total.toFixed(0)}ms` +
+      (dups ? ` | dups: ${dups}` : "") +
+      `\n${top}`
+  );
+}
+
+function shortSql(sql, n = 120) {
+  const s = String(sql || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+function fingerprint(sql) {
+  return String(sql || "")
+    .replace(/\s+/g, " ")
+    .replace(/\b\d+\b/g, "?")
+    .trim();
+}
+
+module.exports = { attach, run, emitSummary, als, ENABLED };


### PR DESCRIPTION
## Summary

- Adds `app/src/util/queryProfiler.js` — env-var-gated (`QUERY_LOG=1`) knex profiler that hooks the instance's `query` / `query-response` / `query-error` events and emits a per-request summary (count, total db time, slowest N, duplicate SQL fingerprints). Per-request scoping uses `AsyncLocalStorage` entered from `wrapChain`, so it captures direct `model.knex.where(...)` calls, transactions, and raw SQL — not just `Base` CRUD.
- Extends `app/src/middleware/timing.js` with a `time(label, fn)` helper for nested step timing. Steps go into a separate `entry.steps` list (not `entry.stages`) so they don't break the chain-stage `unaccounted` math.
- Instruments `controller/princess/gacha.js` and `service/GachaService.js#runDailyDraw` with named steps (`gacha.banners`, `gacha.runDaily`, `rd.tx`, `rd.achievement`, etc.) so the source of slow `#抽` requests is visible in logs.
- Default off; opt in via `QUERY_LOG=1`. `QUERY_LOG_VERBOSE=1` also prints per-query log lines. Knobs: `QUERY_LOG_MIN_COUNT`, `QUERY_LOG_MIN_TOTAL_MS`, `QUERY_LOG_TOP_N`.

### Sample output (from local `#抽`)
```
[timing] total=69ms unaccounted=45ms event=text:#抽 | config=16 | steps: rd.tx=5 rd.achievement=25 gacha.runDaily=38
[query] event=text:#抽 count=32 db=44ms | dups: select * from `user_achievement_progress` where `user_id` = …×11 | select * from `gacha_banner` where `is_active` = ? and `star…×2
     7ms INSERT INTO user_achievement_progress ...
     7ms select * from `user_achievement_progress` where `user_id` = ? and `achievement_id` = ? limit ?
     ...
```

## Test plan

- [x] `yarn lint` clean on changed files
- [x] `yarn test src/middleware/__tests__/timing.test.js` (3/3 pass)
- [x] Smoke test: profiler attached + summary emitted with sorted top-N + duplicate fingerprint detection
- [x] Smoke test: `time()` helper logs steps separately from stages without breaking `unaccounted` math
- [ ] Verify in dev: `QUERY_LOG=1 yarn dev` → `#抽` produces correlated `[timing]` + `[query]` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)