### PR TITLE
fix(xp-history): correct daily trend chart axis rendering

### DIFF
--- a/frontend/src/pages/XpHistory/DailyTrend.jsx
+++ b/frontend/src/pages/XpHistory/DailyTrend.jsx
@@ -202,10 +202,13 @@ export default function DailyTrend({ days, range, onRangeChange }) {
               ))}
               <XAxis
                 dataKey="date"
-                tickFormatter={v => (v || "").slice(5).replace("-", "/")}
+                tickFormatter={v => {
+                  const dateOnly = (v || "").slice(0, 10);
+                  return dateOnly.slice(5).replace("-", "/");
+                }}
                 tick={{
                   fontSize: 9,
-                  fontFamily: "ui-monospace, Menlo, monospace",
+                  fontFamily: "system-ui, sans-serif",
                   fill: COLORS.muted,
                 }}
                 interval={tickInterval}
@@ -218,7 +221,7 @@ export default function DailyTrend({ days, range, onRangeChange }) {
               <YAxis
                 tick={{
                   fontSize: 9,
-                  fontFamily: "ui-monospace, Menlo, monospace",
+                  fontFamily: "system-ui, sans-serif",
                   fill: COLORS.muted,
                 }}
                 axisLine={false}


### PR DESCRIPTION
## Summary
- X 軸 `tickFormatter` 先 `slice(0, 10)` 取 `YYYY-MM-DD` 再 format，避免 API 回傳 ISO datetime 時 tick label 帶出 `T16:00:00`
- X / Y 軸 tick `fontFamily` 改為 `system-ui, sans-serif`，修正 iOS monospace 上 `1` 看起來像 `L`（例：`L40k`）

## Test plan
- [ ] 趨勢 tab 切 1D：單天 bar 不撐滿，X 軸顯示正確日期
- [ ] 趨勢 tab 切 30D：X 軸顯示 `MM/DD` 不帶時間
- [ ] iOS Safari / LIFF 內檢查 Y 軸數字（如 `40k`）字形正確、不再像 `L40k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)