### PR TITLE
perf(app): redis profile cache + batch achievement progress query

### DIFF
--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -15,6 +15,7 @@ jest.mock("../../src/model/application/UserAchievement", () => ({
 }));
 jest.mock("../../src/model/application/UserAchievementProgress", () => ({
   getProgress: jest.fn(),
+  getProgressByIds: jest.fn().mockResolvedValue(new Map()),
   upsert: jest.fn(),
   increment: jest.fn(),
   delete: jest.fn(),
@@ -81,7 +82,12 @@ describe("AchievementEngine", () => {
 
     it("should update progress and not unlock if below target", async () => {
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
-      UserProgressModel.getProgress.mockResolvedValue({ current_value: 50 });
+      UserProgressModel.getProgressByIds.mockResolvedValue(
+        new Map([
+          [1, 50],
+          [2, 50],
+        ])
+      );
       UserProgressModel.upsert.mockResolvedValue();
 
       await AchievementEngine.evaluate("user1", "chat_message", {});
@@ -95,7 +101,12 @@ describe("AchievementEngine", () => {
 
     it("should unlock when progress reaches target", async () => {
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
-      UserProgressModel.getProgress.mockResolvedValue({ current_value: 99 });
+      UserProgressModel.getProgressByIds.mockResolvedValue(
+        new Map([
+          [1, 99],
+          [2, 99],
+        ])
+      );
       UserProgressModel.upsert.mockResolvedValue();
       UserAchievementModel.unlock.mockResolvedValue();
       UserProgressModel.delete.mockResolvedValue();
@@ -128,7 +139,7 @@ describe("AchievementEngine", () => {
         },
       ]);
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
-      UserProgressModel.getProgress.mockResolvedValue({ current_value: 1 });
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[1, 1]]));
       UserProgressModel.upsert.mockResolvedValue();
 
       const result = await AchievementEngine.evaluate("user1", "chat_message", {});
@@ -150,7 +161,7 @@ describe("AchievementEngine", () => {
       };
       AchievementEngine._setCache([achievement]);
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
-      UserProgressModel.getProgress.mockResolvedValue({ current_value: 99 });
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[2, 99]]));
       UserProgressModel.upsert.mockResolvedValue();
       UserAchievementModel.unlock.mockResolvedValue();
       UserProgressModel.delete.mockResolvedValue();
@@ -178,7 +189,7 @@ describe("AchievementEngine", () => {
       };
       AchievementEngine._setCache([achievement]);
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
-      UserProgressModel.getProgress.mockResolvedValue({ current_value: 99 });
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[2, 99]]));
       UserProgressModel.upsert.mockResolvedValue();
       UserAchievementModel.unlock.mockResolvedValue();
       UserProgressModel.delete.mockResolvedValue();
@@ -503,7 +514,7 @@ describe("AchievementEngine", () => {
     });
 
     it("increments progress for the tagged mentionee when keywords match", async () => {
-      UserProgressModel.getProgress.mockResolvedValue({ current_value: 3 });
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[60, 3]]));
 
       await AchievementEngine.evaluate("Uadmin", "received_mention", {
         mentionedByUserId: "Ufan",
@@ -515,7 +526,7 @@ describe("AchievementEngine", () => {
     });
 
     it("unlocks when cumulative mentions reach target_value", async () => {
-      UserProgressModel.getProgress.mockResolvedValue({ current_value: 9 });
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[60, 9]]));
 
       const result = await AchievementEngine.evaluate("Uadmin", "received_mention", {
         mentionedByUserId: "Ufan",

--- a/app/src/middleware/__tests__/profile.test.js
+++ b/app/src/middleware/__tests__/profile.test.js
@@ -1,0 +1,109 @@
+jest.mock("../../util/redis", () => ({
+  get: jest.fn(),
+  set: jest.fn().mockResolvedValue("OK"),
+}));
+jest.mock("../../util/Logger", () => ({
+  DefaultLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.mock("../../util/line", () => ({
+  getGroupSummary: jest.fn().mockResolvedValue({ groupName: "g" }),
+  getGroupCount: jest.fn().mockResolvedValue({ count: 1 }),
+}));
+jest.mock("../../model/application/UserModel", () => ({
+  ensureUser: jest.fn().mockResolvedValue(1),
+  updateProfile: jest.fn().mockResolvedValue(),
+}));
+
+const redis = require("../../util/redis");
+const profileMiddleware = require("../profile");
+const { setLineProfile } = profileMiddleware._internal;
+
+function makeContext({ userId = "Ualice", cachedDatas = {}, getUserProfile } = {}) {
+  return {
+    platform: "line",
+    event: { source: { userId, type: "user" } },
+    state: { userDatas: cachedDatas, groupDatas: {} },
+    setState: jest.fn(function (patch) {
+      this.state = { ...this.state, ...patch };
+    }),
+    getUserProfile: getUserProfile || jest.fn().mockResolvedValue({ userId, displayName: "Alice" }),
+  };
+}
+
+describe("middleware/profile setLineProfile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redis.get.mockResolvedValue(null);
+  });
+
+  it("short-circuits when userDatas already has the user (in-session hit)", async () => {
+    const ctx = makeContext({ cachedDatas: { Ualice: { displayName: "Alice" } } });
+
+    await setLineProfile(ctx);
+
+    expect(redis.get).not.toHaveBeenCalled();
+    expect(ctx.getUserProfile).not.toHaveBeenCalled();
+    expect(ctx.setState).not.toHaveBeenCalled();
+  });
+
+  it("uses redis cache profile:{userId} when present and skips LINE API", async () => {
+    redis.get.mockResolvedValueOnce(JSON.stringify({ userId: "Ualice", displayName: "Cached" }));
+    const ctx = makeContext();
+
+    await setLineProfile(ctx);
+
+    expect(redis.get).toHaveBeenCalledWith("profile:Ualice");
+    expect(ctx.getUserProfile).not.toHaveBeenCalled();
+    expect(ctx.setState).toHaveBeenCalledWith({
+      userDatas: { Ualice: { userId: "Ualice", displayName: "Cached" } },
+    });
+  });
+
+  it("on redis miss, fetches via LINE API and writes profile:{userId} with EX 1800", async () => {
+    redis.get.mockResolvedValueOnce(null);
+    const ctx = makeContext();
+
+    await setLineProfile(ctx);
+
+    expect(ctx.getUserProfile).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledWith(
+      "profile:Ualice",
+      JSON.stringify({ userId: "Ualice", displayName: "Alice" }),
+      { EX: 1800 }
+    );
+  });
+
+  it("times out the LINE API call and skips state update when fetch hangs past 200ms", async () => {
+    redis.get.mockResolvedValueOnce(null);
+    let pendingTimer;
+    const ctx = makeContext({
+      getUserProfile: jest.fn(
+        () =>
+          new Promise(resolve => {
+            pendingTimer = setTimeout(() => resolve({ displayName: "Slow" }), 1000);
+          })
+      ),
+    });
+
+    try {
+      await setLineProfile(ctx);
+
+      expect(ctx.setState).not.toHaveBeenCalled();
+      expect(redis.set).not.toHaveBeenCalled();
+    } finally {
+      if (pendingTimer) clearTimeout(pendingTimer);
+    }
+  });
+
+  it("survives a redis.get failure by falling through to LINE API", async () => {
+    redis.get.mockRejectedValueOnce(new Error("redis down"));
+    const ctx = makeContext();
+
+    await setLineProfile(ctx);
+
+    expect(ctx.getUserProfile).toHaveBeenCalledTimes(1);
+    expect(ctx.setState).toHaveBeenCalledWith({
+      userDatas: { Ualice: { userId: "Ualice", displayName: "Alice" } },
+    });
+  });
+});

--- a/app/src/middleware/profile.js
+++ b/app/src/middleware/profile.js
@@ -1,13 +1,24 @@
 const { getGroupSummary, getGroupCount } = require("../util/line");
 const UserModel = require("../model/application/UserModel");
 const redis = require("../util/redis");
+const { DefaultLogger } = require("../util/Logger");
+
+// Cross-session profile cache. Bottender's per-session state cache only helps
+// for repeat messages from the SAME user within the SAME session — in busy
+// groups every new speaker pays an LINE API roundtrip. Keying on user id in
+// Redis lets a profile fetched in group X serve a request in group Y.
+const PROFILE_CACHE_TTL_SEC = 30 * 60;
+// Cap getUserProfile latency so a transient LINE API stall (observed up to
+// ~800ms on media events) doesn't pin total reply time at >1s. On miss we
+// drop the profile for this event; downstream renderers already fall back.
+const LINE_PROFILE_TIMEOUT_MS = 200;
 
 /**
  * 設置用戶、群組資料
  * @param {Context} context
  * @param {Object} props
  */
-module.exports = async (context, props) => {
+const middleware = async (context, props) => {
   switch (context.platform) {
     case "line":
       // 不處理無userId的用戶
@@ -26,25 +37,63 @@ module.exports = async (context, props) => {
 };
 
 /**
- * 設定Line個人資料至State
+ * 設定Line個人資料至State。三層 cache：in-session userDatas → redis
+ * `profile:{userId}` (30 分鐘) → LINE API（200ms timeout）。
  * @param {Context} context
  */
-function setLineProfile(context) {
+async function setLineProfile(context) {
   const { userDatas } = context.state;
   const { userId } = context.event.source;
 
-  if (Object.prototype.hasOwnProperty.call(userDatas, userId) === true) return;
+  if (Object.prototype.hasOwnProperty.call(userDatas, userId)) return;
 
-  return context.getUserProfile().then(profile => {
-    let temp = { ...userDatas };
-    temp[userId] = profile;
-    context.setState({
-      userDatas: temp,
-    });
+  let profile = await readProfileFromRedis(userId);
 
-    // Best-effort update profile in DB
-    UserModel.updateProfile(userId, profile).catch(() => {});
+  if (!profile) {
+    profile = await fetchLineProfileWithTimeout(context);
+    if (profile) writeProfileToRedis(userId, profile);
+  }
+
+  if (!profile) return;
+
+  context.setState({
+    userDatas: { ...userDatas, [userId]: profile },
   });
+
+  UserModel.updateProfile(userId, profile).catch(() => {});
+}
+
+async function readProfileFromRedis(userId) {
+  try {
+    const cached = await redis.get(`profile:${userId}`);
+    return cached ? JSON.parse(cached) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeProfileToRedis(userId, profile) {
+  redis
+    .set(`profile:${userId}`, JSON.stringify(profile), { EX: PROFILE_CACHE_TTL_SEC })
+    .catch(() => {});
+}
+
+async function fetchLineProfileWithTimeout(context) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`getUserProfile timeout (${LINE_PROFILE_TIMEOUT_MS}ms)`)),
+      LINE_PROFILE_TIMEOUT_MS
+    );
+  });
+  try {
+    return await Promise.race([context.getUserProfile(), timeout]);
+  } catch (err) {
+    DefaultLogger.warn(`setLineProfile: ${err && err.message}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function setLineGroupSummary(context) {
@@ -79,3 +128,10 @@ async function setUserId(context) {
   await redis.set(`user:${platformId}`, id);
   context.event._rawEvent.source = { ...context.event.source, id };
 }
+
+module.exports = middleware;
+module.exports._internal = {
+  setLineProfile,
+  PROFILE_CACHE_TTL_SEC,
+  LINE_PROFILE_TIMEOUT_MS,
+};

--- a/app/src/middleware/profile.js
+++ b/app/src/middleware/profile.js
@@ -3,14 +3,9 @@ const UserModel = require("../model/application/UserModel");
 const redis = require("../util/redis");
 const { DefaultLogger } = require("../util/Logger");
 
-// Cross-session profile cache. Bottender's per-session state cache only helps
-// for repeat messages from the SAME user within the SAME session — in busy
-// groups every new speaker pays an LINE API roundtrip. Keying on user id in
-// Redis lets a profile fetched in group X serve a request in group Y.
+// Cross-session redis cache so a profile fetched in group X serves group Y.
 const PROFILE_CACHE_TTL_SEC = 30 * 60;
-// Cap getUserProfile latency so a transient LINE API stall (observed up to
-// ~800ms on media events) doesn't pin total reply time at >1s. On miss we
-// drop the profile for this event; downstream renderers already fall back.
+// Cap LINE API stalls so total reply time stays under ~1s.
 const LINE_PROFILE_TIMEOUT_MS = 200;
 
 /**
@@ -130,8 +125,4 @@ async function setUserId(context) {
 }
 
 module.exports = middleware;
-module.exports._internal = {
-  setLineProfile,
-  PROFILE_CACHE_TTL_SEC,
-  LINE_PROFILE_TIMEOUT_MS,
-};
+module.exports._internal = { setLineProfile };

--- a/app/src/model/application/UserAchievementProgress.js
+++ b/app/src/model/application/UserAchievementProgress.js
@@ -15,14 +15,9 @@ exports.getProgress = async (userId, achievementId) => {
 };
 
 /**
- * Batch fetch progress rows for one user across multiple achievements. Returns
- * a Map keyed by achievement_id → current_value. Used by AchievementEngine.evaluate
- * to collapse a per-event N+1 (was the dominant duplicate query in production
- * timing logs — every chat_message event re-issued the same single-row select 3+ times).
- *
  * @param {string} userId
  * @param {Array<number>} achievementIds
- * @returns {Promise<Map<number, number>>}
+ * @returns {Promise<Map<number, number>>} achievement_id → current_value
  */
 exports.getProgressByIds = async (userId, achievementIds) => {
   if (!Array.isArray(achievementIds) || achievementIds.length === 0) return new Map();

--- a/app/src/model/application/UserAchievementProgress.js
+++ b/app/src/model/application/UserAchievementProgress.js
@@ -14,6 +14,25 @@ exports.getProgress = async (userId, achievementId) => {
   return mysql(TABLE).where({ user_id: userId, achievement_id: achievementId }).first();
 };
 
+/**
+ * Batch fetch progress rows for one user across multiple achievements. Returns
+ * a Map keyed by achievement_id → current_value. Used by AchievementEngine.evaluate
+ * to collapse a per-event N+1 (was the dominant duplicate query in production
+ * timing logs — every chat_message event re-issued the same single-row select 3+ times).
+ *
+ * @param {string} userId
+ * @param {Array<number>} achievementIds
+ * @returns {Promise<Map<number, number>>}
+ */
+exports.getProgressByIds = async (userId, achievementIds) => {
+  if (!Array.isArray(achievementIds) || achievementIds.length === 0) return new Map();
+  const rows = await mysql(TABLE)
+    .where("user_id", userId)
+    .whereIn("achievement_id", achievementIds)
+    .select("achievement_id", "current_value");
+  return new Map(rows.map(r => [r.achievement_id, r.current_value]));
+};
+
 exports.upsert = async (userId, achievementId, currentValue) => {
   return mysql.raw(
     `INSERT INTO ${TABLE} (user_id, achievement_id, current_value, updated_at)

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -212,24 +212,17 @@ exports.evaluate = async (userId, eventType, context = {}) => {
       .filter(a => isEligible(userId, a));
     if (achievements.length === 0) return { unlocked };
 
-    const unlockedIds = await UserAchievementModel.getUnlockedIds(
-      userId,
-      achievements.map(a => a.id)
-    );
-
-    // Pre-fetch all progress rows in one whereIn query. Each chat_message used
-    // to re-issue `select * from user_achievement_progress where user_id=? and
-    // achievement_id=? limit 1` per achievement key — visible in production
-    // timing dups for ~60% of events.
-    const candidateIds = achievements.filter(a => !unlockedIds.has(a.id)).map(a => a.id);
-    const progressMap = await UserProgressModel.getProgressByIds(userId, candidateIds);
+    const allIds = achievements.map(a => a.id);
+    const [unlockedIds, progressMap] = await Promise.all([
+      UserAchievementModel.getUnlockedIds(userId, allIds),
+      UserProgressModel.getProgressByIds(userId, allIds),
+    ]);
 
     const ctx = { ...context, _userId: userId };
+    const candidates = achievements.filter(a => !unlockedIds.has(a.id));
 
-    for (const achievement of achievements) {
+    for (const achievement of candidates) {
       try {
-        if (unlockedIds.has(achievement.id)) continue;
-
         const currentValue = progressMap.get(achievement.id) || 0;
         const strategy = ACHIEVEMENT_STRATEGY[achievement.key];
         const newValue = strategy ? await strategy(currentValue, achievement, ctx) : currentValue;

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -217,13 +217,22 @@ exports.evaluate = async (userId, eventType, context = {}) => {
       achievements.map(a => a.id)
     );
 
+    // Pre-fetch all progress rows in one whereIn query. Each chat_message used
+    // to re-issue `select * from user_achievement_progress where user_id=? and
+    // achievement_id=? limit 1` per achievement key — visible in production
+    // timing dups for ~60% of events.
+    const candidateIds = achievements.filter(a => !unlockedIds.has(a.id)).map(a => a.id);
+    const progressMap = await UserProgressModel.getProgressByIds(userId, candidateIds);
+
     const ctx = { ...context, _userId: userId };
 
     for (const achievement of achievements) {
       try {
         if (unlockedIds.has(achievement.id)) continue;
 
-        const { currentValue, newValue } = await calculateProgress(userId, achievement, ctx);
+        const currentValue = progressMap.get(achievement.id) || 0;
+        const strategy = ACHIEVEMENT_STRATEGY[achievement.key];
+        const newValue = strategy ? await strategy(currentValue, achievement, ctx) : currentValue;
         if (newValue === null || newValue === currentValue) continue;
 
         await UserProgressModel.upsert(userId, achievement.id, newValue);
@@ -244,16 +253,6 @@ exports.evaluate = async (userId, eventType, context = {}) => {
   }
   return { unlocked };
 };
-
-async function calculateProgress(userId, achievement, context) {
-  const progress = await UserProgressModel.getProgress(userId, achievement.id);
-  const currentValue = progress ? progress.current_value : 0;
-
-  const strategy = ACHIEVEMENT_STRATEGY[achievement.key];
-  const newValue = strategy ? await strategy(currentValue, achievement, context) : currentValue;
-
-  return { currentValue, newValue };
-}
 
 async function handleTrackedSet(userId, achievementId, newItem, currentValue) {
   if (!newItem) return currentValue;


### PR DESCRIPTION
## Summary
- `setLineProfile` 改用 redis key `profile:{userId}`（30 分鐘 TTL）跨 session 共用，並對 LINE API 加 200ms `Promise.race` timeout — 原本只有 per-session `userDatas`，群組裡每個新發話者都要打一次 LINE API（prod p50 130ms、max 800ms）
- `AchievementEngine.evaluate` 加上 `UserProgressModel.getProgressByIds`（單一 `whereIn`）批次撈 progress，並把它與 `getUnlockedIds` 包進 `Promise.all` 並行 — 修掉 60% 事件出現的 `user_achievement_progress` N+1 dup
- 新增 `profile.test.js` 涵蓋三層 cache（in-session / redis / LINE timeout / redis 故障）；既有 `AchievementEngine.test.js` 改 mock 批次 fetcher

## Test plan
- [x] 單元測試 `yarn test --testPathPattern='profile|AchievementEngine'` 55/55 通過
- [x] 全套件 `yarn test` 673/673 通過、`yarn lint` 乾淨
- [ ] 部署後 `docker logs --since=30m redive_linebot-bot-1 | grep '\[timing\] total='` 觀察：setProfile 在 breakdown 出現比例 < 30%（原 75%）
- [ ] 部署後 `[query]` log 內不再看到 `user_achievement_progress` 重複 single-row select
- [ ] total p50 < 80ms（原 142ms）、p95 < 300ms（原 ~780ms）

🤖 Generated with [Claude Code](https://claude.com/claude-code)