### PR TITLE
fix(chat-level): 轉生玩家排名優先於僅高經驗玩家

### DIFF
--- a/app/src/controller/application/ChatLevelController.js
+++ b/app/src/controller/application/ChatLevelController.js
@@ -488,6 +488,7 @@ exports.api.queryRank = async (req, res) => {
   const rows = await mysql("chat_user_data")
     .select("user_id", "current_level", "current_exp", "prestige_count")
     .where("current_exp", ">", 0)
+    .orderBy("prestige_count", "desc")
     .orderBy("current_exp", "desc")
     .orderBy("user_id", "asc")
     .limit(10);


### PR DESCRIPTION
## 問題

`GET /api/chat-levels/rankings` 排行榜原本只依 `current_exp` 降冪排序。但轉生（轉生）會將玩家經驗歸零（全員歸零），導致轉生過的玩家在新週期經驗較低時，排在從未轉生但累積高經驗的玩家之後——和「轉生＝進度更前面」的設計相反。

## 變更

`queryRank` 排序鍵調整為：

1. `prestige_count` 降冪（轉生次數多者優先）
2. `current_exp` 降冪
3. `user_id` 升冪（平手 tiebreaker）

`prestige_count` 欄位本來就已 select，僅多一個 orderBy。

## 已知邊界（未改動）

`where("current_exp", ">", 0)` 過濾仍保留，所以剛轉生、`current_exp` 還是 0 的玩家暫時不會上榜，開始聊天後就會回到榜上。此為原本行為。

## Test plan

- [ ] `yarn test:app` 通過（確認無測試斷言舊排序）
- [ ] 線上呼叫 `/api/chat-levels/rankings`，確認轉生過的玩家排在僅高經驗玩家之前