### PR TITLE
feat(frontend): redesign XP history LIFF and reorganize side nav

### DIFF
--- a/frontend/src/components/NavDrawer.jsx
+++ b/frontend/src/components/NavDrawer.jsx
@@ -31,24 +31,34 @@ import LinkIcon from "@mui/icons-material/Link";
 import CelebrationIcon from "@mui/icons-material/Celebration";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import HistoryIcon from "@mui/icons-material/History";
+import InsightsIcon from "@mui/icons-material/Insights";
 
 const mainItems = [
   { label: "首頁", path: "/", icon: HomeIcon },
   { label: "排行榜", path: "/rankings", icon: EqualizerIcon },
+];
+
+const chatLevelItems = [
   { label: "轉生之路", path: "/prestige", icon: AutoAwesomeIcon },
+  { label: "經驗歷程", path: "/xp-history", icon: InsightsIcon },
+];
+
+const princessItems = [
+  { label: "轉蛋商店", path: "/gacha/exchange", icon: StorefrontIcon },
+  { label: "轉蛋包包", path: "/bag", icon: LocalMallIcon },
+  { label: "裝備管理", path: "/equipment", icon: FitnessCenterIcon },
+];
+
+const arenaItems = [
   { label: "猜拳競技場", path: "/janken", icon: EmojiEventsIcon },
   { label: "蘭德索爾盃", path: "/race", icon: EmojiEventsIcon },
 ];
-
-const princessItems = [{ label: "轉蛋商店", path: "/gacha/exchange", icon: StorefrontIcon }];
 
 const botItems = [{ label: "使用手冊", path: "/panel/manual", icon: LibraryBooksIcon }];
 
 const personalItems = [
   { label: "我的群組", path: "/groups", icon: GroupsIcon },
   { label: "交易管理", path: "/trade/manage", icon: ShoppingBasketIcon },
-  { label: "轉蛋包包", path: "/bag", icon: LocalMallIcon },
-  { label: "裝備管理", path: "/equipment", icon: FitnessCenterIcon },
   { label: "自動設定", path: "/auto/settings", icon: AutoAwesomeIcon },
   { label: "自動行為紀錄", path: "/auto/history", icon: HistoryIcon },
 ];
@@ -125,7 +135,9 @@ export default function NavDrawer({ onClose }) {
   const location = useLocation();
   const navigate = useNavigate();
   const [openSections, setOpenSections] = useState({
+    chatLevel: false,
     princess: false,
+    arena: false,
     bot: false,
     personal: false,
     admin: false,
@@ -142,7 +154,7 @@ export default function NavDrawer({ onClose }) {
   };
 
   return (
-    <Box sx={{ width: 260, pt: 1 }}>
+    <Box sx={{ width: "100%", pt: 1, overflowX: "hidden" }}>
       <List>
         {mainItems.map(({ label, path, icon: Icon }) => (
           <ListItem key={label} disablePadding>
@@ -162,10 +174,26 @@ export default function NavDrawer({ onClose }) {
       <Divider />
 
       <NavSection
+        title="聊天等級"
+        items={chatLevelItems}
+        open={openSections.chatLevel}
+        onToggle={() => toggleSection("chatLevel")}
+        onNavigate={handleNavigate}
+        currentPath={location.pathname}
+      />
+      <NavSection
         title="公主連結"
         items={princessItems}
         open={openSections.princess}
         onToggle={() => toggleSection("princess")}
+        onNavigate={handleNavigate}
+        currentPath={location.pathname}
+      />
+      <NavSection
+        title="競技場"
+        items={arenaItems}
+        open={openSections.arena}
+        onToggle={() => toggleSection("arena")}
         onNavigate={handleNavigate}
         currentPath={location.pathname}
       />

--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -119,8 +119,9 @@ export default function MainLayout() {
           ModalProps={{ keepMounted: true }}
           sx={{
             "& .MuiDrawer-paper": {
-              width: DRAWER_WIDTH,
+              width: `min(${DRAWER_WIDTH}px, 86vw)`,
               boxSizing: "border-box",
+              overflowX: "hidden",
             },
           }}
         >

--- a/frontend/src/pages/XpHistory/BreakdownRow.jsx
+++ b/frontend/src/pages/XpHistory/BreakdownRow.jsx
@@ -1,51 +1,142 @@
-import { Box } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import { tierLabelFromFactor } from "./diminishTier";
+
+const COLOR = {
+  deep: "#3A2800",
+  muted: "#5A6B7F",
+  mutedSoft: "#94A3B8",
+  cyan: "#00838F",
+  amberDeep: "#F59E0B",
+  amberText: "#B45309",
+  redDeep: "#B91C1C",
+  greenDeep: "#15803D",
+  purple: "#6B21A8",
+};
 
 const trim = n => {
   const num = Number(n);
   if (!Number.isFinite(num)) return "0";
   return Number(num.toFixed(2)).toString();
 };
+
 const mult = n => `×${trim(n)}`;
 
-function Row({ label, value, accent, total, dim }) {
+function ChainPart({ label, value, color, weight = 600 }) {
   return (
     <Box
+      component="span"
       sx={{
-        display: "flex",
+        display: "inline-flex",
         alignItems: "baseline",
-        justifyContent: "space-between",
-        gap: 1,
-        py: total ? 0.25 : 0,
+        gap: 0.5,
+        whiteSpace: "nowrap",
       }}
     >
-      <Box
-        component="span"
-        sx={{
-          color: dim ? "text.disabled" : total ? "text.primary" : "text.secondary",
-          fontWeight: total ? 700 : 500,
-          fontSize: total ? 13 : 12,
-        }}
-      >
+      <Box component="span" sx={{ color: COLOR.mutedSoft, fontWeight: 400 }}>
         {label}
       </Box>
-      <Box
-        component="span"
-        sx={{
-          fontFamily: "ui-monospace, Menlo, monospace",
-          fontWeight: total ? 700 : 600,
-          fontSize: total ? 14 : 12,
-          color: accent || (total ? "text.primary" : "text.primary"),
-        }}
-      >
+      <Box component="span" sx={{ color, fontWeight: weight }}>
         {value}
       </Box>
     </Box>
   );
 }
 
-function Divider() {
-  return <Box sx={{ height: "1px", bgcolor: "divider", my: 0.5 }} />;
+function ChainRow({ children }) {
+  return (
+    <Stack
+      direction="row"
+      flexWrap="wrap"
+      sx={{
+        rowGap: "4px",
+        columnGap: "8px",
+        alignItems: "baseline",
+        fontFamily: "ui-monospace, Menlo, monospace",
+        fontSize: 12,
+        lineHeight: 1.7,
+      }}
+    >
+      {children}
+    </Stack>
+  );
+}
+
+function shapeRawParts(ev) {
+  return [
+    { label: "基礎", val: trim(ev.base_xp), color: COLOR.deep, weight: 700, hide: false },
+    {
+      label: "冷卻",
+      val: mult(ev.cooldown_rate),
+      color: ev.cooldown_rate > 1 ? COLOR.amberDeep : COLOR.muted,
+      hide: ev.cooldown_rate === 1,
+    },
+    {
+      label: "群組",
+      val: mult(ev.group_bonus),
+      color: ev.group_bonus > 1 ? COLOR.cyan : COLOR.muted,
+      hide: ev.group_bonus === 1,
+    },
+    {
+      label: "暖流祝福",
+      val: mult(ev.blessing1_mult),
+      color: ev.blessing1_mult > 1 ? COLOR.cyan : COLOR.muted,
+      hide: ev.blessing1_mult === 1,
+    },
+  ];
+}
+
+function shapeEffParts(ev) {
+  return [
+    {
+      label: "蜜月",
+      val: mult(ev.honeymoon_mult),
+      color: ev.honeymoon_mult > 1 ? COLOR.greenDeep : COLOR.muted,
+      hide: ev.honeymoon_mult === 1,
+    },
+    {
+      label: tierLabelFromFactor(ev.diminish_factor),
+      val: mult(ev.diminish_factor),
+      color:
+        ev.diminish_factor === 1
+          ? COLOR.muted
+          : ev.diminish_factor === 0.3
+            ? COLOR.amberText
+            : COLOR.redDeep,
+      hide: ev.diminish_factor === 1,
+    },
+    {
+      label: "試煉",
+      val: mult(ev.trial_mult),
+      color:
+        ev.trial_mult < 1 ? COLOR.amberText : ev.trial_mult > 1 ? COLOR.greenDeep : COLOR.muted,
+      hide: ev.trial_mult === 1,
+    },
+    {
+      label: "永久",
+      val: mult(ev.permanent_mult),
+      color: ev.permanent_mult > 1 ? COLOR.purple : COLOR.muted,
+      hide: ev.permanent_mult === 1,
+    },
+  ];
+}
+
+function ChainArrow({ to, value, color = COLOR.deep, valueSize = 13 }) {
+  return (
+    <Box
+      sx={{
+        mt: 0.5,
+        ml: 1.75,
+        fontFamily: "ui-monospace, Menlo, monospace",
+        fontSize: 12,
+        color: COLOR.muted,
+      }}
+    >
+      → {to}{" "}
+      <Box component="span" sx={{ color, fontWeight: 700, fontSize: valueSize }}>
+        {value}
+      </Box>
+    </Box>
+  );
 }
 
 export default function BreakdownRow({ ev, showAll }) {
@@ -59,6 +150,7 @@ export default function BreakdownRow({ ev, showAll }) {
           fontStyle: "italic",
           color: "text.secondary",
           fontSize: 12,
+          lineHeight: 1.6,
         }}
       >
         此筆早於 v2，無乘數明細
@@ -66,59 +158,33 @@ export default function BreakdownRow({ ev, showAll }) {
     );
   }
 
-  const rawSteps = [
-    { label: "冷卻", val: mult(ev.cooldown_rate), hide: ev.cooldown_rate === 1 },
-    { label: "群組加成", val: mult(ev.group_bonus), hide: ev.group_bonus === 1 },
-    { label: "暖流祝福", val: mult(ev.blessing1_mult), hide: ev.blessing1_mult === 1 },
-  ];
-  const tierLabel = tierLabelFromFactor(ev.diminish_factor);
-  const effSteps = [
-    { label: "蜜月加成", val: mult(ev.honeymoon_mult), hide: ev.honeymoon_mult === 1 },
-    {
-      label: tierLabel,
-      val: mult(ev.diminish_factor),
-      hide: ev.diminish_factor === 1,
-      accent: ev.diminish_factor <= 0.05 ? "error.dark" : undefined,
-    },
-    { label: "試煉倍率", val: mult(ev.trial_mult), hide: ev.trial_mult === 1 },
-    { label: "永久加成", val: mult(ev.permanent_mult), hide: ev.permanent_mult === 1 },
-  ];
-
-  const visibleRaw = rawSteps.filter(s => showAll || !s.hide);
-  const visibleEff = effSteps.filter(s => showAll || !s.hide);
-  const effDimmed = ev.effective_exp === 0 || ev.effective_exp < ev.raw_exp / 2;
+  const rawParts = shapeRawParts(ev);
+  const effParts = shapeEffParts(ev);
+  const visibleRaw = rawParts.filter(p => showAll || !p.hide);
+  const visibleEff = effParts.filter(p => showAll || !p.hide);
 
   return (
-    <Box
-      sx={{
-        p: 1.5,
-        bgcolor: "#F8FAFB",
-        borderRadius: 1,
-        display: "flex",
-        flexDirection: "column",
-        gap: 0.25,
-      }}
-    >
-      <Row label="基礎 XP" value={trim(ev.base_xp)} />
-      {visibleRaw.map((s, i) => (
-        <Row key={`r${i}`} label={s.label} value={s.val} dim />
-      ))}
-      <Divider />
-      <Row label="原始 XP" value={ev.raw_exp} total />
+    <Box sx={{ p: 1.5, bgcolor: "#F8FAFB", borderRadius: 1 }}>
+      <ChainRow>
+        {visibleRaw.map((p, i) => (
+          <ChainPart key={i} {...p} />
+        ))}
+      </ChainRow>
+      <ChainArrow to="原始 XP" value={ev.raw_exp} />
+
       {visibleEff.length > 0 && (
-        <>
-          {visibleEff.map((s, i) => (
-            <Row key={`e${i}`} label={s.label} value={s.val} accent={s.accent} dim />
-          ))}
-          <Divider />
-        </>
+        <Box sx={{ mt: 1 }}>
+          <ChainRow>
+            <Box component="span" sx={{ color: COLOR.mutedSoft, fontWeight: 400 }}>
+              原始 {ev.raw_exp}
+            </Box>
+            {visibleEff.map((p, i) => (
+              <ChainPart key={i} {...p} />
+            ))}
+          </ChainRow>
+        </Box>
       )}
-      <Row
-        label="實得 XP"
-        value={ev.effective_exp}
-        total
-        accent={effDimmed ? "warning.dark" : "success.dark"}
-      />
+      <ChainArrow to="實得 XP" value={ev.effective_exp} color={COLOR.amberDeep} valueSize={14} />
     </Box>
   );
 }

--- a/frontend/src/pages/XpHistory/BreakdownRow.jsx
+++ b/frontend/src/pages/XpHistory/BreakdownRow.jsx
@@ -1,5 +1,6 @@
-import { Box, Stack, Typography } from "@mui/material";
-import { tierLabelFromFactor } from "./diminishTier";
+import { Box, Stack } from "@mui/material";
+import { TIER2_RATE, tierLabelFromFactor } from "./diminishTier";
+import { mult, trim } from "./format";
 
 const COLOR = {
   deep: "#3A2800",
@@ -13,13 +14,17 @@ const COLOR = {
   purple: "#6B21A8",
 };
 
-const trim = n => {
-  const num = Number(n);
-  if (!Number.isFinite(num)) return "0";
-  return Number(num.toFixed(2)).toString();
-};
+function colorForDiminish(factor) {
+  if (factor === 1) return COLOR.muted;
+  if (factor === TIER2_RATE) return COLOR.amberText;
+  return COLOR.redDeep;
+}
 
-const mult = n => `×${trim(n)}`;
+function colorForTrial(m) {
+  if (m < 1) return COLOR.amberText;
+  if (m > 1) return COLOR.greenDeep;
+  return COLOR.muted;
+}
 
 function ChainPart({ label, value, color, weight = 600 }) {
   return (
@@ -96,19 +101,13 @@ function shapeEffParts(ev) {
     {
       label: tierLabelFromFactor(ev.diminish_factor),
       val: mult(ev.diminish_factor),
-      color:
-        ev.diminish_factor === 1
-          ? COLOR.muted
-          : ev.diminish_factor === 0.3
-            ? COLOR.amberText
-            : COLOR.redDeep,
+      color: colorForDiminish(ev.diminish_factor),
       hide: ev.diminish_factor === 1,
     },
     {
       label: "試煉",
       val: mult(ev.trial_mult),
-      color:
-        ev.trial_mult < 1 ? COLOR.amberText : ev.trial_mult > 1 ? COLOR.greenDeep : COLOR.muted,
+      color: colorForTrial(ev.trial_mult),
       hide: ev.trial_mult === 1,
     },
     {

--- a/frontend/src/pages/XpHistory/DailyTrend.jsx
+++ b/frontend/src/pages/XpHistory/DailyTrend.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Box, Stack, ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
 import {
   Bar,
@@ -73,13 +74,13 @@ function TrendTooltip({ active, payload }) {
       <Box>
         原始{" "}
         <Box component="span" sx={{ color: COLORS.muted }}>
-          {d.raw?.toLocaleString()}
+          {d.raw.toLocaleString()}
         </Box>
       </Box>
       <Box>
         實得{" "}
         <Box component="span" sx={{ color: COLORS.amberDeep, fontWeight: 700 }}>
-          {d.effective?.toLocaleString()}
+          {d.effective.toLocaleString()}
         </Box>
       </Box>
       <Box sx={{ color: COLORS.muted }}>訊息 {d.msg_count}</Box>
@@ -90,22 +91,25 @@ function TrendTooltip({ active, payload }) {
 }
 
 export default function DailyTrend({ days, range, onRangeChange }) {
-  const rows = (days || []).slice(-range);
-  const chartData = rows.map(d => ({
-    date: d.date,
-    effective: d.effective_exp || 0,
-    loss: Math.max(0, (d.raw_exp || 0) - (d.effective_exp || 0)),
-    raw: d.raw_exp || 0,
-    msg_count: d.msg_count || 0,
-    honeymoon_active: d.honeymoon_active,
-    trial_id: d.trial_id,
-  }));
+  const { chartData, honeymoonBands, trialBands } = useMemo(() => {
+    const rows = days || [];
+    return {
+      chartData: rows.map(d => ({
+        date: d.date,
+        effective: d.effective_exp || 0,
+        loss: Math.max(0, (d.raw_exp || 0) - (d.effective_exp || 0)),
+        raw: d.raw_exp || 0,
+        msg_count: d.msg_count || 0,
+        honeymoon_active: d.honeymoon_active,
+        trial_id: d.trial_id,
+      })),
+      honeymoonBands: bandRanges(rows, d => d.honeymoon_active),
+      trialBands: bandRanges(rows, d => d.trial_id != null),
+    };
+  }, [days]);
 
-  const honeymoonBands = bandRanges(rows, d => d.honeymoon_active);
-  const trialBands = bandRanges(rows, d => d.trial_id != null);
-
-  const rotateLabels = rows.length > 10;
-  const tickInterval = rows.length <= 7 ? 0 : Math.max(0, Math.ceil(rows.length / 6) - 1);
+  const rotateLabels = chartData.length > 10;
+  const tickInterval = chartData.length <= 7 ? 0 : Math.max(0, Math.ceil(chartData.length / 6) - 1);
   const bottomMargin = rotateLabels ? 30 : 18;
 
   return (

--- a/frontend/src/pages/XpHistory/DailyTrend.jsx
+++ b/frontend/src/pages/XpHistory/DailyTrend.jsx
@@ -1,31 +1,112 @@
-import { useState } from "react";
 import { Box, Stack, ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceArea,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 const COLORS = {
   amber: "#FBBF24",
   amberDeep: "#F59E0B",
   divider: "#E5E7EB",
   muted: "#94A3B8",
-  loss: "rgba(148,163,184,0.45)",
+  lossFg: "#94A3B8",
   text: "#3A2800",
+  green: "#16A34A",
+  greenDeep: "#15803D",
 };
 
+const RANGES = [1, 7, 30, 90, 365];
+
+function rangeLabel(r) {
+  if (r === 1) return "今天";
+  if (r === 365) return "最近一年";
+  return `最近 ${r} 天`;
+}
+
+function rangeButton(r) {
+  if (r === 1) return "今天";
+  if (r === 365) return "1 年";
+  return `${r} 天`;
+}
+
+function bandRanges(rows, predicate) {
+  const out = [];
+  let start = null;
+  rows.forEach((d, i) => {
+    if (predicate(d)) {
+      if (start === null) start = i;
+    } else if (start !== null) {
+      out.push([rows[start].date, rows[i - 1].date]);
+      start = null;
+    }
+  });
+  if (start !== null) out.push([rows[start].date, rows[rows.length - 1].date]);
+  return out;
+}
+
+function TrendTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0]?.payload;
+  if (!d) return null;
+  return (
+    <Box
+      sx={{
+        bgcolor: "#fff",
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 1,
+        p: "8px 12px",
+        fontSize: 11,
+        fontFamily: "ui-monospace, Menlo, monospace",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
+        lineHeight: 1.8,
+        minWidth: 120,
+      }}
+    >
+      <Box sx={{ color: COLORS.text, fontWeight: 700, mb: 0.25 }}>{d.date}</Box>
+      <Box>
+        原始{" "}
+        <Box component="span" sx={{ color: COLORS.muted }}>
+          {d.raw?.toLocaleString()}
+        </Box>
+      </Box>
+      <Box>
+        實得{" "}
+        <Box component="span" sx={{ color: COLORS.amberDeep, fontWeight: 700 }}>
+          {d.effective?.toLocaleString()}
+        </Box>
+      </Box>
+      <Box sx={{ color: COLORS.muted }}>訊息 {d.msg_count}</Box>
+      {d.honeymoon_active && <Box sx={{ color: COLORS.greenDeep, fontSize: 10 }}>🌱 蜜月期</Box>}
+      {d.trial_id && <Box sx={{ color: "#B45309", fontSize: 10 }}>⚔ 試煉中</Box>}
+    </Box>
+  );
+}
+
 export default function DailyTrend({ days, range, onRangeChange }) {
-  const W = 320;
-  const PAD_L = 28;
-  const PAD_R = 8;
-  const PAD_T = 12;
-  const PAD_B = 56;
-  const H = 240;
-  const innerW = W - PAD_L - PAD_R;
-  const innerH = H - PAD_T - PAD_B;
+  const rows = (days || []).slice(-range);
+  const chartData = rows.map(d => ({
+    date: d.date,
+    effective: d.effective_exp || 0,
+    loss: Math.max(0, (d.raw_exp || 0) - (d.effective_exp || 0)),
+    raw: d.raw_exp || 0,
+    msg_count: d.msg_count || 0,
+    honeymoon_active: d.honeymoon_active,
+    trial_id: d.trial_id,
+  }));
 
-  const sliced = (days || []).slice(-range);
-  const maxRaw = Math.max(...sliced.map(d => d.raw_exp || 0), 100);
-  const barW = sliced.length > 0 ? innerW / sliced.length : 0;
-  const gap = Math.min(2, barW * 0.15);
+  const honeymoonBands = bandRanges(rows, d => d.honeymoon_active);
+  const trialBands = bandRanges(rows, d => d.trial_id != null);
 
-  const [picked, setPicked] = useState(null);
+  const rotateLabels = rows.length > 10;
+  const tickInterval = rows.length <= 7 ? 0 : Math.max(0, Math.ceil(rows.length / 6) - 1);
+  const bottomMargin = rotateLabels ? 30 : 18;
 
   return (
     <Stack gap={1.5}>
@@ -36,9 +117,9 @@ export default function DailyTrend({ days, range, onRangeChange }) {
         onChange={(_, v) => v && onRangeChange(v)}
         fullWidth
       >
-        {[7, 30, 90, 365].map(r => (
+        {RANGES.map(r => (
           <ToggleButton key={r} value={r} sx={{ fontFamily: "ui-monospace, Menlo, monospace" }}>
-            {r === 365 ? "1y" : `${r}d`}
+            {rangeButton(r)}
           </ToggleButton>
         ))}
       </ToggleButtonGroup>
@@ -49,183 +130,124 @@ export default function DailyTrend({ days, range, onRangeChange }) {
           borderRadius: 1.5,
           border: 1,
           borderColor: "divider",
-          p: 1.5,
+          p: "14px 12px 10px",
         }}
       >
-        <Stack direction="row" justifyContent="space-between" alignItems="baseline" sx={{ mb: 1 }}>
-          <Typography sx={{ fontWeight: 700, color: COLORS.text }}>raw vs effective</Typography>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="baseline"
+          sx={{ mb: 1.25 }}
+        >
+          <Typography sx={{ fontSize: 13, fontWeight: 700, color: COLORS.text }}>
+            原始{" "}
+            <Box component="span" sx={{ color: COLORS.muted, fontWeight: 400 }}>
+              vs
+            </Box>{" "}
+            實得
+          </Typography>
           <Typography
-            variant="caption"
-            sx={{ fontFamily: "ui-monospace, Menlo, monospace", color: COLORS.muted }}
+            sx={{
+              fontFamily: "ui-monospace, Menlo, monospace",
+              fontSize: 11,
+              color: COLORS.muted,
+            }}
           >
-            最近 {range === 365 ? "一年" : `${range} 天`}
+            {rangeLabel(range)}
           </Typography>
         </Stack>
 
-        <Box
-          component="svg"
-          viewBox={`0 0 ${W} ${H}`}
-          sx={{ width: "100%", display: "block", touchAction: "manipulation" }}
-          onClick={e => {
-            // click on empty area deselects
-            if (e.target.tagName === "svg") setPicked(null);
-          }}
-        >
-          {[0, 0.25, 0.5, 0.75, 1].map(p => (
-            <line
-              key={p}
-              x1={PAD_L}
-              x2={W - PAD_R}
-              y1={PAD_T + innerH * (1 - p)}
-              y2={PAD_T + innerH * (1 - p)}
-              stroke={COLORS.divider}
-              strokeWidth="1"
-              strokeDasharray={p === 0 ? "" : "2 3"}
-            />
-          ))}
-          {[0, 0.5, 1].map(p => (
-            <text
-              key={p}
-              x={PAD_L - 4}
-              y={PAD_T + innerH * (1 - p) + 3}
-              textAnchor="end"
-              fontSize="9"
-              fill={COLORS.muted}
-              fontFamily="ui-monospace, Menlo, monospace"
+        {chartData.length === 0 ? (
+          <Box
+            sx={{
+              py: 6,
+              textAlign: "center",
+              color: "text.secondary",
+              fontFamily: "ui-monospace, Menlo, monospace",
+              fontSize: 12,
+            }}
+          >
+            沒有資料
+          </Box>
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart
+              data={chartData}
+              maxBarSize={36}
+              barCategoryGap="20%"
+              margin={{ top: 4, right: 4, bottom: bottomMargin, left: 0 }}
             >
-              {Math.round(maxRaw * p)}
-            </text>
-          ))}
-
-          {sliced.map((d, i) => {
-            const x = PAD_L + i * barW + gap / 2;
-            const w = Math.max(1, barW - gap);
-            const effH = ((d.effective_exp || 0) / maxRaw) * innerH;
-            const lossH =
-              (Math.max(0, (d.raw_exp || 0) - (d.effective_exp || 0)) / maxRaw) * innerH;
-            const yLoss = PAD_T + innerH - effH - lossH;
-            const yEff = PAD_T + innerH - effH;
-            const isPicked = picked && picked.date === d.date;
-            return (
-              <g
-                key={d.date}
-                onClick={e => {
-                  e.stopPropagation();
-                  setPicked(prev => (prev?.date === d.date ? null : d));
+              <CartesianGrid strokeDasharray="3 4" stroke={COLORS.divider} vertical={false} />
+              {honeymoonBands.map(([x1, x2], i) => (
+                <ReferenceArea
+                  key={`hm-${i}`}
+                  x1={x1}
+                  x2={x2}
+                  fill={COLORS.green}
+                  fillOpacity={0.08}
+                />
+              ))}
+              {trialBands.map(([x1, x2], i) => (
+                <ReferenceArea
+                  key={`tr-${i}`}
+                  x1={x1}
+                  x2={x2}
+                  fill={COLORS.amberDeep}
+                  fillOpacity={0.08}
+                />
+              ))}
+              <XAxis
+                dataKey="date"
+                tickFormatter={v => (v || "").slice(5).replace("-", "/")}
+                tick={{
+                  fontSize: 9,
+                  fontFamily: "ui-monospace, Menlo, monospace",
+                  fill: COLORS.muted,
                 }}
-                style={{ cursor: "pointer" }}
-              >
-                <rect x={x} y={yLoss} width={w} height={lossH} fill={COLORS.loss} />
-                <rect
-                  x={x}
-                  y={yEff}
-                  width={w}
-                  height={effH}
-                  fill={isPicked ? COLORS.amberDeep : COLORS.amber}
-                />
-                {d.honeymoon_active && (
-                  <text
-                    x={x + w / 2}
-                    y={PAD_T + innerH + 12}
-                    textAnchor="middle"
-                    fontSize="9"
-                    fill="#15803D"
-                  >
-                    🌱
-                  </text>
-                )}
-                {d.trial_id && (
-                  <text
-                    x={x + w / 2}
-                    y={PAD_T + innerH + (d.honeymoon_active ? 24 : 12)}
-                    textAnchor="middle"
-                    fontSize="9"
-                    fill="#B45309"
-                  >
-                    ⚔★{d.trial_star ?? ""}
-                  </text>
-                )}
-                {i % Math.max(1, Math.floor(sliced.length / 6)) === 0 && (
-                  <text
-                    x={x + w / 2}
-                    y={
-                      PAD_T +
-                      innerH +
-                      (d.honeymoon_active && d.trial_id
-                        ? 38
-                        : d.honeymoon_active || d.trial_id
-                          ? 26
-                          : 14)
-                    }
-                    textAnchor="middle"
-                    fontSize="9"
-                    fill={COLORS.muted}
-                    fontFamily="ui-monospace, Menlo, monospace"
-                  >
-                    {d.date.slice(5)}
-                  </text>
-                )}
-              </g>
-            );
-          })}
-
-          {picked &&
-            (() => {
-              const i = sliced.findIndex(d => d.date === picked.date);
-              if (i < 0) return null;
-              const x = PAD_L + i * barW + barW / 2;
-              return (
-                <line
-                  x1={x}
-                  x2={x}
-                  y1={PAD_T}
-                  y2={PAD_T + innerH}
-                  stroke={COLORS.text}
-                  strokeWidth="1"
-                  strokeDasharray="2 2"
-                  opacity="0.35"
-                />
-              );
-            })()}
-        </Box>
-
-        <Box
-          sx={{
-            mt: 1,
-            p: "6px 8px",
-            bgcolor: "#F8FAFB",
-            borderRadius: 0.75,
-            fontFamily: "ui-monospace, Menlo, monospace",
-            fontSize: 11,
-            color: "text.secondary",
-            minHeight: 40,
-          }}
-        >
-          {picked ? (
-            <>
-              <Box sx={{ color: COLORS.text, fontWeight: 700 }}>{picked.date}</Box>
-              <Box>
-                raw{" "}
-                <Box component="span" sx={{ color: COLORS.muted }}>
-                  {picked.raw_exp}
-                </Box>{" "}
-                · eff{" "}
-                <Box component="span" sx={{ color: COLORS.amberDeep, fontWeight: 700 }}>
-                  {picked.effective_exp}
-                </Box>{" "}
-                · 訊息 {picked.msg_count}
-              </Box>
-            </>
-          ) : (
-            <Box sx={{ color: COLORS.muted }}>點選長條看單日數字</Box>
-          )}
-        </Box>
+                interval={tickInterval}
+                angle={rotateLabels ? -40 : 0}
+                textAnchor={rotateLabels ? "end" : "middle"}
+                axisLine={false}
+                tickLine={false}
+                dy={4}
+              />
+              <YAxis
+                tick={{
+                  fontSize: 9,
+                  fontFamily: "ui-monospace, Menlo, monospace",
+                  fill: COLORS.muted,
+                }}
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={v => (v >= 1000 ? `${Math.round(v / 1000)}k` : String(v))}
+                width={28}
+              />
+              <Tooltip content={<TrendTooltip />} cursor={{ fill: "rgba(0,0,0,0.04)" }} />
+              <Bar
+                dataKey="effective"
+                stackId="a"
+                fill={COLORS.amber}
+                radius={[0, 0, 2, 2]}
+                name="effective"
+              />
+              <Bar
+                dataKey="loss"
+                stackId="a"
+                fill={COLORS.lossFg}
+                fillOpacity={0.38}
+                radius={[2, 2, 0, 0]}
+                name="loss"
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
 
         <Stack
           direction="row"
-          gap={1.5}
+          gap={1.25}
+          flexWrap="wrap"
           sx={{
-            mt: 1,
+            mt: 0.5,
             fontSize: 10,
             color: "text.secondary",
             fontFamily: "ui-monospace, Menlo, monospace",
@@ -233,14 +255,38 @@ export default function DailyTrend({ days, range, onRangeChange }) {
         >
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
             <Box sx={{ width: 10, height: 10, bgcolor: COLORS.amber, borderRadius: 0.25 }} />
-            effective
+            實得
           </Box>
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-            <Box sx={{ width: 10, height: 10, bgcolor: COLORS.loss, borderRadius: 0.25 }} />
-            loss
+            <Box
+              sx={{
+                width: 10,
+                height: 10,
+                bgcolor: COLORS.lossFg,
+                opacity: 0.38,
+                borderRadius: 0.25,
+              }}
+            />
+            流失
           </Box>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>🌱 蜜月</Box>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>⚔★ 試煉</Box>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <Box
+              sx={{ width: 10, height: 8, bgcolor: COLORS.green, opacity: 0.2, borderRadius: 0.25 }}
+            />
+            蜜月
+          </Box>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <Box
+              sx={{
+                width: 10,
+                height: 8,
+                bgcolor: COLORS.amberDeep,
+                opacity: 0.2,
+                borderRadius: 0.25,
+              }}
+            />
+            試煉
+          </Box>
         </Stack>
       </Box>
     </Stack>

--- a/frontend/src/pages/XpHistory/EventChips.jsx
+++ b/frontend/src/pages/XpHistory/EventChips.jsx
@@ -1,0 +1,60 @@
+import { Box, Stack } from "@mui/material";
+
+const STYLES = {
+  honeymoon: { bg: "#E8F9EF", fg: "#15803D" },
+  trial: { bg: "#FFF7E6", fg: "#B45309" },
+  blessing: { bg: "#E0F7FA", fg: "#00838F" },
+  group: { bg: "#E0F7FA", fg: "#00838F" },
+  dim2: { bg: "#FFF7E6", fg: "#B45309" },
+  dim3: { bg: "#FDECEC", fg: "#B91C1C", border: "#DC2626" },
+  perm: { bg: "#F3E8FF", fg: "#6B21A8" },
+};
+
+export function EventChip({ kind, label, value }) {
+  const s = STYLES[kind] || STYLES.group;
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.5,
+        px: 1,
+        py: "2px",
+        borderRadius: 999,
+        bgcolor: s.bg,
+        color: s.fg,
+        border: s.border ? `1px solid ${s.border}` : "none",
+        fontSize: 11,
+        fontWeight: 700,
+        lineHeight: 1.4,
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span>{label}</span>
+      {value && (
+        <Box
+          component="span"
+          sx={{
+            fontFamily: "ui-monospace, Menlo, monospace",
+            fontWeight: 600,
+            opacity: 0.85,
+          }}
+        >
+          {value}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function EventChipRow({ chips }) {
+  if (!chips?.length) return null;
+  return (
+    <Stack direction="row" gap={0.5} flexWrap="wrap" alignItems="center">
+      {chips.map((c, i) => (
+        <EventChip key={i} {...c} />
+      ))}
+    </Stack>
+  );
+}

--- a/frontend/src/pages/XpHistory/EventList.jsx
+++ b/frontend/src/pages/XpHistory/EventList.jsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import BreakdownRow from "./BreakdownRow";
 import { foldEvents } from "./foldEvents";
 import { tierAccentFromFactor } from "./diminishTier";
 import { EventChipRow } from "./EventChips";
 import { chipsFromEvent } from "./chipsFromEvent";
+import { addDaysTpe, todayTpe, tpeDate } from "./dateTpe";
 
 const TIME_FMT = new Intl.DateTimeFormat(undefined, {
   hour: "2-digit",
@@ -19,13 +20,6 @@ const DETAIL_TIME_FMT = new Intl.DateTimeFormat(undefined, {
   hour12: false,
 });
 
-const TPE_DATE_FMT = new Intl.DateTimeFormat("en-CA", {
-  timeZone: "Asia/Taipei",
-  year: "numeric",
-  month: "2-digit",
-  day: "2-digit",
-});
-
 function localHHMM(ts) {
   const d = new Date(ts);
   return Number.isNaN(d.getTime()) ? "--:--" : TIME_FMT.format(d);
@@ -34,11 +28,6 @@ function localHHMM(ts) {
 function localHHMMSS(ts) {
   const d = new Date(ts);
   return Number.isNaN(d.getTime()) ? "--:--:--" : DETAIL_TIME_FMT.format(d);
-}
-
-function tpeDate(ts) {
-  const d = new Date(ts);
-  return Number.isNaN(d.getTime()) ? "" : TPE_DATE_FMT.format(d);
 }
 
 function dateHeading(date, today, yesterday) {
@@ -51,13 +40,28 @@ function accentFor(folded) {
   return tierAccentFromFactor(folded.events[0].diminish_factor, { degraded: folded.degraded });
 }
 
+function effTotalColor(eff, raw) {
+  if (eff === 0) return "error.main";
+  if (eff < raw / 2) return "warning.main";
+  return "text.primary";
+}
+
 export default function EventList({ events, showAll, groupLabel, defaultExpanded = "first" }) {
   const folded = useMemo(() => foldEvents(events || []), [events]);
   const [expanded, setExpanded] = useState(() => initialExpanded(folded, defaultExpanded));
 
-  useEffect(() => {
-    setExpanded(initialExpanded(folded, defaultExpanded));
-  }, [folded, defaultExpanded]);
+  const grouped = useMemo(() => {
+    const today = todayTpe();
+    const yesterday = addDaysTpe(today, -1);
+    const byDate = new Map();
+    folded.forEach(f => {
+      const date = tpeDate(f.ts) || f.minute.slice(0, 10);
+      if (!byDate.has(date)) byDate.set(date, []);
+      byDate.get(date).push(f);
+    });
+    const dates = [...byDate.keys()].sort().reverse();
+    return { today, yesterday, byDate, dates };
+  }, [folded]);
 
   const toggle = key =>
     setExpanded(prev => {
@@ -75,20 +79,7 @@ export default function EventList({ events, showAll, groupLabel, defaultExpanded
     );
   }
 
-  const today = TPE_DATE_FMT.format(new Date());
-  const yesterday = (() => {
-    const d = new Date();
-    d.setDate(d.getDate() - 1);
-    return TPE_DATE_FMT.format(d);
-  })();
-
-  const byDate = new Map();
-  folded.forEach(f => {
-    const date = tpeDate(f.ts) || f.minute.slice(0, 10);
-    if (!byDate.has(date)) byDate.set(date, []);
-    byDate.get(date).push(f);
-  });
-  const dates = [...byDate.keys()].sort().reverse();
+  const { today, yesterday, byDate, dates } = grouped;
 
   return (
     <Stack gap={2}>
@@ -129,8 +120,7 @@ function initialExpanded(folded, mode) {
 }
 
 function FoldedRow({ folded, expanded, onToggle, showAll, groupLabel }) {
-  const chips = chipsFromEvent(folded.events[0]);
-  const effDimmed = folded.eff_total === 0 || folded.eff_total < folded.raw_total / 2;
+  const chips = useMemo(() => chipsFromEvent(folded.events[0]), [folded]);
   return (
     <Box
       sx={{
@@ -199,12 +189,7 @@ function FoldedRow({ folded, expanded, onToggle, showAll, groupLabel }) {
                 fontFamily: "ui-monospace, Menlo, monospace",
                 fontSize: 18,
                 fontWeight: 700,
-                color:
-                  folded.eff_total === 0
-                    ? "error.main"
-                    : effDimmed
-                      ? "warning.main"
-                      : "text.primary",
+                color: effTotalColor(folded.eff_total, folded.raw_total),
                 lineHeight: 1,
               }}
             >

--- a/frontend/src/pages/XpHistory/EventList.jsx
+++ b/frontend/src/pages/XpHistory/EventList.jsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import BreakdownRow from "./BreakdownRow";
 import { foldEvents } from "./foldEvents";
 import { tierAccentFromFactor } from "./diminishTier";
+import { EventChipRow } from "./EventChips";
+import { chipsFromEvent } from "./chipsFromEvent";
 
 const TIME_FMT = new Intl.DateTimeFormat(undefined, {
   hour: "2-digit",
@@ -10,18 +12,52 @@ const TIME_FMT = new Intl.DateTimeFormat(undefined, {
   hour12: false,
 });
 
+const DETAIL_TIME_FMT = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+const TPE_DATE_FMT = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Taipei",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
 function localHHMM(ts) {
   const d = new Date(ts);
   return Number.isNaN(d.getTime()) ? "--:--" : TIME_FMT.format(d);
+}
+
+function localHHMMSS(ts) {
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? "--:--:--" : DETAIL_TIME_FMT.format(d);
+}
+
+function tpeDate(ts) {
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? "" : TPE_DATE_FMT.format(d);
+}
+
+function dateHeading(date, today, yesterday) {
+  if (date === today) return "今天";
+  if (date === yesterday) return "昨天";
+  return date.slice(5);
 }
 
 function accentFor(folded) {
   return tierAccentFromFactor(folded.events[0].diminish_factor, { degraded: folded.degraded });
 }
 
-export default function EventList({ events, showAll, groupLabel }) {
+export default function EventList({ events, showAll, groupLabel, defaultExpanded = "first" }) {
   const folded = useMemo(() => foldEvents(events || []), [events]);
-  const [expanded, setExpanded] = useState(new Set());
+  const [expanded, setExpanded] = useState(() => initialExpanded(folded, defaultExpanded));
+
+  useEffect(() => {
+    setExpanded(initialExpanded(folded, defaultExpanded));
+  }, [folded, defaultExpanded]);
 
   const toggle = key =>
     setExpanded(prev => {
@@ -39,112 +75,176 @@ export default function EventList({ events, showAll, groupLabel }) {
     );
   }
 
+  const today = TPE_DATE_FMT.format(new Date());
+  const yesterday = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return TPE_DATE_FMT.format(d);
+  })();
+
+  const byDate = new Map();
+  folded.forEach(f => {
+    const date = tpeDate(f.ts) || f.minute.slice(0, 10);
+    if (!byDate.has(date)) byDate.set(date, []);
+    byDate.get(date).push(f);
+  });
+  const dates = [...byDate.keys()].sort().reverse();
+
   return (
-    <Stack gap={1}>
-      {folded.map(f => {
-        const isOpen = expanded.has(f.key);
-        return (
-          <Box
-            key={f.key}
+    <Stack gap={2}>
+      {dates.map(date => (
+        <Stack key={date} gap={1}>
+          <Typography
             sx={{
-              bgcolor: "background.paper",
-              borderRadius: 1.5,
-              overflow: "hidden",
-              border: 1,
-              borderColor: "divider",
-              display: "flex",
+              fontFamily: "ui-monospace, Menlo, monospace",
+              fontSize: 11,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: "text.disabled",
+              pl: 0.5,
             }}
           >
-            <Box sx={{ width: 4, bgcolor: accentFor(f), flexShrink: 0 }} />
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Box
-                onClick={() => toggle(f.key)}
-                sx={{
-                  p: 1.5,
-                  cursor: "pointer",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1.25,
-                }}
-              >
-                <Box
-                  sx={{
-                    fontFamily: "ui-monospace, Menlo, monospace",
-                    fontSize: 13,
-                    fontWeight: 700,
-                    minWidth: 42,
-                  }}
-                >
-                  {localHHMM(f.ts)}
+            {dateHeading(date, today, yesterday)} · {date}
+          </Typography>
+          {byDate.get(date).map(f => (
+            <FoldedRow
+              key={f.key}
+              folded={f}
+              expanded={expanded.has(f.key)}
+              onToggle={() => toggle(f.key)}
+              showAll={showAll}
+              groupLabel={groupLabel}
+            />
+          ))}
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+function initialExpanded(folded, mode) {
+  if (mode === "all") return new Set(folded.map(f => f.key));
+  if (mode === "first" && folded.length > 0) return new Set([folded[0].key]);
+  return new Set();
+}
+
+function FoldedRow({ folded, expanded, onToggle, showAll, groupLabel }) {
+  const chips = chipsFromEvent(folded.events[0]);
+  const effDimmed = folded.eff_total === 0 || folded.eff_total < folded.raw_total / 2;
+  return (
+    <Box
+      sx={{
+        bgcolor: "background.paper",
+        borderRadius: 1.5,
+        overflow: "hidden",
+        border: 1,
+        borderColor: "divider",
+        display: "flex",
+      }}
+    >
+      <Box sx={{ width: 4, bgcolor: accentFor(folded), flexShrink: 0 }} />
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box
+          onClick={onToggle}
+          sx={{
+            p: 1.5,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            gap: 1.25,
+          }}
+        >
+          <Box
+            sx={{
+              fontFamily: "ui-monospace, Menlo, monospace",
+              fontSize: 13,
+              fontWeight: 700,
+              minWidth: 42,
+            }}
+          >
+            {localHHMM(folded.ts)}
+          </Box>
+          <Stack sx={{ flex: 1, minWidth: 0 }} gap={0.5}>
+            <Typography
+              sx={{
+                fontSize: 12,
+                color: "text.secondary",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {groupLabel(folded.group_id)}
+              {folded.count > 1 && (
+                <Box component="span" sx={{ color: "warning.main", fontWeight: 700 }}>
+                  {" "}
+                  · ×{folded.count}
                 </Box>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography
-                    sx={{
-                      fontSize: 12,
-                      color: "text.secondary",
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                    }}
-                  >
-                    {groupLabel(f.group_id)}
-                    {f.count > 1 && (
-                      <Box component="span" sx={{ color: "warning.main", fontWeight: 700 }}>
-                        {" "}
-                        · ×{f.count}
-                      </Box>
-                    )}
-                  </Typography>
-                </Box>
-                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
+              )}
+            </Typography>
+            <EventChipRow chips={chips} />
+          </Stack>
+          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
+            <Typography
+              sx={{
+                fontFamily: "ui-monospace, Menlo, monospace",
+                fontSize: 11,
+                color: "text.secondary",
+              }}
+            >
+              {folded.raw_total > 0 ? `${folded.raw_total} →` : "→"}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: "ui-monospace, Menlo, monospace",
+                fontSize: 18,
+                fontWeight: 700,
+                color:
+                  folded.eff_total === 0
+                    ? "error.main"
+                    : effDimmed
+                      ? "warning.main"
+                      : "text.primary",
+                lineHeight: 1,
+              }}
+            >
+              {folded.eff_total}
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              color: "text.disabled",
+              fontSize: 12,
+              transform: expanded ? "rotate(90deg)" : "none",
+              transition: "transform 0.15s",
+            }}
+          >
+            ›
+          </Box>
+        </Box>
+        {expanded && (
+          <Stack gap={1} sx={{ px: 1.5, pb: 1.5 }}>
+            {folded.events.map(ev => (
+              <Box key={ev.id}>
+                {folded.events.length > 1 && (
                   <Typography
                     sx={{
                       fontFamily: "ui-monospace, Menlo, monospace",
                       fontSize: 11,
-                      color: "text.secondary",
+                      color: "text.disabled",
+                      mb: 0.5,
+                      pl: 0.25,
                     }}
                   >
-                    {f.raw_total > 0 ? `${f.raw_total} →` : "→"}
+                    #{ev.id} · {localHHMMSS(ev.ts)}
                   </Typography>
-                  <Typography
-                    sx={{
-                      fontFamily: "ui-monospace, Menlo, monospace",
-                      fontSize: 18,
-                      fontWeight: 700,
-                      color:
-                        f.eff_total === 0
-                          ? "error.main"
-                          : f.eff_total < f.raw_total / 2
-                            ? "warning.main"
-                            : "text.primary",
-                      lineHeight: 1,
-                    }}
-                  >
-                    {f.eff_total}
-                  </Typography>
-                </Box>
-                <Box
-                  sx={{
-                    color: "text.disabled",
-                    fontSize: 12,
-                    transform: isOpen ? "rotate(90deg)" : "none",
-                    transition: "transform 0.15s",
-                  }}
-                >
-                  ›
-                </Box>
+                )}
+                <BreakdownRow ev={ev} showAll={showAll} />
               </Box>
-              {isOpen && (
-                <Stack gap={1} sx={{ px: 1.5, pb: 1.5 }}>
-                  {f.events.map(ev => (
-                    <BreakdownRow key={ev.id} ev={ev} showAll={showAll} />
-                  ))}
-                </Stack>
-              )}
-            </Box>
-          </Box>
-        );
-      })}
-    </Stack>
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </Box>
   );
 }

--- a/frontend/src/pages/XpHistory/TodayHeader.jsx
+++ b/frontend/src/pages/XpHistory/TodayHeader.jsx
@@ -1,0 +1,119 @@
+import { Box, Stack, Typography } from "@mui/material";
+
+const COLOR = {
+  cyan: "#00838F",
+  cyan2: "#00ACC1",
+  amber: "#FBBF24",
+  amberDeep: "#F59E0B",
+  amberText: "#FCD34D",
+  redSoft: "#FCA5A5",
+};
+
+const DATE_FMT_TPE = new Intl.DateTimeFormat("zh-TW", {
+  timeZone: "Asia/Taipei",
+  month: "2-digit",
+  day: "2-digit",
+  weekday: "short",
+});
+
+function formatDateBadge(dateStr) {
+  if (!dateStr) return "";
+  const d = new Date(`${dateStr}T00:00:00+08:00`);
+  if (Number.isNaN(d.getTime())) return dateStr;
+  // e.g. "05/01 五"
+  return DATE_FMT_TPE.format(d).replace("週", "");
+}
+
+export default function TodayHeader({ summary }) {
+  if (!summary) return null;
+  const { date, raw_exp, effective_exp, msg_count, tier1_upper, tier2_upper } = summary;
+  const cap = raw_exp || 0;
+  const t1Used = Math.min(cap, tier1_upper);
+  const t2Used = Math.min(Math.max(0, cap - tier1_upper), tier2_upper - tier1_upper);
+  const t3Used = Math.max(0, cap - tier2_upper);
+  const total = Math.max(cap, tier2_upper * 1.4);
+  const w1 = (t1Used / total) * 100;
+  const w2 = (t2Used / total) * 100;
+  const w3 = (t3Used / total) * 100;
+  const wRest = Math.max(0, 100 - w1 - w2 - w3);
+
+  const tierLabel = t3Used > 0 ? "⚠ 第三階 ×0.03" : t2Used > 0 ? "第二階 ×0.30" : "滿速 第一階";
+  const tierColor = t3Used > 0 ? COLOR.redSoft : COLOR.amberText;
+
+  return (
+    <Box
+      sx={{
+        background: `linear-gradient(135deg, ${COLOR.cyan}, ${COLOR.cyan2})`,
+        borderRadius: 1.75,
+        p: "18px 18px 16px",
+        color: "#fff",
+      }}
+    >
+      <Stack direction="row" justifyContent="space-between" alignItems="baseline" sx={{ mb: 1.25 }}>
+        <Typography sx={{ fontSize: 14, fontWeight: 700 }}>今日經驗</Typography>
+        <Typography
+          sx={{
+            fontFamily: "ui-monospace, Menlo, monospace",
+            fontSize: 11,
+            color: COLOR.amberText,
+            fontWeight: 700,
+          }}
+        >
+          {formatDateBadge(date)}
+        </Typography>
+      </Stack>
+
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-end" gap={1.5}>
+        <Box>
+          <Typography sx={{ fontSize: 11, opacity: 0.85 }}>累計實得</Typography>
+          <Box sx={{ fontFamily: "ui-monospace, Menlo, monospace", mt: 0.25 }}>
+            <Box
+              component="span"
+              sx={{ fontSize: 32, fontWeight: 700, color: COLOR.amberText, lineHeight: 1 }}
+            >
+              {effective_exp}
+            </Box>
+            <Box component="span" sx={{ fontSize: 13, opacity: 0.85, ml: 0.5 }}>
+              / {raw_exp} 原始
+            </Box>
+          </Box>
+        </Box>
+        <Box sx={{ textAlign: "right" }}>
+          <Typography sx={{ fontSize: 11, opacity: 0.85 }}>訊息</Typography>
+          <Typography sx={{ fontSize: 22, fontWeight: 700, lineHeight: 1, mt: 0.25 }}>
+            {msg_count}
+          </Typography>
+        </Box>
+      </Stack>
+
+      <Box sx={{ mt: 1.75 }}>
+        <Stack direction="row" gap="2px" sx={{ height: 8 }}>
+          {w1 > 0 && <Box sx={{ width: `${w1}%`, bgcolor: COLOR.amber, borderRadius: 0.5 }} />}
+          {w2 > 0 && <Box sx={{ width: `${w2}%`, bgcolor: COLOR.amberDeep, borderRadius: 0.5 }} />}
+          {w3 > 0 && <Box sx={{ width: `${w3}%`, bgcolor: "#9CA3AF", borderRadius: 0.5 }} />}
+          {wRest > 0 && (
+            <Box
+              sx={{ width: `${wRest}%`, bgcolor: "rgba(255,255,255,0.27)", borderRadius: 0.5 }}
+            />
+          )}
+        </Stack>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          sx={{
+            mt: 0.5,
+            fontSize: 10,
+            fontFamily: "ui-monospace, Menlo, monospace",
+          }}
+        >
+          <Box component="span" sx={{ color: tierColor, fontWeight: 700 }}>
+            {tierLabel}
+          </Box>
+          <Box component="span" sx={{ opacity: 0.85 }}>
+            {raw_exp} / {tier2_upper}+ 原始
+          </Box>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/XpHistory/TodayHeader.jsx
+++ b/frontend/src/pages/XpHistory/TodayHeader.jsx
@@ -1,4 +1,5 @@
 import { Box, Stack, Typography } from "@mui/material";
+import { formatDateBadge } from "./dateTpe";
 
 const COLOR = {
   cyan: "#00838F",
@@ -8,21 +9,6 @@ const COLOR = {
   amberText: "#FCD34D",
   redSoft: "#FCA5A5",
 };
-
-const DATE_FMT_TPE = new Intl.DateTimeFormat("zh-TW", {
-  timeZone: "Asia/Taipei",
-  month: "2-digit",
-  day: "2-digit",
-  weekday: "short",
-});
-
-function formatDateBadge(dateStr) {
-  if (!dateStr) return "";
-  const d = new Date(`${dateStr}T00:00:00+08:00`);
-  if (Number.isNaN(d.getTime())) return dateStr;
-  // e.g. "05/01 五"
-  return DATE_FMT_TPE.format(d).replace("週", "");
-}
 
 export default function TodayHeader({ summary }) {
   if (!summary) return null;

--- a/frontend/src/pages/XpHistory/chipsFromEvent.js
+++ b/frontend/src/pages/XpHistory/chipsFromEvent.js
@@ -1,0 +1,35 @@
+function fmtMult(n) {
+  if (n == null || !Number.isFinite(Number(n))) return null;
+  return `×${Number(n).toFixed(2)}`;
+}
+
+export function chipsFromEvent(ev) {
+  const chips = [];
+  const m = ev.modifiers || {};
+
+  if (m.honeymoon || (ev.honeymoon_mult != null && ev.honeymoon_mult > 1)) {
+    chips.push({ kind: "honeymoon", label: "🌱 蜜月", value: fmtMult(ev.honeymoon_mult) });
+  }
+  if (m.active_trial_star) {
+    chips.push({
+      kind: "trial",
+      label: `⚔ ★${m.active_trial_star}`,
+      value: fmtMult(ev.trial_mult),
+    });
+  }
+  if (Array.isArray(m.blessings) && m.blessings.includes(1)) {
+    const v = ev.blessing1_mult > 1 ? fmtMult(ev.blessing1_mult) : null;
+    chips.push({ kind: "blessing", label: "🗣 暖流", value: v });
+  }
+  if (ev.group_bonus != null && ev.group_bonus > 1) {
+    chips.push({ kind: "group", label: "群組", value: fmtMult(ev.group_bonus) });
+  }
+  if (ev.diminish_factor != null && ev.diminish_factor < 1) {
+    const tier = ev.diminish_factor === 0.3 ? "dim2" : "dim3";
+    chips.push({ kind: tier, label: "已遞減", value: fmtMult(ev.diminish_factor) });
+  }
+  if (m.permanent_xp_multiplier && m.permanent_xp_multiplier > 0) {
+    chips.push({ kind: "perm", label: "永久", value: fmtMult(1 + m.permanent_xp_multiplier) });
+  }
+  return chips;
+}

--- a/frontend/src/pages/XpHistory/chipsFromEvent.js
+++ b/frontend/src/pages/XpHistory/chipsFromEvent.js
@@ -1,13 +1,15 @@
-function fmtMult(n) {
-  if (n == null || !Number.isFinite(Number(n))) return null;
-  return `×${Number(n).toFixed(2)}`;
-}
+import { mult } from "./format";
+import { TIER2_RATE } from "./diminishTier";
+
+const BLESSING_WARM_CURRENT = 1;
+
+const fmtMult = n => (Number.isFinite(Number(n)) ? mult(n) : null);
 
 export function chipsFromEvent(ev) {
   const chips = [];
   const m = ev.modifiers || {};
 
-  if (m.honeymoon || (ev.honeymoon_mult != null && ev.honeymoon_mult > 1)) {
+  if (ev.honeymoon_mult > 1 || m.honeymoon) {
     chips.push({ kind: "honeymoon", label: "🌱 蜜月", value: fmtMult(ev.honeymoon_mult) });
   }
   if (m.active_trial_star) {
@@ -17,18 +19,18 @@ export function chipsFromEvent(ev) {
       value: fmtMult(ev.trial_mult),
     });
   }
-  if (Array.isArray(m.blessings) && m.blessings.includes(1)) {
+  if (Array.isArray(m.blessings) && m.blessings.includes(BLESSING_WARM_CURRENT)) {
     const v = ev.blessing1_mult > 1 ? fmtMult(ev.blessing1_mult) : null;
     chips.push({ kind: "blessing", label: "🗣 暖流", value: v });
   }
-  if (ev.group_bonus != null && ev.group_bonus > 1) {
+  if (ev.group_bonus > 1) {
     chips.push({ kind: "group", label: "群組", value: fmtMult(ev.group_bonus) });
   }
   if (ev.diminish_factor != null && ev.diminish_factor < 1) {
-    const tier = ev.diminish_factor === 0.3 ? "dim2" : "dim3";
+    const tier = ev.diminish_factor === TIER2_RATE ? "dim2" : "dim3";
     chips.push({ kind: tier, label: "已遞減", value: fmtMult(ev.diminish_factor) });
   }
-  if (m.permanent_xp_multiplier && m.permanent_xp_multiplier > 0) {
+  if (m.permanent_xp_multiplier > 0) {
     chips.push({ kind: "perm", label: "永久", value: fmtMult(1 + m.permanent_xp_multiplier) });
   }
   return chips;

--- a/frontend/src/pages/XpHistory/dateTpe.js
+++ b/frontend/src/pages/XpHistory/dateTpe.js
@@ -1,0 +1,36 @@
+// Backend day boundary is Asia/Taipei (UTC+8); see XpHistoryService.todayDateUtc8.
+const DATE_FMT_ISO = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Taipei",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+const DATE_FMT_BADGE = new Intl.DateTimeFormat("zh-TW", {
+  timeZone: "Asia/Taipei",
+  month: "2-digit",
+  day: "2-digit",
+  weekday: "short",
+});
+
+export function todayTpe() {
+  return DATE_FMT_ISO.format(new Date());
+}
+
+export function tpeDate(ts) {
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? "" : DATE_FMT_ISO.format(d);
+}
+
+export function addDaysTpe(date, days) {
+  const d = new Date(`${date}T00:00:00+08:00`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return DATE_FMT_ISO.format(d);
+}
+
+export function formatDateBadge(dateStr) {
+  if (!dateStr) return "";
+  const d = new Date(`${dateStr}T00:00:00+08:00`);
+  if (Number.isNaN(d.getTime())) return dateStr;
+  return DATE_FMT_BADGE.format(d).replace("週", "");
+}

--- a/frontend/src/pages/XpHistory/format.js
+++ b/frontend/src/pages/XpHistory/format.js
@@ -1,0 +1,7 @@
+export const trim = n => {
+  const num = Number(n);
+  if (!Number.isFinite(num)) return "0";
+  return Number(num.toFixed(2)).toString();
+};
+
+export const mult = n => `×${trim(n)}`;

--- a/frontend/src/pages/XpHistory/index.jsx
+++ b/frontend/src/pages/XpHistory/index.jsx
@@ -23,6 +23,7 @@ import EventList from "./EventList";
 import DailyTrend from "./DailyTrend";
 import TodayHeader from "./TodayHeader";
 import { makeGroupLabel } from "./groupLabel";
+import { addDaysTpe, todayTpe } from "./dateTpe";
 
 const GLOSSARY = [
   { term: "原始 XP", body: "每則訊息的帳面值（基礎 × 冷卻 × 群組 × 暖流）。" },
@@ -35,21 +36,6 @@ const GLOSSARY = [
   { term: "試煉", body: "★2 ×0.7、★5 ×0.5；★3 拉長冷卻、★4 關閉群組加成。" },
   { term: "永久", body: "轉生獎勵或活動發出的永久 XP 加成，可累加。" },
 ];
-
-// Backend day boundary is Asia/Taipei (UTC+8); see XpHistoryService.todayDateUtc8.
-const DATE_FMT_TPE = new Intl.DateTimeFormat("en-CA", {
-  timeZone: "Asia/Taipei",
-  year: "numeric",
-  month: "2-digit",
-  day: "2-digit",
-});
-const TODAY = () => DATE_FMT_TPE.format(new Date());
-
-function addDays(date, days) {
-  const d = new Date(`${date}T00:00:00+08:00`);
-  d.setUTCDate(d.getUTCDate() + days);
-  return DATE_FMT_TPE.format(d);
-}
 
 export default function XpHistory() {
   const { loggedIn } = useLiff();
@@ -70,8 +56,8 @@ export default function XpHistory() {
 
   useEffect(() => {
     if (!loggedIn) return;
-    const to = TODAY();
-    const from = addDays(to, -1);
+    const to = todayTpe();
+    const from = addDaysTpe(to, -1);
     api
       .get(`/api/me/xp-events?from=${from}&to=${to}`)
       .then(res => setEvents(Array.isArray(res.data.events) ? res.data.events : []));
@@ -102,8 +88,8 @@ export default function XpHistory() {
 
   useEffect(() => {
     if (!loggedIn) return;
-    const to = TODAY();
-    const from = addDays(to, -(dailyRange - 1));
+    const to = todayTpe();
+    const from = addDaysTpe(to, -(dailyRange - 1));
     api
       .get(`/api/me/xp-daily?from=${from}&to=${to}`)
       .then(res => setDays(Array.isArray(res.data.days) ? res.data.days : []));

--- a/frontend/src/pages/XpHistory/index.jsx
+++ b/frontend/src/pages/XpHistory/index.jsx
@@ -21,6 +21,7 @@ import api from "../../services/api";
 import { fetchGroupSummarys } from "../../services/group";
 import EventList from "./EventList";
 import DailyTrend from "./DailyTrend";
+import TodayHeader from "./TodayHeader";
 import { makeGroupLabel } from "./groupLabel";
 
 const GLOSSARY = [
@@ -61,6 +62,7 @@ export default function XpHistory() {
   const [days, setDays] = useState([]);
   const [dailyRange, setDailyRange] = useState(30);
   const [groupNames, setGroupNames] = useState({});
+  const [summary, setSummary] = useState(null);
 
   useEffect(() => {
     document.title = "經驗歷程";
@@ -73,6 +75,14 @@ export default function XpHistory() {
     api
       .get(`/api/me/xp-events?from=${from}&to=${to}`)
       .then(res => setEvents(Array.isArray(res.data.events) ? res.data.events : []));
+  }, [loggedIn]);
+
+  useEffect(() => {
+    if (!loggedIn) return;
+    api
+      .get("/api/me/xp-summary")
+      .then(res => setSummary(res.data?.today || null))
+      .catch(() => setSummary(null));
   }, [loggedIn]);
 
   useEffect(() => {
@@ -130,8 +140,51 @@ export default function XpHistory() {
         <Tab label="每日趨勢" />
       </Tabs>
 
-      {tab === 0 && <EventList events={events} showAll={showAll} groupLabel={groupLabel} />}
-      {tab === 1 && <DailyTrend days={days} range={dailyRange} onRangeChange={setDailyRange} />}
+      {tab === 0 && (
+        <Stack gap={1.75}>
+          <TodayHeader summary={summary} />
+          <Typography
+            sx={{
+              fontFamily: "ui-monospace, Menlo, monospace",
+              fontSize: 11,
+              letterSpacing: "0.1em",
+              color: "text.disabled",
+              pl: 0.5,
+            }}
+          >
+            訊息事件
+          </Typography>
+          <EventList
+            events={events}
+            showAll={showAll}
+            groupLabel={groupLabel}
+            defaultExpanded="first"
+          />
+        </Stack>
+      )}
+      {tab === 1 && (
+        <Stack gap={1.5}>
+          <DailyTrend days={days} range={dailyRange} onRangeChange={setDailyRange} />
+          <Box
+            sx={{
+              p: 1.5,
+              bgcolor: "background.paper",
+              borderRadius: 1.5,
+              border: 1,
+              borderColor: "divider",
+              fontSize: 12,
+              color: "text.secondary",
+              lineHeight: 1.7,
+            }}
+          >
+            <Box component="strong" sx={{ color: "text.primary" }}>
+              怎麼讀？
+            </Box>{" "}
+            金黃段 = 實得 XP；半透明灰 = 因遞減 / 試煉而流失。長條下方徽章標注該日狀態 — 🌱 蜜月、⚔
+            試煉中。
+          </Box>
+        </Stack>
+      )}
 
       <Drawer
         anchor="bottom"


### PR DESCRIPTION
## Summary

- Align the **/xp-history** LIFF page with the new design handoff: gradient `TodayHeader` summary card, date-grouped event list with chip rows beneath each group name, and a two-line horizontal `raw → effective` multiplier-chain breakdown.
- Replace the hand-rolled SVG daily trend with **Recharts** (already in `frontend/package.json`): stacked `effective` / `loss` bars, honeymoon / trial `ReferenceArea` bands, custom tooltip, and a new `1D` entry on the range picker.
- Translate residual English UI strings (`raw` / `effective` / `loss` / range labels) to Traditional Chinese throughout the page.
- Surface **經驗歷程** in `NavDrawer` and regroup sections by domain so single-item sections stop floating in `mainItems`:
  - top-level: 首頁 · 排行榜
  - 聊天等級: 轉生之路 · 經驗歷程
  - 公主連結: 轉蛋商店 · 轉蛋包包 · 裝備管理
  - 競技場: 猜拳競技場 · 蘭德索爾盃
  - 機器人功能 / 個人功能 / 管理員 / 相關連結
- Make the mobile drawer fluid: paper width clamped to `min(260px, 86vw)` and `overflowX: hidden` on both the inner Box and paper to remove the horizontal-scroll feel on narrow phones.

## Test plan

- [ ] `yarn lint:frontend` is clean (0 errors).
- [ ] `yarn build:frontend` succeeds.
- [ ] `/xp-history` Tab 1 renders TodayHeader, date-grouped events with chips, latest event auto-expanded; chain breakdown shows `base × … → 原始 N` and `原始 N × … → 實得 M`.
- [ ] `/xp-history` Tab 2 renders the Recharts stacked bar chart with honeymoon / trial bands and tooltip; range buttons cover 今天 / 7 天 / 30 天 / 90 天 / 1 年.
- [ ] `NavDrawer` shows the new groupings; 經驗歷程 entry navigates to `/xp-history`.
- [ ] On a phone-width viewport, opening the menu does not introduce horizontal scrolling on the page or the drawer paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)