### PR TITLE
perf(inventory): index userId,itemId + batch achievement upserts + parallel gacha reads

### DIFF
--- a/app/__tests__/model/UserAchievementProgress.test.js
+++ b/app/__tests__/model/UserAchievementProgress.test.js
@@ -1,0 +1,50 @@
+// Unit test for the batch upsert SQL contract. jest.mock is NOT hoisted here
+// (app jest config uses transform:{}), so the mock must precede the require.
+jest.mock("../../src/util/mysql", () => {
+  const knex = jest.fn();
+  knex.raw = jest.fn().mockResolvedValue([{}]);
+  // base.js calls mysql.transactionProvider() at module load.
+  knex.transactionProvider = jest.fn(() => jest.fn());
+  return knex;
+});
+
+const mysql = require("../../src/util/mysql");
+const UserProgress = require("../../src/model/application/UserAchievementProgress");
+
+describe("UserAchievementProgress.upsertMany", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("is a no-op (no SQL) for an empty or non-array argument", async () => {
+    expect(await UserProgress.upsertMany([])).toBeUndefined();
+    expect(await UserProgress.upsertMany(undefined)).toBeUndefined();
+    expect(mysql.raw).not.toHaveBeenCalled();
+  });
+
+  it("emits one parameter-bound INSERT...ON DUPLICATE KEY UPDATE for a single row", async () => {
+    await UserProgress.upsertMany([{ userId: "U1", achievementId: 7, currentValue: 42 }]);
+
+    expect(mysql.raw).toHaveBeenCalledTimes(1);
+    const [sql, bindings] = mysql.raw.mock.calls[0];
+    const groups = sql.match(/\(\?, \?, \?, NOW\(\)\)/g) || [];
+    expect(groups).toHaveLength(1);
+    expect(sql).toMatch(/INSERT INTO user_achievement_progress/);
+    expect(sql).toMatch(/ON DUPLICATE KEY UPDATE current_value = VALUES\(current_value\)/);
+    expect(bindings).toEqual(["U1", 7, 42]);
+  });
+
+  it("flattens many rows into one statement with bindings in row order", async () => {
+    await UserProgress.upsertMany([
+      { userId: "U1", achievementId: 1, currentValue: 10 },
+      { userId: "U1", achievementId: 2, currentValue: 20 },
+      { userId: "U2", achievementId: 3, currentValue: 30 },
+    ]);
+
+    expect(mysql.raw).toHaveBeenCalledTimes(1);
+    const [sql, bindings] = mysql.raw.mock.calls[0];
+    const groups = sql.match(/\(\?, \?, \?, NOW\(\)\)/g) || [];
+    expect(groups).toHaveLength(3);
+    // 3 columns × 3 rows = 9 bindings, flattened in (userId, achievementId, currentValue) order
+    expect(bindings).toEqual(["U1", 1, 10, "U1", 2, 20, "U2", 3, 30]);
+    expect(bindings).toHaveLength(groups.length * 3);
+  });
+});

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -17,6 +17,7 @@ jest.mock("../../src/model/application/UserAchievementProgress", () => ({
   getProgress: jest.fn(),
   getProgressByIds: jest.fn().mockResolvedValue(new Map()),
   upsert: jest.fn(),
+  upsertMany: jest.fn().mockResolvedValue(),
   increment: jest.fn(),
   delete: jest.fn(),
   findByUser: jest.fn(),
@@ -76,7 +77,7 @@ describe("AchievementEngine", () => {
       await AchievementEngine.evaluate("user1", "chat_message", {});
 
       expect(UserAchievementModel.getUnlockedIds).toHaveBeenCalled();
-      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
       expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
     });
 
@@ -94,8 +95,14 @@ describe("AchievementEngine", () => {
 
       // Should not have logged any errors
       expect(DefaultLogger.error).not.toHaveBeenCalled();
+      // Progress writes are now batched into a single upsertMany call.
       // chat_100 progress: 50 + 1 = 51, below target of 100
-      expect(UserProgressModel.upsert).toHaveBeenCalledWith("user1", 1, 51);
+      expect(UserProgressModel.upsertMany).toHaveBeenCalledTimes(1);
+      expect(UserProgressModel.upsertMany).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ userId: "user1", achievementId: 1, currentValue: 51 }),
+        ])
+      );
       expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
     });
 
@@ -122,6 +129,94 @@ describe("AchievementEngine", () => {
     it("should not throw on event with no mapped achievements", async () => {
       await AchievementEngine.evaluate("user1", "unknown_event", {});
       expect(DefaultLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("batches all changed achievements of one event into a single upsertMany call", async () => {
+      // chat_message maps to chat_100 (id1) and chat_1000 (id2); both advance.
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgressByIds.mockResolvedValue(
+        new Map([
+          [1, 50],
+          [2, 80],
+        ])
+      );
+
+      await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      // N+1 collapse: one write for the whole pass, carrying both rows.
+      expect(UserProgressModel.upsertMany).toHaveBeenCalledTimes(1);
+      expect(UserProgressModel.upsertMany).toHaveBeenCalledWith([
+        { userId: "user1", achievementId: 1, currentValue: 51 },
+        { userId: "user1", achievementId: 2, currentValue: 81 },
+      ]);
+    });
+
+    it("does not call upsertMany when no candidate value changes", async () => {
+      // instant-to-target achievement already at/over target → strategy returns
+      // currentValue unchanged, so nothing is collected to write.
+      AchievementEngine._setCache([
+        { id: 1, key: "gacha_first", type: "milestone", target_value: 1, reward_stones: 0 },
+      ]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[1, 1]]));
+
+      await AchievementEngine.evaluate("user1", "gacha_pull", {});
+
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
+    });
+
+    it("still unlocks when the batched progress write fails (write/unlock isolation)", async () => {
+      // chat_100 (id1) and chat_1000 (id2) both cross their target this pass.
+      AchievementEngine._setCache([
+        { id: 1, key: "chat_100", target_value: 100, reward_stones: 50, condition: null },
+        { id: 2, key: "chat_1000", target_value: 1000, reward_stones: 200, condition: null },
+      ]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgressByIds.mockResolvedValue(
+        new Map([
+          [1, 99],
+          [2, 999],
+        ])
+      );
+      UserProgressModel.upsertMany.mockRejectedValueOnce(new Error("deadlock"));
+      UserAchievementModel.unlock.mockResolvedValue();
+      UserProgressModel.delete.mockResolvedValue();
+
+      const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      // Batch failure is logged but does NOT abort the unlocks.
+      expect(DefaultLogger.error).toHaveBeenCalledWith(
+        "AchievementEngine.evaluate batch upsert error:",
+        expect.any(Error)
+      );
+      expect(UserAchievementModel.unlock).toHaveBeenCalledWith("user1", 1);
+      expect(UserAchievementModel.unlock).toHaveBeenCalledWith("user1", 2);
+      expect(result.unlocked.map(a => a.key)).toEqual(["chat_100", "chat_1000"]);
+    });
+
+    it("isolates a failing unlock so the remaining achievements still unlock", async () => {
+      AchievementEngine._setCache([
+        { id: 1, key: "chat_100", target_value: 100, reward_stones: 50, condition: null },
+        { id: 2, key: "chat_1000", target_value: 1000, reward_stones: 200, condition: null },
+      ]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgressByIds.mockResolvedValue(
+        new Map([
+          [1, 99],
+          [2, 999],
+        ])
+      );
+      // First unlock (id1) blows up inside unlockAchievement; second must survive.
+      UserAchievementModel.unlock.mockRejectedValueOnce(new Error("write conflict"));
+      UserAchievementModel.unlock.mockResolvedValue();
+      UserProgressModel.delete.mockResolvedValue();
+
+      const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      expect(DefaultLogger.error).toHaveBeenCalledTimes(1);
+      expect(UserAchievementModel.unlock).toHaveBeenCalledWith("user1", 2);
+      // id1 threw before its push, so only chat_1000 ends up in the result.
+      expect(result.unlocked.map(a => a.key)).toEqual(["chat_1000"]);
     });
   });
 
@@ -479,7 +574,7 @@ describe("AchievementEngine", () => {
       });
 
       expect(result.unlocked).toEqual([]);
-      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
       expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
     });
   });
@@ -521,7 +616,11 @@ describe("AchievementEngine", () => {
         text: "大大鬆餅祝福你",
       });
 
-      expect(UserProgressModel.upsert).toHaveBeenCalledWith("Uadmin", 60, 4);
+      expect(UserProgressModel.upsertMany).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ userId: "Uadmin", achievementId: 60, currentValue: 4 }),
+        ])
+      );
       expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
     });
 
@@ -544,7 +643,7 @@ describe("AchievementEngine", () => {
         text: "鬆餅祝福",
       });
 
-      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
     });
 
     it("does not increment when keywords are missing", async () => {
@@ -555,7 +654,7 @@ describe("AchievementEngine", () => {
         text: "哈囉",
       });
 
-      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
     });
 
     it("does not fire for users outside includeUserIds (eligibility gate)", async () => {
@@ -567,7 +666,7 @@ describe("AchievementEngine", () => {
       });
 
       expect(result.unlocked).toEqual([]);
-      expect(UserProgressModel.upsert).not.toHaveBeenCalled();
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
     });
   });
 

--- a/app/migrations/20260531073137_add_inventory_userId_itemId_index.js
+++ b/app/migrations/20260531073137_add_inventory_userId_itemId_index.js
@@ -1,0 +1,31 @@
+/**
+ * Add a composite index on Inventory(userId, itemId).
+ *
+ * Root cause of several slow `/me` and gacha queries: `Inventory` only had
+ * PRIMARY(ID), so every `WHERE userId = ? ... ORDER BY itemId` did a full table
+ * scan (~660k rows) plus a filesort. The composite index covers both the
+ * userId equality filter and the itemId ordering, eliminating both.
+ *
+ * Online DDL: on MySQL 8 InnoDB, adding a secondary index runs in-place with
+ * `ALGORITHM=INPLACE, LOCK=NONE` (concurrent reads + writes stay allowed), so
+ * this is safe to apply on the live table. It still builds over ~660k rows —
+ * run it off-peak and confirm the maintenance window with the repo owner.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("Inventory", table => {
+    table.index(["userId", "itemId"], "idx_inventory_userId_itemId");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("Inventory", table => {
+    table.dropIndex(["userId", "itemId"], "idx_inventory_userId_itemId");
+  });
+};

--- a/app/src/model/application/UserAchievementProgress.js
+++ b/app/src/model/application/UserAchievementProgress.js
@@ -37,6 +37,26 @@ exports.upsert = async (userId, achievementId, currentValue) => {
   );
 };
 
+/**
+ * Batch upsert progress for many achievements of a single evaluate() pass.
+ * Collapses the previous per-row N+1 writes into one multi-row statement.
+ * Relies on the UNIQUE(user_id, achievement_id) constraint for the upsert.
+ *
+ * @param {Array<{userId: string, achievementId: number, currentValue: number}>} updates
+ * @returns {Promise<*>|undefined} undefined when there is nothing to write
+ */
+exports.upsertMany = async updates => {
+  if (!Array.isArray(updates) || updates.length === 0) return;
+  const values = updates.map(() => "(?, ?, ?, NOW())").join(", ");
+  const bindings = updates.flatMap(u => [u.userId, u.achievementId, u.currentValue]);
+  return mysql.raw(
+    `INSERT INTO ${TABLE} (user_id, achievement_id, current_value, updated_at)
+     VALUES ${values}
+     ON DUPLICATE KEY UPDATE current_value = VALUES(current_value), updated_at = NOW()`,
+    bindings
+  );
+};
+
 exports.increment = async (userId, achievementId, amount = 1) => {
   return mysql.raw(
     `INSERT INTO ${TABLE} (user_id, achievement_id, current_value, updated_at)

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -221,6 +221,12 @@ exports.evaluate = async (userId, eventType, context = {}) => {
     const ctx = { ...context, _userId: userId };
     const candidates = achievements.filter(a => !unlockedIds.has(a.id));
 
+    // Phase 1: compute the new value for every candidate. Strategy evaluation
+    // stays serial because some strategies (handleTrackedSet) do a Redis
+    // read-before-write that must not interleave. Per-candidate try/catch keeps
+    // one bad strategy from aborting the rest.
+    const updates = [];
+    const toUnlock = [];
     for (const achievement of candidates) {
       try {
         const currentValue = progressMap.get(achievement.id) || 0;
@@ -228,15 +234,38 @@ exports.evaluate = async (userId, eventType, context = {}) => {
         const newValue = strategy ? await strategy(currentValue, achievement, ctx) : currentValue;
         if (newValue === null || newValue === currentValue) continue;
 
-        await UserProgressModel.upsert(userId, achievement.id, newValue);
-
-        if (newValue >= achievement.target_value) {
-          await unlockAchievement(userId, achievement);
-          unlocked.push(achievement);
-        }
+        updates.push({ userId, achievementId: achievement.id, currentValue: newValue });
+        if (newValue >= achievement.target_value) toUnlock.push(achievement);
       } catch (innerErr) {
         DefaultLogger.error(
           `AchievementEngine.evaluate error for key ${achievement.key}:`,
+          innerErr
+        );
+      }
+    }
+
+    // Phase 2: collapse the per-candidate progress writes into one statement.
+    // Guarded on its own so a batch-write failure is logged but does NOT skip
+    // the unlocks below — this preserves the per-candidate failure isolation the
+    // original row-by-row loop had. unlockAchievement deletes the progress row
+    // regardless, so proceeding to unlock after a failed write is safe.
+    if (updates.length > 0) {
+      try {
+        await UserProgressModel.upsertMany(updates);
+      } catch (batchErr) {
+        DefaultLogger.error("AchievementEngine.evaluate batch upsert error:", batchErr);
+      }
+    }
+
+    // Phase 3: unlock serially — each unlock writes a stone-ledger row and
+    // deletes the progress row, and is order-sensitive, so it is not batched.
+    for (const achievement of toUnlock) {
+      try {
+        await unlockAchievement(userId, achievement);
+        unlocked.push(achievement);
+      } catch (innerErr) {
+        DefaultLogger.error(
+          `AchievementEngine.evaluate unlock error for key ${achievement.key}:`,
           innerErr
         );
       }

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -145,14 +145,16 @@ async function runDailyDraw(userId, opts = {}) {
   const { tag, pickup = false, ensure = false, europe = false } = opts;
   const times = 10;
 
-  const allActiveBanners = await time("rd.banners", () =>
-    GachaBanner.getActiveBannersWithCharacters()
-  );
+  // banners and the gacha pool are independent reads — fetch them concurrently
+  // to save one DB round-trip on the hot daily-draw path.
+  const [allActiveBanners, gachaPool] = await Promise.all([
+    time("rd.banners", () => GachaBanner.getActiveBannersWithCharacters()),
+    time("rd.pool", () => GachaModel.getDatabasePool()),
+  ]);
   const rateUpBanners = allActiveBanners.filter(b => b.type === "rate_up");
   const europeBanners = allActiveBanners.filter(b => b.type === "europe");
   const activeEuropeBanner = europe && europeBanners.length > 0 ? europeBanners[0] : null;
 
-  const gachaPool = await time("rd.pool", () => GachaModel.getDatabasePool());
   const filteredPool = filterPool(gachaPool, tag);
   const dailyPool = buildDailyPool(filteredPool, rateUpBanners, { pickup, ensure, europe });
 


### PR DESCRIPTION
## 背景

以 6 天、68k 事件的 `[timing]` log + 源碼追蹤 + 對 production MySQL 直接 `EXPLAIN` 定位出的效能瓶頸。核心根因：**`Inventory` 表（66.3 萬列、27,847 使用者）只有 `PRIMARY(ID)`，`userId` 無任何索引**，導致 `WHERE userId=? ... ORDER BY itemId` 走全表掃描 + filesort，同時拖慢 gacha 抽卡與 `/me` 多項查詢。

## 變更內容

### 修復 1（最高優先）— `Inventory(userId, itemId)` 複合索引
新增 migration `20260531073137_add_inventory_userId_itemId_index.js`。複合索引同時涵蓋 `userId` 等值過濾與 `itemId` 排序，一次消掉 table scan 與 filesort。

預期讓 `rd.inventory`（p50 483ms）、`me.gachaProg.inv` / `me.godStone` / `me.charOwned`（各 p50 ~575ms）降到 <5ms。

> ⚠️ **上線注意**：66 萬列的 `ALTER TABLE ADD INDEX`。MySQL 8 InnoDB 預設以 `ALGORITHM=INPLACE, LOCK=NONE` 線上加索引（讀寫不中斷），但仍會建立 660k 列的索引，**請離峰執行並先確認維護時段**。

### 修復 2 — gacha 抽卡管線並行化
`GachaService.runDailyDraw()` 內 `rd.banners` 與 `rd.pool` 兩個獨立查詢由串行 `await` 改為 `Promise.all` 並行，省一個 round-trip。行為不變（`rateUpBanners` / `europeBanners` 推導移到兩查詢之後）。

### 修復 4 — AchievementEngine 批次 upsert（解掉最後的 N+1）
`evaluate()` 原本在 for 迴圈內逐筆 `await UserProgressModel.upsert(...)`（每個 gacha 事件 2–6 次）。改為三階段：
1. **計算**：逐一跑 strategy（保持串行——部分有 Redis read-before-write 依賴），收集要寫入與要解鎖的項目；單項錯誤隔離。
2. **批次寫入**：單條多列 `upsertMany`（新增於 model 層，沿用既有 `upsert`/`increment` 的 raw SQL 風格、全部參數綁定）。
3. **解鎖**：維持串行（含女神石 ledger 寫入 + progress 刪除，有順序性）。

批次寫入包在獨立 try/catch 中——寫入失敗會記 log 但**不會中斷該回合的解鎖**，保留原本逐筆迴圈的錯誤隔離性（此點由 adversarial review 指出後修正）。

### 修復 3 — 略過（刻意保留）
`me.godStone` + `me.charOwned` 合併查詢屬選配，且**明確以「修復 1 上線後先量測、沒必要就不做」為前提**。修復 1 後兩者已快，且本機無法量測 production，故不在本 PR 動作；保留給日後依實測決定。

## 測試

- 既有測試更新：`evaluate()` 改用 `upsertMany`，相關斷言改為驗證批次寫入內容與順序。
- 新增 5 筆測試：
  - 單一事件多成就 → 收斂成一次 `upsertMany`（N+1→1）
  - 無值變動時不呼叫 `upsertMany`
  - 批次寫入失敗時解鎖仍照常觸發（write/unlock 隔離）
  - 單一解鎖失敗時其餘成就仍解鎖（unlock 隔離）
  - `upsertMany` SQL contract（佔位符數量、綁定順序、空陣列 no-op）
- `app/` 全測試：**673 passed**；唯一失敗的 6 個 suite / 16 test 全為**既有、需本機 MySQL 的整合測試**（`ECONNREFUSED 127.0.0.1:3306`），與本變更無關。
- `yarn lint` 對所有變更檔通過。

## Review

已跑多視角 adversarial review（行為保留 / SQL 安全 / migration 線上安全 / 測試充分性）：3 個確認項皆為 low 且都指向「批次寫入失敗會連帶略過解鎖」——已修正並補測試；其餘為誤報（含「線上 DDL 不保證」一項，經查 MySQL 8 secondary index ADD 預設即 INPLACE+LOCK=NONE，安全）。

## 部署順序建議

1. 離峰時段先跑 migration（`yarn migrate`）建索引。
2. 部署 bot / worker（含修復 2、4 程式碼）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
