### PR TITLE
chore(db): 收攏 docker init SQL 進 knex baseline，統一 schema 來源

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ Yarn workspaces root; two packages plus shared dev tooling:
 
 - **app/** — Bottender bot + Express API + Socket.IO + cron worker. All backend code lives here.
 - **frontend/** — React 19 + MUI 7 + Vite admin dashboard, embedded as LINE LIFF.
-- **migration/** — MySQL init scripts (mounted into the mysql container on first boot).
 - **docs/** — Design specs (e.g. `docs/superpowers/specs/`).
+
+The legacy `migration/Princess.sql` docker init was folded into knex (`app/migrations/20210101000000_baseline_initial_schema.{js,sql}`); knex is now the single schema source.
 
 There is no `job/` package — cron is `yarn worker` inside `app/` (see below).
 
@@ -69,7 +70,7 @@ Command routing in `OrderBased` composes routers from every domain controller (g
 - **MySQL** via Knex (`app/knexfile.js`) — database is hardcoded `Princess`. Host-run migrations read the root `.env` (`DB_HOST=mysql` maps to the docker-exposed port 3306 on localhost).
 - **Redis** — Bottender session store + general cache (`app/src/util/redis.js`). Session TTL 60 min, state TTL 15 min (`app/bottender.config.js`).
 - **SQLite** — read-only game data (`app/assets/redive_tw.db`) and a local task log (`app/assets/task.db`); accessed via `better-sqlite3` through `app/src/model/princess/GameSqlite.js`.
-- **Migrations** — `app/migrations/`. Create new ones with `cd app && yarn knex migrate:make <name>` — never hand-write.
+- **Migrations** — `app/migrations/`. Create new ones with `cd app && yarn knex migrate:make <name>` — never hand-write. knex is the single schema source (the old docker `Princess.sql` init was folded into the `20210101000000_baseline_initial_schema` migration). **Fresh DB bootstrap**: `cd app && yarn migrate && yarn knex seed:run` (migrate builds all tables, seeders fill `chat_exp_unit` / `GachaPool` / etc.) — there is no more SQL injected at container first-boot.
 
 ### Socket.IO
 
@@ -157,5 +158,5 @@ Copy `.env.example` to root `.env`. Required: `LINE_ACCESS_TOKEN`, `LINE_CHANNEL
 - `app/knexfile.js` — single MySQL connection config for app + worker + migrations.
 - `app/config/default.json` — game logic constants, external link URLs, color palette; read via `config` package (`require("config").get(...)`).
 - `app/config/crontab.config.js` — cron schedule → `app/bin/<Script>.js` mapping (edit here when adding background jobs).
-- `docker-compose.yml` — infra only (mysql, redis, phpmyadmin). Dev reality; bot/frontend run on the host.
+- `docker-compose.yml` — infra only (mysql, redis, phpmyadmin). Dev reality; bot/frontend run on the host. No longer mounts any SQL init — schema is bootstrapped purely by knex (`yarn migrate`).
 - `docker-compose.traefik.yml` — production service + Traefik routing labels. Not used locally.

--- a/app/migrations/20210101000000_baseline_initial_schema.js
+++ b/app/migrations/20210101000000_baseline_initial_schema.js
@@ -1,0 +1,40 @@
+/**
+ * Baseline initial schema — 收攏自原 migration/Princess.sql 的 docker init。
+ *
+ * 背景：以前新環境靠 docker `docker-entrypoint-initdb.d` 注入 Princess.sql 建底表，
+ * 再跑 knex migration 疊上去（兩套來源）。本 migration 把那批底表收進 knex，
+ * 成為單一來源；docker init 掛載與 Princess.sql 已移除。
+ *
+ * 安全性：
+ *   - schema 句全為 `CREATE TABLE IF NOT EXISTS` → 線上既有表上跑為 no-op，零 schema 變更。
+ *   - 不含任何 INSERT/TRUNCATE（原 Princess.sql 對 chat_exp_unit 等的灌種子已移除，
+ *     避免在線上重跑時清掉現有資料）。資料種子交給 `app/seeds/*`，
+ *     fresh bootstrap 流程為：`yarn migrate && yarn knex seed:run`。
+ *   - 時間戳 20210101000000 早於最早一支既有 migration（20210728152528），
+ *     確保 fresh DB 上後續 alterTable 能找到底表。
+ *
+ * ponytail: 直接讀同名 .sql 逐句執行，省掉把含反引號/單引號的 DDL 硬塞進 JS 字串。
+ */
+const fs = require("fs");
+const path = require("path");
+
+exports.up = async function (knex) {
+  const sql = fs.readFileSync(
+    path.join(__dirname, "20210101000000_baseline_initial_schema.sql"),
+    "utf8"
+  );
+  const statements = sql
+    .split("\n")
+    .filter(line => !/^\s*--/.test(line)) // 去掉註解行（含檔頭），避免與第一句 CREATE 黏在一起被濾掉
+    .join("\n")
+    .split(";")
+    .map(s => s.trim())
+    .filter(s => /^CREATE TABLE/i.test(s));
+
+  for (const stmt of statements) {
+    await knex.raw(stmt);
+  }
+};
+
+// baseline 不回滾（與原 docker init 對等，無對應 down）。
+exports.down = async function () {};

--- a/app/migrations/20210101000000_baseline_initial_schema.sql
+++ b/app/migrations/20210101000000_baseline_initial_schema.sql
@@ -1,31 +1,5 @@
--- phpMyAdmin SQL Dump
--- version 5.0.4
--- https://www.phpmyadmin.net/
---
--- 主機： mysql
--- 產生時間： 2021 年 04 月 26 日 18:09
--- 伺服器版本： 8.0.23
--- PHP 版本： 7.4.15
-
-SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
-START TRANSACTION;
-SET time_zone = "+00:00";
-
-
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8mb4 */;
-
---
--- 資料庫： `Princess`
---
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `Admin`
---
+-- AUTO-GENERATED from migration/Princess.sql (schema only, NO data).
+-- 由 baseline migration 讀取執行；勿手改。資料種子交給 app/seeds/*。
 
 CREATE TABLE IF NOT EXISTS `Admin` (
   `ID` int NOT NULL AUTO_INCREMENT,
@@ -33,12 +7,6 @@ CREATE TABLE IF NOT EXISTS `Admin` (
   `privilege` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `arena_like_records`
---
 
 CREATE TABLE IF NOT EXISTS `arena_like_records` (
   `merge_hash` varchar(255) NOT NULL,
@@ -51,12 +19,6 @@ CREATE TABLE IF NOT EXISTS `arena_like_records` (
   PRIMARY KEY (`attack_hash`,`defense_hash`,`userId`),
   KEY `IDX_MERGE_HASH` (`merge_hash`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `arena_records`
---
 
 CREATE TABLE IF NOT EXISTS `arena_records` (
   `id` int NOT NULL AUTO_INCREMENT,
@@ -77,12 +39,6 @@ CREATE TABLE IF NOT EXISTS `arena_records` (
   KEY `right_hash` (`right_hash`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='紀錄競技場勝負';
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `BulletIn`
---
-
 CREATE TABLE IF NOT EXISTS `BulletIn` (
   `id` int NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
@@ -93,207 +49,11 @@ CREATE TABLE IF NOT EXISTS `BulletIn` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='公主公告儲存';
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `chat_exp_unit`
---
-
 CREATE TABLE IF NOT EXISTS `chat_exp_unit` (
   `unit_level` int NOT NULL,
   `total_exp` int NOT NULL,
   PRIMARY KEY (`unit_level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='聊天經驗單位';
-
---
--- 資料表新增資料前，先清除舊資料 `chat_exp_unit`
---
-
-TRUNCATE TABLE `chat_exp_unit`;
---
--- 傾印資料表的資料 `chat_exp_unit`
---
-
-INSERT INTO `chat_exp_unit` (`unit_level`, `total_exp`) VALUES
-(1, 0),
-(2, 240),
-(3, 720),
-(4, 1200),
-(5, 1680),
-(6, 2160),
-(7, 2880),
-(8, 3600),
-(9, 4320),
-(10, 5040),
-(11, 5760),
-(12, 6480),
-(13, 7200),
-(14, 7920),
-(15, 8640),
-(16, 9560),
-(17, 10680),
-(18, 12000),
-(19, 13520),
-(20, 15240),
-(21, 17160),
-(22, 19280),
-(23, 21420),
-(24, 23580),
-(25, 25760),
-(26, 27960),
-(27, 30190),
-(28, 32450),
-(29, 34740),
-(30, 37060),
-(31, 39480),
-(32, 42000),
-(33, 44620),
-(34, 47340),
-(35, 50160),
-(36, 53080),
-(37, 56100),
-(38, 59620),
-(39, 63640),
-(40, 68160),
-(41, 73180),
-(42, 78700),
-(43, 86220),
-(44, 95740),
-(45, 107260),
-(46, 120780),
-(47, 136300),
-(48, 153820),
-(49, 175340),
-(50, 200860),
-(51, 230380),
-(52, 263900),
-(53, 301420),
-(54, 343940),
-(55, 391460),
-(56, 443980),
-(57, 501500),
-(58, 564020),
-(59, 631540),
-(60, 704060),
-(61, 781580),
-(62, 864100),
-(63, 951620),
-(64, 1045140),
-(65, 1144660),
-(66, 1250180),
-(67, 1361700),
-(68, 1479220),
-(69, 1602740),
-(70, 1732260),
-(71, 1867780),
-(72, 2009300),
-(73, 2156820),
-(74, 2310340),
-(75, 2469860),
-(76, 2635380),
-(77, 2806900),
-(78, 2984420),
-(79, 3167940),
-(80, 3357460),
-(81, 3552980),
-(82, 3754500),
-(83, 3962020),
-(84, 4175540),
-(85, 4395060),
-(86, 4620580),
-(87, 4852100),
-(88, 5089620),
-(89, 5333140),
-(90, 5582660),
-(91, 5838180),
-(92, 6099700),
-(93, 6367220),
-(94, 6640740),
-(95, 6920260),
-(96, 7205780),
-(97, 7497300),
-(98, 7794820),
-(99, 8098340),
-(100, 8407860),
-(101, 8723380),
-(102, 9044900),
-(103, 9372420),
-(104, 9705940),
-(105, 10045460),
-(106, 10390980),
-(107, 10742500),
-(108, 11100020),
-(109, 11463540),
-(110, 11833060),
-(111, 12208580),
-(112, 12590100),
-(113, 12977620),
-(114, 13371140),
-(115, 13770660),
-(116, 14176180),
-(117, 14587700),
-(118, 15005220),
-(119, 15428740),
-(120, 15858260),
-(121, 16293780),
-(122, 16735300),
-(123, 17182820),
-(124, 17636340),
-(125, 18095860),
-(126, 18561380),
-(127, 19032900),
-(128, 19510420),
-(129, 19993940),
-(130, 20483460),
-(131, 20978980),
-(132, 21480500),
-(133, 21988020),
-(134, 22501540),
-(135, 23021060),
-(136, 23546580),
-(137, 24078100),
-(138, 24615620),
-(139, 25159140),
-(140, 25708660),
-(141, 26264180),
-(142, 26825700),
-(143, 27393220),
-(144, 27966740),
-(145, 28546260),
-(146, 29131780),
-(147, 29723300),
-(148, 30320820),
-(149, 30924340),
-(150, 31533860),
-(151, 32149380),
-(152, 32770900),
-(153, 33398420),
-(154, 34031940),
-(155, 34671460),
-(156, 35316980),
-(157, 35968500),
-(158, 36626020),
-(159, 37289540),
-(160, 37959060),
-(161, 38634580),
-(162, 39316100),
-(163, 40003620),
-(164, 40697140),
-(165, 41396660),
-(166, 42102180),
-(167, 42813700),
-(168, 43531220),
-(169, 44254740),
-(170, 44984260),
-(171, 45719780),
-(172, 46461300),
-(173, 47208820);
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `chat_level_title`
---
 
 CREATE TABLE IF NOT EXISTS `chat_level_title` (
   `id` int NOT NULL AUTO_INCREMENT,
@@ -302,69 +62,11 @@ CREATE TABLE IF NOT EXISTS `chat_level_title` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='聊天等級稱號';
 
---
--- 資料表新增資料前，先清除舊資料 `chat_level_title`
---
-
-TRUNCATE TABLE `chat_level_title`;
---
--- 傾印資料表的資料 `chat_level_title`
---
-
-INSERT INTO `chat_level_title` (`id`, `title`, `title_range`) VALUES
-(1, '小屁孩', 1),
-(2, '村民', 3),
-(3, '見習冒險者', 6),
-(4, '冒險者', 10),
-(5, '魔族殺手', 10),
-(6, '龍族殺手', 10),
-(7, '神族殺手', 10),
-(8, '異世界少年', 6),
-(9, '見習勇者', 6),
-(10, '實習勇者', 6),
-(11, '遊俠', 3),
-(12, '吟遊詩人', 3),
-(13, '神官', 3),
-(14, '騎士', 3);
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `chat_range_title`
---
-
 CREATE TABLE IF NOT EXISTS `chat_range_title` (
   `id` int NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='級距頭銜前贅';
-
---
--- 資料表新增資料前，先清除舊資料 `chat_range_title`
---
-
-TRUNCATE TABLE `chat_range_title`;
---
--- 傾印資料表的資料 `chat_range_title`
---
-
-INSERT INTO `chat_range_title` (`id`, `title`) VALUES
-(1, '初級'),
-(2, '中級'),
-(3, '高級'),
-(4, '銅級'),
-(5, '銀級'),
-(6, '金級'),
-(7, '白金級'),
-(8, '秘銀級'),
-(9, '山銅級'),
-(10, '精鋼級');
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `chat_user_data`
---
 
 CREATE TABLE IF NOT EXISTS `chat_user_data` (
   `id` int NOT NULL,
@@ -373,12 +75,6 @@ CREATE TABLE IF NOT EXISTS `chat_user_data` (
   `rank` int NOT NULL DEFAULT '99999',
   UNIQUE KEY `id` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='聊天制度用戶經驗';
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `CustomerOrder`
---
 
 CREATE TABLE IF NOT EXISTS `CustomerOrder` (
   `ID` int NOT NULL AUTO_INCREMENT,
@@ -401,12 +97,6 @@ CREATE TABLE IF NOT EXISTS `CustomerOrder` (
   KEY `IDX_CustOrderSource` (`SourceId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `GachaPool`
---
-
 CREATE TABLE IF NOT EXISTS `GachaPool` (
   `ID` int NOT NULL AUTO_INCREMENT,
   `Name` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -419,24 +109,12 @@ CREATE TABLE IF NOT EXISTS `GachaPool` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `GachaSignin`
---
-
 CREATE TABLE IF NOT EXISTS `GachaSignin` (
   `ID` int NOT NULL AUTO_INCREMENT,
   `userId` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `signinDate` datetime NOT NULL,
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `GlobalOrders`
---
 
 CREATE TABLE IF NOT EXISTS `GlobalOrders` (
   `ID` int NOT NULL AUTO_INCREMENT,
@@ -453,12 +131,6 @@ CREATE TABLE IF NOT EXISTS `GlobalOrders` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `Guild`
---
-
 CREATE TABLE IF NOT EXISTS `Guild` (
   `ID` int NOT NULL AUTO_INCREMENT,
   `GuildId` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -468,12 +140,6 @@ CREATE TABLE IF NOT EXISTS `Guild` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `GuildBattleConfig`
---
-
 CREATE TABLE IF NOT EXISTS `GuildBattleConfig` (
   `GuildId` varchar(45) NOT NULL,
   `NotifyToken` varchar(255) NOT NULL,
@@ -481,12 +147,6 @@ CREATE TABLE IF NOT EXISTS `GuildBattleConfig` (
   `modify_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`GuildId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='紀錄戰隊系統設定';
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `GuildBattleFinish`
---
 
 CREATE TABLE IF NOT EXISTS `GuildBattleFinish` (
   `id` int NOT NULL AUTO_INCREMENT,
@@ -496,12 +156,6 @@ CREATE TABLE IF NOT EXISTS `GuildBattleFinish` (
   PRIMARY KEY (`id`),
   KEY `idxUserId` (`UserId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `GuildConfig`
---
 
 CREATE TABLE IF NOT EXISTS `GuildConfig` (
   `ID` int NOT NULL AUTO_INCREMENT,
@@ -516,12 +170,6 @@ CREATE TABLE IF NOT EXISTS `GuildConfig` (
   UNIQUE KEY `GuildId_UNIQUE` (`GuildId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `GuildMembers`
---
-
 CREATE TABLE IF NOT EXISTS `GuildMembers` (
   `ID` int NOT NULL AUTO_INCREMENT,
   `GuildId` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -535,12 +183,6 @@ CREATE TABLE IF NOT EXISTS `GuildMembers` (
   UNIQUE KEY `GM_Unique` (`GuildId`,`UserId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `Inventory`
---
-
 CREATE TABLE IF NOT EXISTS `Inventory` (
   `ID` int NOT NULL AUTO_INCREMENT,
   `userId` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -549,12 +191,6 @@ CREATE TABLE IF NOT EXISTS `Inventory` (
   `createDTM` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `MessageRecord`
---
 
 CREATE TABLE IF NOT EXISTS `MessageRecord` (
   `ID` int NOT NULL,
@@ -567,12 +203,6 @@ CREATE TABLE IF NOT EXISTS `MessageRecord` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='訊息數據紀錄';
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `notify_list`
---
-
 CREATE TABLE IF NOT EXISTS `notify_list` (
   `id` int NOT NULL COMMENT '跟User編號一樣',
   `type` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '類型，1:Line Notify、2:Discord Webhook',
@@ -582,12 +212,6 @@ CREATE TABLE IF NOT EXISTS `notify_list` (
   `modify_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改時間',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='訂閱系統token紀錄';
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `PrincessUID`
---
 
 CREATE TABLE IF NOT EXISTS `PrincessUID` (
   `userId` varchar(45) NOT NULL COMMENT 'Line使用者ID',
@@ -599,23 +223,11 @@ CREATE TABLE IF NOT EXISTS `PrincessUID` (
   UNIQUE KEY `userId_UNIQUE` (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='提供使用者綁定公主連結UID';
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `sent_bulletin`
---
-
 CREATE TABLE IF NOT EXISTS `sent_bulletin` (
   `id` int NOT NULL,
   `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='紀錄已發送的公告';
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `subscribe_type`
---
 
 CREATE TABLE IF NOT EXISTS `subscribe_type` (
   `id` int NOT NULL AUTO_INCREMENT,
@@ -624,26 +236,6 @@ CREATE TABLE IF NOT EXISTS `subscribe_type` (
   `description` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
---
--- 資料表新增資料前，先清除舊資料 `subscribe_type`
---
-
-TRUNCATE TABLE `subscribe_type`;
---
--- 傾印資料表的資料 `subscribe_type`
---
-
-INSERT INTO `subscribe_type` (`id`, `type`, `title`, `description`) VALUES
-(1, 'PrincessNews', '公主連結消息', '可以接收公主連結最新公告。'),
-(2, 'BotNews', '最新消息', '可以接收機器人功能最新消息更新，包括功能的修正、新增、刪除。'),
-(3, 'ChatInfo', '等級系統消息', '可以接收等級系統的消息，例如：獲得了XX經驗、恭喜晉升為 36等 金級的龍族殺手。');
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `TotalEventTimes`
---
 
 CREATE TABLE IF NOT EXISTS `TotalEventTimes` (
   `TET_DATE` varchar(6) NOT NULL,
@@ -654,12 +246,6 @@ CREATE TABLE IF NOT EXISTS `TotalEventTimes` (
   `TET_UNSEND` int NOT NULL COMMENT '收回次數',
   PRIMARY KEY (`TET_DATE`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='每月份事件總數紀錄';
-
--- --------------------------------------------------------
-
---
--- 資料表結構 `User`
---
 
 CREATE TABLE IF NOT EXISTS `User` (
   `No` int NOT NULL AUTO_INCREMENT,
@@ -672,12 +258,6 @@ CREATE TABLE IF NOT EXISTS `User` (
   UNIQUE KEY `platformId` (`platformId`,`platform`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
-
---
--- 資料表結構 `web_announcement`
---
-
 CREATE TABLE IF NOT EXISTS `web_announcement` (
   `id` int NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
@@ -686,8 +266,3 @@ CREATE TABLE IF NOT EXISTS `web_announcement` (
   `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-COMMIT;
-
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   mysql:
     image: mysql
     volumes:
-      - ./migration:/docker-entrypoint-initdb.d
       - type: volume
         source: dbdata
         target: /var/lib/mysql

--- a/docs/plans/migration-consolidation-snake-rename.md
+++ b/docs/plans/migration-consolidation-snake-rename.md
@@ -1,0 +1,98 @@
+# Migration 收攏 + Table 命名 snake_case 統一
+
+> 目標：(1) 把「`Princess.sql` docker init + knex migration」兩套來源收攏成 **knex 單一來源**，新人空庫可一鍵啟動、**線上零 schema 變更**；(2) 把 legacy 駝峰表名統一成 snake_case。
+> 兩件事用兩支 PR 拆開做：PR#1 純賺、不碰線上；PR#2 會動線上、需部署窗口。
+
+## 進度
+
+- **Phase 0 線上審計：完成**（2026-06-26）。關鍵結論：`User` 已於 batch 38 改名為 `user`（移出改名清單，14→13）；5 張空表是新功能待啟用（不砍）；13 張 legacy 表全活躍（全改名）；12 條 FK 全在 snake_case 表間、零指向 legacy 表、零 trigger（DB 層改名安全）；線上共 77 表。
+- **Phase 1 收攏：完成、未 commit**（分支 `chore/consolidate-migrations-knex`）。空庫 throwaway 驗證：`yarn migrate` → 132 支跑完 = **77 表（與線上一致）**、冪等、`Admin` 修復；`yarn knex seed:run` → 6 seeders OK。待 review 後 commit/PR。
+- **Phase 2 改名：未開始**，需部署窗口決策。
+
+## 背景事實（已驗證）
+
+- `migration/Princess.sql` 建 26 張底表，靠 `docker-entrypoint-initdb.d` **僅首次啟動**注入。
+- `app/migrations/` 131 支（88 createTable / 15 alterTable）疊在其上。**最早一支 `20210728152528` 第一件事就是 `alter "Guild"`**，而 `Guild` 只由 SQL 建 → 拔掉 SQL 直接空庫 `yarn migrate` 會在第一支炸。兩套互相依賴。
+- `Princess.sql` **無 FK、無 trigger** → 改名風險大降（rename 的痛點通常是 FK/trigger，這裡沒有）。
+- 棄用表前人已清一輪（`20260327_drop_unused_tables.js` 等）。
+- 6 支 seeder：`GachaPool / ChatExpUnit / MinigameLevel / PrestigeBlessings / PrestigeTrials / SubscribeCard`。
+- knex `^3.2.10`，knexfile 無特殊 migrations 設定（預設 `./migrations`、`knex_migrations` 表）。
+
+## 待處理 legacy 駝峰表（14）與改動規模（引號內引用點）
+
+| 表 | refs | 表 | refs |
+|---|---|---|---|
+| Inventory | 13 | Guild | 4 |
+| GachaPool | 9 | CustomerOrder | 3 |
+| GuildConfig | 9 | GlobalOrders | 2 |
+| GuildMembers | 8 | PrincessUID | 2 |
+| GuildBattleFinish | 5 | GuildBattleConfig / MessageRecord / TotalEventTimes | 各 1 |
+| Admin | 4 | **User** | **0 ⚠️ 疑休眠** |
+
+合計約 62 點，幾乎都在 `app/src/model/**` 的 `table:` 宣告。`User` 引用 0，可能該 drop 而非 rename → 待 Phase 0 確認。
+
+---
+
+## Phase 0 — 線上唯讀調查（執行前的必要輸入）
+
+由線上 agent 跑唯讀盤點（prompt 見對話），回傳：
+1. `SELECT name, batch, migration_time FROM knex_migrations ORDER BY id;` — baseline 補跑順序的依據。
+2. `information_schema.tables` 全表 row_count + update_time — 確認休眠/空表（首要嫌疑 `User`）。
+3. 14 張 legacy 表各自 `COUNT(*)` 與是否仍存在。
+4. `key_column_usage` + `SHOW TRIGGERS` — 確認後續 knex migration 有無新增 FK/trigger 牽連 legacy 表（SQL 本身沒有，但要查 knex 後來加的）。
+5. `SHOW CREATE TABLE` for Guild/User/Inventory/GachaPool — 改名與 baseline 欄位核對。
+
+**Phase 0 出口決策**：`User`（及任何 row=0 的 legacy 表）→ rename 或 drop。
+
+---
+
+## Phase 1 — 收攏成 knex（PR#1，線上零 schema 變更）
+
+1. 新增 baseline migration `app/migrations/20210101000000_baseline_initial_schema.js`：
+   - 內容 = `Princess.sql` 的 26 張 `CREATE TABLE` **逐字搬入**，唯一改動是 `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`，以 `knex.raw` 執行。
+   - 為何用 SQL 原文而非線上 `SHOW CREATE`：baseline 必須代表**原始 init 狀態**，後面的 alter/drop 才能在空庫上正確 replay。線上 `SHOW CREATE` 只當交叉核對。
+   - `down()` 留空（baseline 不回滾）。
+   ```js
+   // ponytail: 直接搬 Princess.sql + IF NOT EXISTS，prod 上全 no-op，空庫上建底表
+   exports.up = async (knex) => {
+     await knex.raw(`CREATE TABLE IF NOT EXISTS \`Guild\` (...);`);
+     // ... 其餘 25 張
+   };
+   exports.down = async () => {};
+   ```
+   - ⚠️ **地雷（已避開）**：`Princess.sql` 對 `chat_exp_unit`/`chat_level_title`/`chat_range_title`/`subscribe_type` 有 `TRUNCATE`+`INSERT`。baseline **絕不可**帶這段——否則 prod 跑 migrate 會 `TRUNCATE chat_exp_unit` 清掉轉生新曲線。baseline 只含 26 句 `CREATE TABLE IF NOT EXISTS`，資料全交給 `app/seeds/*`。實作為 `.js`（讀檔逐句跑）+ `.sql`（純 schema）一對，避開 DDL 反引號/單引號塞 JS 字串的問題。
+2. 拔掉 `docker-compose.yml` 的 `./migration:/docker-entrypoint-initdb.d` 掛載；刪除 `migration/Princess.sql`。
+3. 新人啟動流程更新（README / CLAUDE.md）：`make infra` → `cd app && yarn migrate && yarn knex seed:run`。
+4. **驗證（空庫實跑）**：
+   - 全新 volume：`docker compose down -v && make infra`。
+   - `yarn migrate` 應一路綠到底；`yarn migrate` 再跑一次應 no-op（驗冪等）。
+   - 比對最終表集合 = 目前線上現役表集合。
+5. **部署（prod 安全）**：照常 `docker exec redive_linebot-worker-1 yarn migrate`。baseline 因 `IF NOT EXISTS` 全跳過，只在 `knex_migrations` 補一筆 → **零 schema 變更**。knex 3 會把這支「時間戳較早但未執行」的 pending 補跑，預設 list validation 不受影響。
+
+---
+
+## Phase 2 — snake_case 改名（PR#2，會動線上，需部署窗口）
+
+> 誠實提醒：改表名 = prod schema 變更，**做不到對線上零影響**。但 `RENAME TABLE` 是 metadata-only、毫秒級、不複製資料；無 FK/trigger（待 Phase 0 終認）→ 真正風險只剩 **code 與 schema 必須同步部署**。本 bot 為 reply-only，部署當下若不同步，少數訊息會短暫報錯。
+
+1. 定案映射（Phase 0 後，扣除改判為 drop 的表），例：
+   `Guild→guild`、`GuildConfig→guild_config`、`GuildMembers→guild_members`、`GuildBattleConfig→guild_battle_config`、`GuildBattleFinish→guild_battle_finish`、`GachaPool→gacha_pool`、`GlobalOrders→global_orders`、`CustomerOrder→customer_order`、`Inventory→inventory`、`MessageRecord→message_record`、`PrincessUID→princess_uid`、`TotalEventTimes→total_event_times`、`Admin→admin`。（`User` 已於 batch 38 改名為 `user`，不在清單。共 **13 張**。）
+2. 新增 migration `<ts>_rename_legacy_tables_to_snake.js`：每張 `RENAME TABLE`，以 `hasTable(old) && !hasTable(new)` 守衛（空庫與 prod 都冪等）。`down()` 反向 rename。
+3. Code 改動（同 PR）：把約 62 個引用點改成 snake_case。已知熱點檔：
+   `model/platform/line.js`、`model/princess/guild/battle.js`、`model/application/Statistics.js`、`model/princess/gacha/index.js`、`model/application/Inventory.js`、`model/application/Guild.js`、`service/RaceService.js`、`service/AchievementEngine.js`，及對應 `__tests__`。逐一精確替換（引號包住的表名），勿誤傷同名變數/英文字。
+4. `yarn test:app` + `yarn lint:app` 綠燈。
+5. **部署 runbook（原子）**：
+   - 選低流量窗口。
+   - 部署「使用新表名的 code」+ 在**同一次 release** 跑 rename migration（兩者必須一起上）。
+   - 重啟 bot + worker。
+   - 冒煙測試：抽測會打到改名表的指令（轉蛋 / 戰隊 / 背包 / 排行）。
+   - **回滾**：跑 migration `down()`（反向 rename）+ redeploy 舊 image。
+
+---
+
+## 風險清單
+
+- `User` 等 row=0 表：rename 或 drop，Phase 0 拍板。
+- 後續 knex migration 可能新增了 FK 指向 legacy 表（SQL 原文沒有）→ Phase 0 的 `key_column_usage` 查證；MySQL `RENAME` 會自動更新指向被改名表的 FK，但仍需驗。
+- baseline 時間戳與線上 `knex_migrations` 既有檔名不可衝突 → Phase 0 清單確認。
+- 部署同步：Phase 2 code 與 migration 必須同 release，否則短暫報錯。


### PR DESCRIPTION
## Summary

把「`migration/Princess.sql` docker init + knex migration」兩套 schema 來源**收攏成 knex 單一來源**，新人空庫可一鍵啟動、**線上零 schema 變更**。

- 新增 `app/migrations/20210101000000_baseline_initial_schema.{js,sql}`：原 `Princess.sql` 的 26 張底表改為 `CREATE TABLE IF NOT EXISTS`（**純 schema、零 INSERT/TRUNCATE**），時間戳最早，fresh DB 先建底表供後續 migration 疊加。`.js` 讀同名 `.sql` 逐句執行（避開反引號/單引號 DDL 塞 JS 字串）。
- 移除 `docker-compose.yml` 的 `./migration:/docker-entrypoint-initdb.d` 掛載，刪除 `migration/Princess.sql`。
- 更新 `CLAUDE.md`：bootstrap 改為 knex 單一來源；新增 `docs/plans/migration-consolidation-snake-rename.md`（含後續 snake_case 改名計畫）。

## 為什麼線上安全

- baseline 全為 `IF NOT EXISTS` → prod 既有表上跑為 no-op，只補一筆 `knex_migrations`，**零 schema 變更**。
- **刻意不含** `Princess.sql` 原本對 `chat_exp_unit` 等的 `TRUNCATE`+`INSERT`——否則 prod 重跑會清掉轉生新曲線。資料種子全交給 `app/seeds/*`。
- 時間戳 `20210101000000` 早於最早既有 migration（`20210728152528`），knex 3 會把它當唯一 pending 補跑，預設 list validation 不受影響。

## Test plan

- [x] 空庫 throwaway `mysql:9` 跑 `yarn migrate` → 132 支全綠、**77 表（與線上一致）**
- [x] 先前 `Admin`（26 張第一張）漏建 bug 已修並複驗存在
- [x] 冪等：再跑 `yarn migrate` → `Already up to date`
- [x] `yarn knex seed:run` → 6 seeders OK（`chat_exp_unit`=101 新曲線、`GachaPool`=214）
- [x] `eslint` 新 migration 通過
- [ ] 部署：prod `docker exec ... yarn migrate` 後確認 baseline no-op、表結構與資料不變

## 部署註記

只需照常 `yarn migrate`。baseline 在 prod 為 no-op，無需任何手動 DB 操作。後續 snake_case 改名為獨立 PR（會動線上、需部署窗口）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)