### PR TITLE
Increase coupon code length limit

### DIFF
--- a/app/__tests__/schema/coupon.test.js
+++ b/app/__tests__/schema/coupon.test.js
@@ -1,0 +1,34 @@
+const ajv = require("../../src/util/ajv");
+
+describe("couponAdd schema", () => {
+  const validPayload = code => ({
+    code,
+    startAt: "2026-06-15T00:00:00Z",
+    endAt: "2026-06-16T00:00:00Z",
+    reward: 1,
+  });
+
+  it("accepts coupon code up to 50 characters", () => {
+    const validate = ajv.getSchema("couponAdd");
+
+    const isValid = validate(validPayload("A".repeat(50)));
+
+    expect(isValid).toBe(true);
+  });
+
+  it("rejects coupon code longer than 50 characters", () => {
+    const validate = ajv.getSchema("couponAdd");
+
+    const isValid = validate(validPayload("A".repeat(51)));
+
+    expect(isValid).toBe(false);
+    expect(validate.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          instancePath: "/code",
+          keyword: "maxLength",
+        }),
+      ])
+    );
+  });
+});

--- a/app/src/schema/application/commands/coupon.js
+++ b/app/src/schema/application/commands/coupon.js
@@ -5,7 +5,7 @@ module.exports = {
       code: {
         type: "string",
         minLength: 1,
-        maxLength: 10,
+        maxLength: 50,
       },
       startAt: {
         type: "string",


### PR DESCRIPTION
## Summary
- Increase the admin coupon code validation limit from 10 to 50 characters.
- Add schema coverage for accepting 50-character coupon codes and rejecting 51-character coupon codes.

## Test Plan
- [x] `yarn --cwd app test app/__tests__/schema/coupon.test.js`
- [x] `app/node_modules/.bin/eslint app/src/schema/application/commands/coupon.js app/__tests__/schema/coupon.test.js`
- [x] `app/node_modules/.bin/prettier --check app/src/schema/application/commands/coupon.js app/__tests__/schema/coupon.test.js`

## Notes
- Full `yarn --cwd app test` currently fails in existing Janken DB-related suites with `AggregateError`; the coupon schema test passes and is not part of the failing suites.
