### PR TITLE
fix(xp-history): timezone leak + mobile chip overlap

### DIFF
--- a/app/src/service/XpHistoryService.js
+++ b/app/src/service/XpHistoryService.js
@@ -1,11 +1,8 @@
-const moment = require("moment");
 const ChatExpEvent = require("../model/application/ChatExpEvent");
 const ChatExpDaily = require("../model/application/ChatExpDaily");
 const UserBlessing = require("../model/application/UserBlessing");
 const { resolveTierUppers } = require("./chatXp/diminishTier");
-const { todayUtc8 } = require("../util/date");
-
-const TPE_OFFSET_MIN = 480;
+const { todayUtc8, toUtc8Date } = require("../util/date");
 
 function deriveTier(dailyRaw, tier1Upper, tier2Upper) {
   if (dailyRaw < tier1Upper) return 1;
@@ -100,7 +97,7 @@ async function buildDaily(userId, { from, to }) {
     .orderBy("date", "asc");
   return {
     days: rows.map(r => ({
-      date: moment(r.date).utcOffset(TPE_OFFSET_MIN).format("YYYY-MM-DD"),
+      date: toUtc8Date(r.date),
       raw_exp: r.raw_exp,
       effective_exp: r.effective_exp,
       msg_count: r.msg_count,

--- a/app/src/service/XpHistoryService.js
+++ b/app/src/service/XpHistoryService.js
@@ -1,8 +1,11 @@
+const moment = require("moment");
 const ChatExpEvent = require("../model/application/ChatExpEvent");
 const ChatExpDaily = require("../model/application/ChatExpDaily");
 const UserBlessing = require("../model/application/UserBlessing");
 const { resolveTierUppers } = require("./chatXp/diminishTier");
 const { todayUtc8 } = require("../util/date");
+
+const TPE_OFFSET_MIN = 480;
 
 function deriveTier(dailyRaw, tier1Upper, tier2Upper) {
   if (dailyRaw < tier1Upper) return 1;
@@ -97,7 +100,7 @@ async function buildDaily(userId, { from, to }) {
     .orderBy("date", "asc");
   return {
     days: rows.map(r => ({
-      date: r.date,
+      date: moment(r.date).utcOffset(TPE_OFFSET_MIN).format("YYYY-MM-DD"),
       raw_exp: r.raw_exp,
       effective_exp: r.effective_exp,
       msg_count: r.msg_count,

--- a/app/src/util/date.js
+++ b/app/src/util/date.js
@@ -2,6 +2,8 @@ const moment = require("moment");
 
 const TPE_OFFSET_MIN = 480;
 
+exports.toUtc8Date = input => moment(input).utcOffset(TPE_OFFSET_MIN).format("YYYY-MM-DD");
+
 exports.todayUtc8 = () => moment().utcOffset(TPE_OFFSET_MIN).format("YYYY-MM-DD");
 
 exports.yesterdayUtc8 = () =>

--- a/frontend/src/pages/XpHistory/DailyTrend.jsx
+++ b/frontend/src/pages/XpHistory/DailyTrend.jsx
@@ -10,6 +10,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { formatDateBadge } from "./dateTpe";
 
 const COLORS = {
   amber: "#FBBF24",
@@ -70,7 +71,7 @@ function TrendTooltip({ active, payload }) {
         minWidth: 120,
       }}
     >
-      <Box sx={{ color: COLORS.text, fontWeight: 700, mb: 0.25 }}>{d.date}</Box>
+      <Box sx={{ color: COLORS.text, fontWeight: 700, mb: 0.25 }}>{formatDateBadge(d.date)}</Box>
       <Box>
         原始{" "}
         <Box component="span" sx={{ color: COLORS.muted }}>

--- a/frontend/src/pages/XpHistory/EventList.jsx
+++ b/frontend/src/pages/XpHistory/EventList.jsx
@@ -139,73 +139,84 @@ function FoldedRow({ folded, expanded, onToggle, showAll, groupLabel }) {
           sx={{
             p: 1.5,
             cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            gap: 1.25,
           }}
         >
-          <Box
-            sx={{
-              fontFamily: "ui-monospace, Menlo, monospace",
-              fontSize: 13,
-              fontWeight: 700,
-              minWidth: 42,
-            }}
-          >
-            {localHHMM(folded.ts)}
-          </Box>
-          <Stack sx={{ flex: 1, minWidth: 0 }} gap={0.5}>
-            <Typography
-              sx={{
-                fontSize: 12,
-                color: "text.secondary",
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
-              {groupLabel(folded.group_id)}
-              {folded.count > 1 && (
-                <Box component="span" sx={{ color: "warning.main", fontWeight: 700 }}>
-                  {" "}
-                  · ×{folded.count}
-                </Box>
-              )}
-            </Typography>
-            <EventChipRow chips={chips} />
-          </Stack>
-          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
-            <Typography
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
+            <Box
               sx={{
                 fontFamily: "ui-monospace, Menlo, monospace",
-                fontSize: 11,
-                color: "text.secondary",
-              }}
-            >
-              {folded.raw_total > 0 ? `${folded.raw_total} →` : "→"}
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: "ui-monospace, Menlo, monospace",
-                fontSize: 18,
+                fontSize: 13,
                 fontWeight: 700,
-                color: effTotalColor(folded.eff_total, folded.raw_total),
-                lineHeight: 1,
+                minWidth: 42,
               }}
             >
-              {folded.eff_total}
-            </Typography>
+              {localHHMM(folded.ts)}
+            </Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  color: "text.secondary",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {groupLabel(folded.group_id)}
+                {folded.count > 1 && (
+                  <Box component="span" sx={{ color: "warning.main", fontWeight: 700 }}>
+                    {" "}
+                    · ×{folded.count}
+                  </Box>
+                )}
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-end",
+                flexShrink: 0,
+              }}
+            >
+              <Typography
+                sx={{
+                  fontFamily: "ui-monospace, Menlo, monospace",
+                  fontSize: 11,
+                  color: "text.secondary",
+                }}
+              >
+                {folded.raw_total > 0 ? `${folded.raw_total} →` : "→"}
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: "ui-monospace, Menlo, monospace",
+                  fontSize: 18,
+                  fontWeight: 700,
+                  color: effTotalColor(folded.eff_total, folded.raw_total),
+                  lineHeight: 1,
+                }}
+              >
+                {folded.eff_total}
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                color: "text.disabled",
+                fontSize: 12,
+                transform: expanded ? "rotate(90deg)" : "none",
+                transition: "transform 0.15s",
+                flexShrink: 0,
+              }}
+            >
+              ›
+            </Box>
           </Box>
-          <Box
-            sx={{
-              color: "text.disabled",
-              fontSize: 12,
-              transform: expanded ? "rotate(90deg)" : "none",
-              transition: "transform 0.15s",
-            }}
-          >
-            ›
-          </Box>
+          {chips.length > 0 && (
+            <Box sx={{ mt: 0.75 }}>
+              <EventChipRow chips={chips} />
+            </Box>
+          )}
         </Box>
         {expanded && (
           <Stack gap={1} sx={{ px: 1.5, pb: 1.5 }}>


### PR DESCRIPTION
## Summary

Two user-reported bugs in `經驗歷程` (xp-history):

### 1. Daily trend dates off by one day (Taipei)
- `chat_exp_daily.date` stores a Taipei calendar day (UTC+8), but `mysql2` returned it as a JS Date that JSON-serialized to a UTC ISO string (`2026-05-11T16:00:00.000Z`). The frontend chart sliced this raw string for both X-axis labels and the tooltip, so every bar appeared one day earlier than the user expected.
- Backend: format `r.date` as `YYYY-MM-DD` in Taipei before responding (`XpHistoryService.buildDaily`).
- Frontend: tooltip now renders with `formatDateBadge(d.date)` (e.g. `05/12 (二)`) instead of the raw ISO.

### 2. Multiplier chips overlap effective XP number on mobile
- Chips lived inside the same flex column as the group label and competed with the right-side XP number for width. Each chip is `whiteSpace: nowrap`, so it overflowed into the XP column and the bold `eff_total` text rendered on top of the chip.
- Moved `EventChipRow` to its own full-width row below the header line.
- Added `flexShrink: 0` to the XP column + chevron so they keep their natural width.

## Test plan

- [ ] Reload xp-history page on a mobile LIFF client; daily trend X-axis labels and tooltip show the correct Taipei date (the rightmost bar should read today, not yesterday).
- [ ] On a narrow viewport, the `已遞減` chip wraps to its own line under the header and no longer overlaps the bold effective XP number.
- [ ] Spot-check on desktop that the new chip row layout looks acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)