### PR TITLE
fix(prestige): stop faking Lv.100 MAX in #轉生狀態 below the cap

### DIFF
--- a/app/src/templates/application/Prestige/Status.js
+++ b/app/src/templates/application/Prestige/Status.js
@@ -336,7 +336,7 @@ function buildTrialActiveCard({
   };
 }
 
-function buildTrialReadyCard({ readyTrial }) {
+function buildTrialReadyCard({ readyTrial, atMaxLevel = true }) {
   return {
     type: "box",
     layout: "vertical",
@@ -388,7 +388,9 @@ function buildTrialReadyCard({ readyTrial }) {
               },
               {
                 type: "text",
-                text: "消費這次通過記錄即可轉生 · 等級歸零，再選一個祝福永久強化",
+                text: atMaxLevel
+                  ? "消費這次通過記錄即可轉生 · 等級歸零，再選一個祝福永久強化"
+                  : "通過記錄已保留 · 達 Lv.100 後轉生：等級歸零，再選一個祝福永久強化",
                 size: "xxs",
                 color: COLORS.textMuted,
                 wrap: true,
@@ -655,7 +657,7 @@ function buildBlessingsSection({ ownedBlessings, isReady, isAwakened }) {
   };
 }
 
-function buildFooter({ scenario, liffUri, liffUriSummary }) {
+function buildFooter({ scenario, liffUri, liffUriSummary, atMaxLevel = true }) {
   if (scenario === "honeymoon" || scenario === "between") {
     return {
       type: "box",
@@ -686,6 +688,36 @@ function buildFooter({ scenario, liffUri, liffUriSummary }) {
   }
 
   if (scenario === "ready") {
+    // Passed the trial but not yet Lv.100: prestige() will reject (NOT_LEVEL_100),
+    // so don't offer the actionable CTA — point them at the remaining level grind.
+    if (!atMaxLevel) {
+      return {
+        type: "box",
+        layout: "vertical",
+        paddingAll: "lg",
+        paddingTop: "md",
+        contents: [
+          {
+            type: "box",
+            layout: "vertical",
+            backgroundColor: "#E5E7EB",
+            cornerRadius: "md",
+            paddingTop: "md",
+            paddingBottom: "md",
+            contents: [
+              {
+                type: "text",
+                text: "達 Lv.100 即可轉生",
+                size: "sm",
+                color: COLORS.textMuted,
+                weight: "bold",
+                align: "center",
+              },
+            ],
+          },
+        ],
+      };
+    }
     return {
       type: "box",
       layout: "vertical",
@@ -783,13 +815,14 @@ function resolveScenario({ awakened, readyTrial, activeTrial, prestigeCount }) {
   return "between"; // prestige 1+ but no active trial yet
 }
 
-function buildFlag({ scenario, prestigeCount, activeTrial, readyTrial }) {
+function buildFlag({ scenario, prestigeCount, activeTrial, readyTrial, atMaxLevel = true }) {
   if (scenario === "awakened") {
     return "★★★★★ 轉生 5 次 · 試煉旅程已完成";
   }
   if (scenario === "ready" && readyTrial) {
     const stars = "★".repeat(Math.max(0, prestigeCount || 0));
-    return `🪄 試煉通過 · 可立即轉生${stars ? `  ·  ${stars} 轉生 ${prestigeCount} 次` : ""}`;
+    const lead = atMaxLevel ? "🪄 試煉通過 · 可立即轉生" : "🪄 試煉通過 · 達 Lv.100 後可轉生";
+    return `${lead}${stars ? `  ·  ${stars} 轉生 ${prestigeCount} 次` : ""}`;
   }
   if (scenario === "active" && activeTrial) {
     const stars = "★".repeat(Math.max(0, prestigeCount || 0));
@@ -831,19 +864,27 @@ function build(input) {
     prestigeCount: input.prestigeCount,
   });
 
+  const isReady = scenario === "ready";
+  const isAwakened = scenario === "awakened";
+  // A passed trial only becomes consumable at Lv.100 (PrestigeService.prestige
+  // throws NOT_LEVEL_100 below cap), yet a trial can be passed as early as ~Lv.57
+  // because completion is gated on trial XP (required_exp ~10k), not on level.
+  // So the "ready" scenario does NOT imply the player is maxed — gate every
+  // MAX/100 readout on the real level instead of on the scenario.
+  const atMaxLevel = (input.level || 0) >= 100;
+  const readyAtMax = isReady && atMaxLevel;
+
   const flagText = buildFlag({
     scenario,
     prestigeCount: input.prestigeCount,
     activeTrial: input.activeTrial,
     readyTrial: input.readyTrial,
+    atMaxLevel,
   });
-
-  const isReady = scenario === "ready";
-  const isAwakened = scenario === "awakened";
 
   const heroLevelDisplay = (() => {
     if (isAwakened) return "✨ 覺醒者";
-    if (isReady) return "Lv.100 MAX";
+    if (readyAtMax) return "Lv.100 MAX";
     return `Lv.${input.level || 0}`;
   })();
 
@@ -857,6 +898,7 @@ function build(input) {
     levelText: heroLevelDisplay,
     isReady,
     isAwakened,
+    readyAtMax,
   });
 
   const sections = [hero];
@@ -874,7 +916,7 @@ function build(input) {
       })
     );
   } else if (scenario === "ready") {
-    sections.push(buildTrialReadyCard({ readyTrial: input.readyTrial }));
+    sections.push(buildTrialReadyCard({ readyTrial: input.readyTrial, atMaxLevel }));
   } else if (scenario === "awakened") {
     sections.push(buildAwakenedChip());
   }
@@ -892,6 +934,7 @@ function build(input) {
       scenario,
       liffUri: input.liffUri,
       liffUriSummary: input.liffUriSummary,
+      atMaxLevel,
     })
   );
 
@@ -922,6 +965,7 @@ function buildHeroExplicit({
   levelText,
   isReady,
   isAwakened,
+  readyAtMax,
 }) {
   const avatarBorder = isReady || isAwakened ? COLORS.amber400 : "#FFFFFF";
 
@@ -933,12 +977,12 @@ function buildHeroExplicit({
   }
 
   const isMax = !expNext && expCurrent > 0;
-  const expText = isReady
+  const expText = readyAtMax
     ? `MAX · ${formatExp(expCurrent)} / ${formatExp(expCurrent || expNext || 0)}`
     : isMax
       ? "MAX"
       : `${formatExp(expCurrent)} / ${formatExp(expNext)}`;
-  const clampedRate = isReady ? 100 : Math.max(0, Math.min(100, expRate || 0));
+  const clampedRate = readyAtMax ? 100 : Math.max(0, Math.min(100, expRate || 0));
 
   const heroBg = isAwakened
     ? {

--- a/app/src/templates/application/Prestige/__tests__/Status.test.js
+++ b/app/src/templates/application/Prestige/__tests__/Status.test.js
@@ -236,6 +236,46 @@ describe("Prestige/Status.build", () => {
     });
   });
 
+  // Regression: a trial can be passed as early as ~Lv.57 (completion is gated on
+  // trial XP, not level), but prestige requires Lv.100. The card must not fake a
+  // maxed level/exp readout nor offer the (non-functional) 立即轉生 CTA below cap.
+  describe("ready-but-below-cap scenario", () => {
+    const flex = Status.build({
+      ...baseInput,
+      prestigeCount: 1,
+      level: 57,
+      expCurrent: 4200,
+      expNext: 9300,
+      expRate: 45,
+      readyTrial: { star: 1, display_name: "啟程" },
+      ownedBlessings: [{ slug: "language_gift", display_name: "語言天賦" }],
+    });
+
+    it("shows the real level pill, not Lv.100 MAX", () => {
+      expect(findText(flex.contents, t => t === "Lv.57")).toBe("Lv.57");
+      expect(findText(flex.contents, t => /MAX/.test(t))).toBeNull();
+    });
+    it("hero flag defers prestige to Lv.100", () => {
+      expect(findText(flex.contents, t => t.includes("試煉通過"))).toBe(
+        "🪄 試煉通過 · 達 Lv.100 後可轉生  ·  ★ 轉生 1 次"
+      );
+    });
+    it("renders real EXP progress instead of MAX", () => {
+      expect(findText(flex.contents, t => t === "EXP")).toBe("EXP");
+      expect(findText(flex.contents, t => /\//.test(t) && !t.includes("7"))).toBeTruthy();
+    });
+    it("shows 達 Lv.100 即可轉生 footer with no action", () => {
+      expect(findText(flex.contents, t => t === "達 Lv.100 即可轉生")).toBe("達 Lv.100 即可轉生");
+      expect(findActionUri(flex.contents)).toBeNull();
+    });
+    it("ready card copy defers prestige to Lv.100 (no 即可轉生 promise)", () => {
+      expect(findText(flex.contents, t => t.includes("達 Lv.100 後轉生"))).toBe(
+        "通過記錄已保留 · 達 Lv.100 後轉生：等級歸零，再選一個祝福永久強化"
+      );
+      expect(findText(flex.contents, t => t.includes("消費這次通過記錄即可轉生"))).toBeNull();
+    });
+  });
+
   describe("awakened scenario", () => {
     const flex = Status.build({
       ...baseInput,


### PR DESCRIPTION
## Summary

`#轉生狀態` was showing **Lv.100 MAX** (plus a maxed EXP bar and a non-functional 立即轉生 button) to users who hadn't actually reached the level cap.

**Root cause:** a trial is marked `passed` the moment `active_trial_exp_progress >= required_exp` (~9k–12.5k XP, and a trial can be started as early as Lv.50) — completely independent of level. But `PrestigeService.prestige()` only unlocks at Lv.100 (`NOT_LEVEL_100`). The Status template treated the `ready` scenario (passed-but-unconsumed trial) as proof of max level, so a user who passed their first trial around **~Lv.57** saw a card claiming Lv.100 MAX while still grinding toward 100.

**Fix:** introduce an `atMaxLevel = level >= 100` flag and gate every MAX/100 readout on the real level instead of on the scenario, in `app/src/templates/application/Prestige/Status.js`:

- Hero level pill → real `Lv.N` until 100 (was hardcoded `Lv.100 MAX`)
- EXP text + progress bar → real progress / percentage (was `MAX` / 100%)
- Hero flag → `達 Lv.100 後可轉生` (was `可立即轉生`)
- Footer → `達 Lv.100 即可轉生` hint, dropping the dead `立即轉生` CTA button
- Ready card subtitle → `達 Lv.100 後轉生：…` (was `消費這次通過記錄即可轉生 …`)

At-max behavior (`level >= 100`) is **unchanged** — still shows `Lv.100 MAX` and the working `立即轉生` CTA.

## Test plan

- [x] `yarn test src/templates/application/Prestige/__tests__/Status.test.js` — 36 passing (added a `ready-but-below-cap` regression block)
- [x] `yarn test Prestige ChatLevel` — 124 passing, no regressions
- [x] `yarn lint` on both changed files — clean
- [x] At-max `ready` scenario (level 100) assertions unchanged and still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)