### PR TITLE
refactor(db): 統一 legacy 表名為 snake_case（13 張）

### DIFF
--- a/app/__tests__/bin/rollback-prestige-system.test.js
+++ b/app/__tests__/bin/rollback-prestige-system.test.js
@@ -89,7 +89,7 @@ describe("rollback-prestige-system", () => {
             del: userAchievementsDelMock,
           };
         }
-        if (table === "Inventory") {
+        if (table === "inventory") {
           return {
             where: jest.fn().mockReturnThis(),
             del: inventoryDelMock,

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -701,7 +701,7 @@ describe("AchievementEngine", () => {
       expect(result.unlocked).toBe(true);
       expect(result.achievement.key).toBe("prestige_departure");
       expect(UserAchievementModel.unlock).toHaveBeenCalledWith("Uabc", 101);
-      expect(mysql).toHaveBeenCalledWith("Inventory");
+      expect(mysql).toHaveBeenCalledWith("inventory");
     });
 
     it("is a no-op when already unlocked", async () => {
@@ -778,7 +778,7 @@ describe("AchievementEngine", () => {
             where: jest.fn().mockResolvedValue([]),
           };
         }
-        if (table === "Inventory") {
+        if (table === "inventory") {
           return { insert: jest.fn().mockResolvedValue() };
         }
         return { where: jest.fn().mockResolvedValue([]) };

--- a/app/__tests__/service/GachaService.test.js
+++ b/app/__tests__/service/GachaService.test.js
@@ -29,7 +29,7 @@ let currentTrx;
 
 jest.mock("../../src/model/application/Inventory", () => {
   const inventory = {
-    table: "Inventory",
+    table: "inventory",
     transaction: jest.fn(async () => {
       currentTrx = makeTrxBuilder();
       return currentTrx;
@@ -191,7 +191,7 @@ describe("GachaService.runDailyDraw", () => {
     const result = await GachaService.runDailyDraw("Ufree");
     expect(result.godStoneCost).toBe(0);
     const costInserts = txInserts.filter(
-      t => t.table === "Inventory" && t.rows.itemId === 999 && t.rows.itemAmount < 0
+      t => t.table === "inventory" && t.rows.itemId === 999 && t.rows.itemAmount < 0
     );
     expect(costInserts.length).toBe(0);
   });
@@ -204,7 +204,7 @@ describe("GachaService.runDailyDraw", () => {
       expect(result.rareCount["3"]).toBe(10);
 
       const costInsert = txInserts.find(
-        t => t.table === "Inventory" && t.rows.itemId === 999 && t.rows.itemAmount === -5000
+        t => t.table === "inventory" && t.rows.itemId === 999 && t.rows.itemAmount === -5000
       );
       expect(costInsert).toBeDefined();
     });

--- a/app/bin/ConsumeCleanUpMembers.js
+++ b/app/bin/ConsumeCleanUpMembers.js
@@ -44,7 +44,7 @@ async function consume() {
   CustomLogger.info(`關閉 ${markIds.length} 個 群組會員資料`);
 
   if (markIds.length > 0) {
-    await mysql("GuildMembers").update({ status: 0, LeftDTM: new Date() }).whereIn("ID", markIds);
+    await mysql("guild_members").update({ status: 0, LeftDTM: new Date() }).whereIn("ID", markIds);
   }
 }
 

--- a/app/bin/DailyCleanup.js
+++ b/app/bin/DailyCleanup.js
@@ -16,7 +16,7 @@ async function removeDeletedOrders() {
   let expireDates = new Date();
   expireDates.setDate(expireDates.getDate() - 3);
   await mysql
-    .from("CustomerOrder")
+    .from("customer_order")
     .where("status", 0)
     .where("ModifyDTM", "<", expireDates)
     .delete();
@@ -27,7 +27,7 @@ async function markUselessOrders() {
   expireDates.setMonth(expireDates.getMonth() - 2);
 
   let affectedRows = await mysql
-    .from("CustomerOrder")
+    .from("customer_order")
     .where("status", 1)
     .where("touchDTM", "<", expireDates)
     .delete();
@@ -42,7 +42,7 @@ async function clearClosed() {
 
   let delGuilds = await mysql
     .select("guildId")
-    .from("Guild")
+    .from("guild")
     .where("status", 0)
     .where("CloseDTM", "<", expireDates)
     .then(res => res.map(data => data.guildId));
@@ -53,16 +53,16 @@ async function clearClosed() {
   }
 
   await mysql.transaction(async trx => {
-    let r1 = await trx.from("Guild").whereIn("GuildId", delGuilds).delete();
+    let r1 = await trx.from("guild").whereIn("GuildId", delGuilds).delete();
     records.push(`刪除了 ${r1} 個群組`);
 
-    let r2 = await trx.from("GuildMembers").whereIn("GuildId", delGuilds).delete();
+    let r2 = await trx.from("guild_members").whereIn("GuildId", delGuilds).delete();
     records.push(`刪除了 ${r2} 個群組會員資料`);
 
-    let r3 = await trx.from("GuildConfig").whereIn("GuildId", delGuilds).delete();
+    let r3 = await trx.from("guild_config").whereIn("GuildId", delGuilds).delete();
     records.push(`刪除了 ${r3} 個群組設定`);
 
-    let r4 = await trx.from("CustomerOrder").whereIn("SourceId", delGuilds).delete();
+    let r4 = await trx.from("customer_order").whereIn("SourceId", delGuilds).delete();
     records.push(`刪除了 ${r4} 個群組自訂指令`);
   });
 
@@ -72,7 +72,7 @@ async function clearClosed() {
 async function clearLeftMembers() {
   let expireDates = new Date();
   expireDates.setDate(expireDates.getDate() - 7);
-  let affectedRows = await mysql("GuildMembers")
+  let affectedRows = await mysql("guild_members")
     .where("LeftDTM", "<", expireDates)
     .where("status", "=", 0)
     .delete();

--- a/app/bin/DailyQuestProcess.js
+++ b/app/bin/DailyQuestProcess.js
@@ -70,7 +70,7 @@ async function handle(payload) {
   try {
     DefaultLogger.info(`[DailyQuest] ${userId} complete. Give reward`);
     await trx("daily_quest").insert({ user_id: userId });
-    await trx("Inventory").insert({
+    await trx("inventory").insert({
       userId,
       itemId: config.get("daily_quest.reward.itemId"),
       itemAmount: config.get("daily_quest.reward.itemAmount"),
@@ -88,7 +88,7 @@ async function handle(payload) {
     .where("user_id", userId);
 
   if (weeklyRecords.length === 7) {
-    await mysql("Inventory").insert({
+    await mysql("inventory").insert({
       userId,
       itemId: config.get("daily_quest.weekly_reward.itemId"),
       itemAmount: config.get("daily_quest.weekly_reward.itemAmount"),

--- a/app/bin/EventDequeue.js
+++ b/app/bin/EventDequeue.js
@@ -100,7 +100,7 @@ function handleJoin(event) {
 function handleLeave(event) {
   return mysql
     .update({ status: 0, closeDTM: new Date() })
-    .from("Guild")
+    .from("guild")
     .where({ status: 1, GuildId: event.source.groupId });
 }
 
@@ -113,7 +113,7 @@ async function handleMemberJoined(event) {
   let guildData = userData.groupList.find(list => list.guildId === groupId);
 
   if (!guildData) {
-    await mysql.insert({ guildId: groupId, userId, JoinedDTM: new Date() }).into("GuildMembers");
+    await mysql.insert({ guildId: groupId, userId, JoinedDTM: new Date() }).into("guild_members");
     clearUserCache(userId);
   } else if (guildData.status === 0) {
     await setMemberStatus(userId, groupId, 1);
@@ -140,7 +140,7 @@ async function handleMessage(event) {
   if (!member) return;
 
   if (event.message.type === "text") {
-    await mysql("GuildMembers")
+    await mysql("guild_members")
       .update({ LastSpeakDTM: new Date() })
       .increment("SpeakTimes", 1)
       .where({ userId, guildId: groupId });
@@ -258,7 +258,7 @@ async function getUserData(userId) {
 
   if (userData.length !== 0) {
     result = { ...result, ...userData[0] };
-    let groupData = await mysql.select("*").from("GuildMembers").where({ userId });
+    let groupData = await mysql.select("*").from("guild_members").where({ userId });
     result.groupList = groupData.map(data => ({
       id: data.ID,
       guildId: data.GuildId,
@@ -290,15 +290,15 @@ async function userRecord(userId) {
 }
 
 async function groupRecord(groupId) {
-  let groupData = await mysql.select("*").from("Guild").where({ guildId: groupId });
+  let groupData = await mysql.select("*").from("guild").where({ guildId: groupId });
   let data = groupData.length === 0 ? false : groupData[0];
 
   if (data === false) {
-    await mysql.insert({ guildId: groupId, createDTM: new Date() }).into("Guild");
+    await mysql.insert({ guildId: groupId, createDTM: new Date() }).into("guild");
   } else if (data.Status === 0) {
     await mysql
       .update({ status: 1, closeDTM: null })
-      .from("Guild")
+      .from("guild")
       .where({ status: 0, guildId: groupId });
   }
 }
@@ -313,7 +313,7 @@ function closeUser(userId) {
 
 async function setMemberStatus(userId, groupId, status) {
   clearUserCache(userId);
-  return mysql("GuildMembers")
+  return mysql("guild_members")
     .update({ status, leftDTM: status === 1 ? null : new Date() })
     .where({ guildId: groupId, userId });
 }
@@ -339,13 +339,13 @@ async function recordMessageTimes(botEvent, id) {
   }
   if (!increaseCol) return;
 
-  let affectedRow = await mysql("MessageRecord")
+  let affectedRow = await mysql("message_record")
     .update({ MR_MODIFYDTM: new Date() })
     .increment(increaseCol)
     .where({ id });
 
   if (affectedRow === 0) {
-    await mysql.insert({ id, MR_MODIFYDTM: new Date(), [increaseCol]: 1 }).into("MessageRecord");
+    await mysql.insert({ id, MR_MODIFYDTM: new Date(), [increaseCol]: 1 }).into("message_record");
   }
 }
 
@@ -369,7 +369,7 @@ async function getGroupMemberCount(groupId) {
   if (cached !== null) return parseInt(cached, 10);
 
   try {
-    let result = await mysql("GuildMembers")
+    let result = await mysql("guild_members")
       .where({ GuildId: groupId, status: 1 })
       .count({ count: "*" })
       .first();

--- a/app/bin/MonthlyReset.js
+++ b/app/bin/MonthlyReset.js
@@ -22,7 +22,7 @@ async function recordTotalTimes() {
   let [affectedRows] = await mysql
     .from(
       mysql.raw("?? (??, ??, ??, ??, ??, ??)", [
-        "TotalEventTimes",
+        "total_event_times",
         "TET_DATE",
         "TET_TEXT",
         "TET_IMAGE",
@@ -32,7 +32,7 @@ async function recordTotalTimes() {
       ])
     )
     .insert(function () {
-      this.from("MessageRecord")
+      this.from("message_record")
         .select({ date: mysql.raw(str) })
         .sum({ textCnt: "MR_TEXT" })
         .sum({ imageCnt: "MR_IMAGE" })
@@ -46,8 +46,8 @@ async function recordTotalTimes() {
 
 async function clearRecords() {
   await mysql.transaction(async trx => {
-    await mysql("GuildMembers").update({ SpeakTimes: 0 }).transacting(trx);
-    await mysql("MessageRecord")
+    await mysql("guild_members").update({ SpeakTimes: 0 }).transacting(trx);
+    await mysql("message_record")
       .update({
         MR_TEXT: 0,
         MR_IMAGE: 0,

--- a/app/bin/TitleDelivery.js
+++ b/app/bin/TitleDelivery.js
@@ -29,7 +29,7 @@ async function deliveryGachaTitles(trx) {
   const collectKeys = ["gacha_king_1", "gacha_king_2", "gacha_king_3"];
   const collectUsers = await trx
     .select("userId")
-    .from("Inventory")
+    .from("inventory")
     .count({ count: "itemId" })
     .whereNot("itemId", 999)
     .orderBy("count", "desc")
@@ -47,7 +47,7 @@ async function deliveryGachaTitles(trx) {
   const richKeys = ["gacha_rich_1", "gacha_rich_2", "gacha_rich_3"];
   const richUsers = await trx
     .select("userId")
-    .from("Inventory")
+    .from("inventory")
     .sum({ sum: "itemAmount" })
     .where("itemId", 999)
     .orderBy("sum", "desc")

--- a/app/bin/WeeklyMemberAudit.js
+++ b/app/bin/WeeklyMemberAudit.js
@@ -11,7 +11,7 @@ async function main() {
 async function provideCleanUpMembers() {
   let memberDatas = await mysql
     .select(["id", { groupId: "GuildId" }, { userId: "UserId" }])
-    .from("GuildMembers")
+    .from("guild_members")
     .where({ status: 1 });
 
   CustomLogger.info(`七天固定盤點會員資料，此次處理筆數 ${memberDatas.length}`);

--- a/app/bin/rollback-prestige-system.js
+++ b/app/bin/rollback-prestige-system.js
@@ -74,7 +74,7 @@ async function revokeTierAchievements(achievementIds) {
 }
 
 async function deleteSentinelInventory() {
-  return mysql("Inventory").where({ note: SENTINEL_NOTE }).del();
+  return mysql("inventory").where({ note: SENTINEL_NOTE }).del();
 }
 
 function writeAuditLog(audit) {

--- a/app/migrations/20260626061708_rename_legacy_tables_to_snake.js
+++ b/app/migrations/20260626061708_rename_legacy_tables_to_snake.js
@@ -1,0 +1,42 @@
+/**
+ * 把殘留的 PascalCase legacy 表名統一成 snake_case（表名專用，欄位名不動）。
+ *
+ * 對應 PR：snake_case 表名統一。User 已於更早 migration 改名為 user，不在此列。
+ * 安全性：
+ *   - RENAME TABLE 為 metadata-only、毫秒級、不複製資料；這批表無 FK / trigger 牽連（已查 prod）。
+ *   - hasTable 守衛 → prod（camelCase 存在）會改名；fresh DB / 已改名環境為 no-op，冪等。
+ *   - 需與「改用新表名的應用程式碼」同一次 release 上線。
+ *
+ * ponytail: 假設 lower_case_table_names=0（prod 與 docker mysql 皆是，故大小寫敏感、改名有意義）。
+ */
+const RENAMES = [
+  ["Admin", "admin"],
+  ["CustomerOrder", "customer_order"],
+  ["GachaPool", "gacha_pool"],
+  ["GlobalOrders", "global_orders"],
+  ["Guild", "guild"],
+  ["GuildBattleConfig", "guild_battle_config"],
+  ["GuildBattleFinish", "guild_battle_finish"],
+  ["GuildConfig", "guild_config"],
+  ["GuildMembers", "guild_members"],
+  ["Inventory", "inventory"],
+  ["MessageRecord", "message_record"],
+  ["PrincessUID", "princess_uid"],
+  ["TotalEventTimes", "total_event_times"],
+];
+
+exports.up = async function (knex) {
+  for (const [from, to] of RENAMES) {
+    if ((await knex.schema.hasTable(from)) && !(await knex.schema.hasTable(to))) {
+      await knex.schema.renameTable(from, to);
+    }
+  }
+};
+
+exports.down = async function (knex) {
+  for (const [from, to] of RENAMES) {
+    if ((await knex.schema.hasTable(to)) && !(await knex.schema.hasTable(from))) {
+      await knex.schema.renameTable(to, from);
+    }
+  }
+};

--- a/app/seeds/GachaPoolSeeder.js
+++ b/app/seeds/GachaPoolSeeder.js
@@ -3,14 +3,14 @@ const _ = require("lodash");
 
 exports.seed = function (knex) {
   // Deletes ALL existing entries
-  return knex("GachaPool")
+  return knex("gacha_pool")
     .del()
     .then(function () {
       // Inserts seed entries
 
       return Promise.all(
         _.chunk(characters, 50).map(data => {
-          return knex("GachaPool").insert(
+          return knex("gacha_pool").insert(
             data.map(char => ({
               Name: char.Name,
               HeadImage_Url: char.HeadImage,

--- a/app/src/model/application/Admin.js
+++ b/app/src/model/application/Admin.js
@@ -3,11 +3,11 @@ const redis = require("../../util/redis");
 const config = require("config");
 
 exports.getList = () => {
-  return mysql.select().from("Admin");
+  return mysql.select().from("admin");
 };
 
 exports.find = async userId => {
-  return await mysql.from("Admin").where({ userId }).first();
+  return await mysql.from("admin").where({ userId }).first();
 };
 
 /**
@@ -17,7 +17,7 @@ exports.find = async userId => {
 exports.isAdmin = userId => {
   return mysql
     .select("ID")
-    .from("Admin")
+    .from("admin")
     .where({ userId })
     .then(res => (res.length > 0 ? true : false));
 };
@@ -27,7 +27,7 @@ exports.isAdminFromCache = async userId => {
   let adminList = await redis.get(key);
 
   if (!adminList) {
-    let result = await mysql("Admin").select("userId");
+    let result = await mysql("admin").select("userId");
     adminList = result.map(item => item.userId);
     await redis.set(key, JSON.stringify(adminList), {
       EX: 60 * 60,

--- a/app/src/model/application/CustomerOrder.js
+++ b/app/src/model/application/CustomerOrder.js
@@ -1,7 +1,7 @@
 const mysql = require("../../util/mysql");
 const redis = require("../../util/redis");
 
-exports.table = "CustomerOrder";
+exports.table = "customer_order";
 exports.columnsAlias = [
   "no",
   "sourceId",

--- a/app/src/model/application/GlobalOrders.js
+++ b/app/src/model/application/GlobalOrders.js
@@ -2,7 +2,7 @@ const mysql = require("../../util/mysql");
 const redis = require("../../util/redis");
 const memKey = "GlobalOrders";
 const uuid = require("uuid-random");
-const TABLE = "GlobalOrders";
+const TABLE = "global_orders";
 exports.table = TABLE;
 
 function buildRows(objData, key) {

--- a/app/src/model/application/Guild.js
+++ b/app/src/model/application/Guild.js
@@ -8,7 +8,7 @@ const redis = require("../../util/redis");
  * @returns {Promise<{ID: Number, GuildId: String}>}
  */
 exports.findByGroupId = async groupId => {
-  return await mysql.select("*").from("Guild").where({ GuildId: groupId }).first();
+  return await mysql.select("*").from("guild").where({ GuildId: groupId }).first();
 };
 
 /**
@@ -25,12 +25,12 @@ exports.fetchGuildInfoByUser = userId => {
       "speakTimes",
       "lastSpeakDTM",
     ])
-    .from("GuildMembers")
+    .from("guild_members")
     .where({ userId, status: 1 });
 };
 
 exports.fetchGuildMembers = guildId => {
-  return mysql.select(["guildId", "userId"]).from("GuildMembers").where({ guildId, status: 1 });
+  return mysql.select(["guildId", "userId"]).from("guild_members").where({ guildId, status: 1 });
 };
 
 /**
@@ -45,4 +45,4 @@ exports.clearLineSession = guildId => {
 /**
  * @returns {Knex}
  */
-exports.query = () => mysql("Guild");
+exports.query = () => mysql("guild");

--- a/app/src/model/application/GuildConfig.js
+++ b/app/src/model/application/GuildConfig.js
@@ -1,12 +1,12 @@
 const mysql = require("../../util/mysql");
 const redis = require("../../util/redis");
-exports.table = "GuildConfig";
+exports.table = "guild_config";
 
 exports.fetchConfig = async groupId => {
   var GroupConfig = await redis.get(`GuildConfig_${groupId}`);
 
   if (GroupConfig === null) {
-    var query = mysql.select("*").from("GuildConfig").where({ GuildId: groupId });
+    var query = mysql.select("*").from("guild_config").where({ GuildId: groupId });
     return query.then(res => {
       if (res.length === 0) {
         res = {
@@ -56,7 +56,7 @@ exports.getDiscordWebhook = async groupId => {
   let webhook = await redis.get(memoryKey);
   if (webhook !== null) return webhook;
 
-  let query = mysql.select("DiscordWebhook").from("GuildConfig").where({ GuildId: groupId });
+  let query = mysql.select("DiscordWebhook").from("guild_config").where({ GuildId: groupId });
 
   let [data] = await query;
   if (data !== undefined) {
@@ -81,7 +81,7 @@ exports.setDiscordWebhook = (groupId, webhook) => {
     .update({
       DiscordWebhook: webhook,
     })
-    .into("GuildConfig")
+    .into("guild_config")
     .where({
       GuildId: groupId,
     })
@@ -99,7 +99,7 @@ exports.removeDicordWebhook = groupId => {
     .update({
       DiscordWebhook: null,
     })
-    .into("GuildConfig")
+    .into("guild_config")
     .where({
       GuildId: groupId,
     })
@@ -121,7 +121,7 @@ exports.setWelcomeMessage = (groupId, message) => {
     .update({
       WelcomeMessage: message,
     })
-    .into("GuildConfig")
+    .into("guild_config")
     .where({
       GuildId: groupId,
     })
@@ -136,7 +136,7 @@ exports.setWelcomeMessage = (groupId, message) => {
 exports.getWelcomeMessage = groupId => {
   return mysql
     .select("WelcomeMessage")
-    .from("GuildConfig")
+    .from("guild_config")
     .where({ GuildId: groupId })
     .whereNotNull("WelcomeMessage")
     .where("WelcomeMessage", "<>", "")
@@ -158,7 +158,7 @@ function saveConfig(groupId, config) {
       Config: JSON.stringify(config),
       modifyDTM: new Date(),
     })
-    .into("GuildConfig")
+    .into("guild_config")
     .where({
       GuildId: groupId,
     })
@@ -172,7 +172,7 @@ function insertConfig(groupId, config) {
       Config: JSON.stringify(config),
       modifyDTM: new Date(),
     })
-    .into("GuildConfig")
+    .into("guild_config")
     .then();
 }
 

--- a/app/src/model/application/Inventory.js
+++ b/app/src/model/application/Inventory.js
@@ -1,7 +1,7 @@
 const mysql = require("../../util/mysql");
 const base = require("../base");
 
-exports.tableName = "Inventory";
+exports.tableName = "inventory";
 
 exports.query = () => mysql(this.tableName);
 
@@ -55,19 +55,19 @@ class Inventory extends base {
       .select([
         "itemId",
         { amount: this.connection.raw("SUM(itemAmount)") },
-        { name: "GachaPool.Name" },
+        { name: "gacha_pool.Name" },
         { headImage: "HeadImage_Url" },
       ])
       .where({ userId })
-      .join("GachaPool", "GachaPool.ID", "itemId")
+      .join("gacha_pool", "gacha_pool.ID", "itemId")
       .groupBy("itemId");
   }
 
   getAllUserOwnCharacters(userId) {
     return this.knex
-      .select(["itemId", { name: "GachaPool.Name" }, { headImage: "HeadImage_Url" }, "attributes"])
+      .select(["itemId", { name: "gacha_pool.Name" }, { headImage: "HeadImage_Url" }, "attributes"])
       .where({ userId })
-      .join("GachaPool", "GachaPool.ID", "itemId")
+      .join("gacha_pool", "gacha_pool.ID", "itemId")
       .whereNot({ itemId: 999 });
   }
 
@@ -124,6 +124,6 @@ class Inventory extends base {
 }
 
 exports.inventory = new Inventory({
-  table: "Inventory",
+  table: "inventory",
   fillable: ["userId", "itemId", "itemAmount", "attributes", "note"],
 });

--- a/app/src/model/application/MarketDetail.js
+++ b/app/src/model/application/MarketDetail.js
@@ -16,9 +16,9 @@ class MarketDetail extends base {
         "closed_at",
         { name: "Name" },
         { image: "HeadImage_Url" },
-        { star: "GachaPool.star" },
+        { star: "gacha_pool.star" },
       ])
-      .leftJoin("GachaPool", "GachaPool.ID", "item_id")
+      .leftJoin("gacha_pool", "gacha_pool.ID", "item_id")
       .where({ [`${this.table}.id`]: id })
       .first();
   }

--- a/app/src/model/application/Statistics.js
+++ b/app/src/model/application/Statistics.js
@@ -12,7 +12,7 @@ exports.getGuildCount = async () => {
 
   count = await mysql
     .select()
-    .from("Guild")
+    .from("guild")
     .count({ cnt: "*" })
     .then(data => data[0].cnt);
 
@@ -52,7 +52,7 @@ exports.getCustomerOrderCount = async () => {
 
   count = await mysql
     .select()
-    .from("CustomerOrder")
+    .from("customer_order")
     .count({ cnt: "*" })
     .then(data => data[0].cnt);
 
@@ -74,12 +74,12 @@ exports.getSpeakTimesCount = async () => {
   times = await mysql
     .select()
     .sum({ times: "SpeakTimes" })
-    .from("GuildMembers")
+    .from("guild_members")
     .then(data => parseInt(data[0].times) || 0);
 
   let historyTimes = await mysql
     .sum({ times: "TET_TEXT" })
-    .from("TotalEventTimes")
+    .from("total_event_times")
     .then(data => parseInt(data[0].times) || 0);
 
   times += historyTimes;
@@ -101,7 +101,7 @@ exports.getGuildDataByUser = async userId => {
 
   guildData = await mysql
     .select()
-    .from("GuildMembers")
+    .from("guild_members")
     .sum({ times: "SpeakTimes" })
     .count({ cnt: "*" })
     .where({ userId })

--- a/app/src/model/platform/line.js
+++ b/app/src/model/platform/line.js
@@ -175,7 +175,7 @@ exports.memberLeft = (userId, groupId) => {
  */
 exports.setMemberStatus = (userId, groupId, status) => {
   return setStatus(
-    "GuildMembers",
+    "guild_members",
     {
       status: status,
       leftDTM: status === 1 ? null : new Date(),
@@ -188,8 +188,8 @@ exports.setMemberStatus = (userId, groupId, status) => {
 };
 
 exports.table = {
-  Guild: "Guild",
-  GuildMembers: "GuildMembers",
+  Guild: "guild",
+  GuildMembers: "guild_members",
   User: "user",
 };
 
@@ -197,7 +197,7 @@ exports.increaseSpeakTimes = (userId, guildId) => {
   mysql
     .update({ LastSpeakDTM: new Date() })
     .increment("SpeakTimes", 1)
-    .from("GuildMembers")
+    .from("guild_members")
     .where({ userId, guildId })
     .then();
 };
@@ -209,7 +209,7 @@ exports.increaseSpeakTimes = (userId, guildId) => {
 exports.getGroupSpeakRank = groupId => {
   return mysql
     .from(this.table.GuildMembers)
-    .join("MessageRecord", "MessageRecord.id", "=", `${this.table.GuildMembers}.id`)
+    .join("message_record", "message_record.id", "=", `${this.table.GuildMembers}.id`)
     .select([
       "userId",
       "status",

--- a/app/src/model/princess/GodStoneShop.js
+++ b/app/src/model/princess/GodStoneShop.js
@@ -29,7 +29,7 @@ exports.all = async function () {
       { headImage: "HeadImage_Url" },
       { star: "Star" },
     ])
-    .join("GachaPool", "GachaPool.id", "=", "god_stone_shop.item_id");
+    .join("gacha_pool", "gacha_pool.id", "=", "god_stone_shop.item_id");
 };
 
 exports.create = async function (attributes) {

--- a/app/src/model/princess/gacha/index.js
+++ b/app/src/model/princess/gacha/index.js
@@ -4,7 +4,7 @@ const LineClient = getClient("line");
 const redis = require("../../../util/redis");
 const { get } = require("lodash");
 const base = require("../../base");
-exports.table = "GachaPool";
+exports.table = "gacha_pool";
 
 exports.all = async (options = {}) => {
   let query = mysql.from(this.table);
@@ -40,7 +40,7 @@ exports.getDatabasePool = () => {
  * @returns {Promise}
  */
 exports.insertNewData = objData => {
-  return mysql.insert({ ...objData, modify_ts: new Date() }).into("GachaPool");
+  return mysql.insert({ ...objData, modify_ts: new Date() }).into("gacha_pool");
 };
 
 /**
@@ -58,7 +58,7 @@ exports.insertNewData = objData => {
 exports.updateData = (id, objData) => {
   return mysql
     .update({ ...objData, modify_ts: new Date() })
-    .from("GachaPool")
+    .from("gacha_pool")
     .where({ id })
     .then(res => res);
 };
@@ -69,7 +69,7 @@ exports.updateData = (id, objData) => {
  * @returns {Promise}
  */
 exports.deleteData = id => {
-  return mysql.from("GachaPool").where({ id }).del();
+  return mysql.from("gacha_pool").where({ id }).del();
 };
 
 /**
@@ -104,8 +104,8 @@ exports.getUserCollectedCharacterCount = userId => {
   return mysql
     .select()
     .count("*", { as: "count" })
-    .from("Inventory")
-    .join(this.table, "Inventory.itemId", "=", "GachaPool.id")
+    .from("inventory")
+    .join(this.table, "inventory.itemId", "=", "gacha_pool.id")
     .where({
       userId,
     })
@@ -115,7 +115,7 @@ exports.getUserCollectedCharacterCount = userId => {
 exports.getUserGodStoneCount = userId => {
   return mysql
     .select()
-    .from("Inventory")
+    .from("inventory")
     .sum({ total: "itemAmount" })
     .where({ itemId: 999, userId })
     .then(res => (res.length === 0 ? 0 : res[0].total || 0));
@@ -151,7 +151,7 @@ exports.getCollectedRank = async options => {
 
   var query = mysql
     .select("userId")
-    .from("Inventory")
+    .from("inventory")
     .count({ cnt: "itemId" })
     .where("itemId", "<>", 999)
     .groupBy("userId")
@@ -189,5 +189,5 @@ exports.getCollectedRank = async options => {
 class GachaPool extends base {}
 
 exports.model = new GachaPool({
-  table: "GachaPool",
+  table: "gacha_pool",
 });

--- a/app/src/model/princess/guild/battle.js
+++ b/app/src/model/princess/guild/battle.js
@@ -11,12 +11,12 @@ exports.setFinishBattle = (guildId, userId) => {
     .transaction(trx => {
       trx
         .select("id")
-        .from("GuildBattleFinish")
+        .from("guild_battle_finish")
         .where({ guildId, userId })
         .whereBetween("CreateDTM", [start, end])
         .then(res => {
           if (res.length === 0) {
-            return trx("GuildBattleFinish").insert({
+            return trx("guild_battle_finish").insert({
               guildId,
               userId,
             });
@@ -32,7 +32,7 @@ exports.setFinishBattle = (guildId, userId) => {
 exports.resetFinishBattle = (guildId, userId) => {
   let { start, end } = getBattleDate(new Date());
   return mysql
-    .from("GuildBattleFinish")
+    .from("guild_battle_finish")
     .where({ guildId, userId })
     .whereBetween("CreateDTM", [start, end])
     .delete();
@@ -46,13 +46,13 @@ exports.resetFinishBattle = (guildId, userId) => {
 exports.getFinishList = async (guildId, objDate) => {
   let { start, end } = getBattleDate(objDate);
 
-  let rows = await mysql.select("userId").from("GuildMembers").where({ guildId, status: 1 });
+  let rows = await mysql.select("userId").from("guild_members").where({ guildId, status: 1 });
 
   const memberIds = rows.map(row => row.userId);
 
   let GBFrows = await mysql
     .select(["userId", "createDTM"])
-    .from("GuildBattleFinish")
+    .from("guild_battle_finish")
     .where({ guildId })
     .whereBetween("createDTM", [start, end]);
 
@@ -73,7 +73,7 @@ exports.getFinishList = async (guildId, objDate) => {
 exports.getMonthFinishList = (guildId, month) => {
   return mysql
     .select(["userId", "createDTM"])
-    .from("GuildBattleFinish")
+    .from("guild_battle_finish")
     .where({ guildId })
     .whereRaw("month(createDTM) = ?", [month]);
 };

--- a/app/src/model/princess/guild/config.js
+++ b/app/src/model/princess/guild/config.js
@@ -1,5 +1,5 @@
 const mysql = require("../../../util/mysql");
-const GUILD_BATTLE_CONFIG_TABLE = "GuildBattleConfig";
+const GUILD_BATTLE_CONFIG_TABLE = "guild_battle_config";
 
 /**
  * 獲取群組戰隊設定

--- a/app/src/model/princess/uid.js
+++ b/app/src/model/princess/uid.js
@@ -3,7 +3,7 @@ const redis = require("../../util/redis");
 const axios = require("axios").default;
 const nicknameAPI = "https://www.pay.so-net.tw/exchange/checkUser";
 
-exports.table = "PrincessUID";
+exports.table = "princess_uid";
 
 /**
  * 綁定遊戲ID

--- a/app/src/repositories/princess/guild/guildRepository.js
+++ b/app/src/repositories/princess/guild/guildRepository.js
@@ -27,5 +27,5 @@ exports.findByGuildId = (guildId, relation) => {
 };
 
 function princess(query) {
-  return query.join("PrincessUID", "Guild.uid", "=", "PrincessUID.uid");
+  return query.join("princess_uid", "guild.uid", "=", "princess_uid.uid");
 }

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -295,7 +295,7 @@ async function unlockAchievement(userId, achievement) {
     // Append a new ledger row — balance is SUM(itemAmount) across rows.
     // The prior UPDATE-without-row-ID version multiplied the reward by the
     // user's existing row count (see project_stone_ledger_refactor memo).
-    await mysql("Inventory").insert({
+    await mysql("inventory").insert({
       userId,
       itemId: GODDESS_STONE_ITEM_ID,
       itemAmount: achievement.reward_stones,

--- a/app/src/service/RaceService.js
+++ b/app/src/service/RaceService.js
@@ -82,7 +82,7 @@ exports.placeBet = async function (userId, raceId, runnerId, amount) {
 
   // Atomic balance check + deduction inside transaction
   return mysql.transaction(async trx => {
-    const balRow = await trx("Inventory")
+    const balRow = await trx("inventory")
       .where({ userId, itemId: 999 })
       .sum("itemAmount as total")
       .first();
@@ -98,7 +98,7 @@ exports.placeBet = async function (userId, raceId, runnerId, amount) {
       runner_id: runnerId,
       amount,
     });
-    await trx("Inventory").insert({
+    await trx("inventory").insert({
       userId,
       itemId: 999,
       itemAmount: -amount,
@@ -223,7 +223,7 @@ exports.settleBets = async function (raceId) {
     await mysql.transaction(async trx => {
       for (const bet of allBets) {
         await trx("race_bet").where("id", bet.id).update({ payout: bet.amount });
-        await trx("Inventory").insert([
+        await trx("inventory").insert([
           { userId: bet.user_id, itemId: 999, itemAmount: bet.amount, note: "race_refund" },
         ]);
       }
@@ -240,7 +240,7 @@ exports.settleBets = async function (raceId) {
     for (const bet of winnerBets) {
       const payout = Math.floor(prizePool * (bet.amount / winnerTotal));
       await trx("race_bet").where("id", bet.id).update({ payout });
-      await trx("Inventory").insert([
+      await trx("inventory").insert([
         { userId: bet.user_id, itemId: 999, itemAmount: payout, note: "race_payout" },
       ]);
     }

--- a/app/src/service/__tests__/JankenRewardService.test.js
+++ b/app/src/service/__tests__/JankenRewardService.test.js
@@ -9,7 +9,7 @@ describe("JankenRewardService.payoutDaily", () => {
       mysql("janken_daily_reward_log").delete(),
       mysql("janken_records").delete(),
       mysql("janken_rating").delete(),
-      mysql("Inventory").where({ note: "janken_daily_rank_reward" }).delete(),
+      mysql("inventory").where({ note: "janken_daily_rank_reward" }).delete(),
       mysql("janken_seasons").delete(),
     ]);
     await mysql("janken_seasons").insert({ id: 1, started_at: new Date(), status: "active" });
@@ -33,7 +33,7 @@ describe("JankenRewardService.payoutDaily", () => {
     const result = await JankenRewardService.payoutDaily(yesterdayDateString());
     expect(result.dryRun).toBe(true);
     expect(result.candidates).toHaveLength(1);
-    const stones = await mysql("Inventory").where({ note: "janken_daily_rank_reward" });
+    const stones = await mysql("inventory").where({ note: "janken_daily_rank_reward" });
     expect(stones).toHaveLength(0);
     const logs = await mysql("janken_daily_reward_log");
     expect(logs).toHaveLength(0);
@@ -65,7 +65,7 @@ describe("JankenRewardService.payoutDaily", () => {
     expect(result.dryRun).toBe(false);
     const log = await mysql("janken_daily_reward_log").where({ user_id: "U_FlagOn" }).first();
     expect(log.amount).toBe(500); // top1
-    const stones = await mysql("Inventory")
+    const stones = await mysql("inventory")
       .where({ note: "janken_daily_rank_reward", userId: "U_FlagOn" })
       .first();
     expect(Number(stones.itemAmount)).toBe(500);

--- a/docs/plans/migration-consolidation-snake-rename.md
+++ b/docs/plans/migration-consolidation-snake-rename.md
@@ -7,7 +7,7 @@
 
 - **Phase 0 線上審計：完成**（2026-06-26）。關鍵結論：`User` 已於 batch 38 改名為 `user`（移出改名清單，14→13）；5 張空表是新功能待啟用（不砍）；13 張 legacy 表全活躍（全改名）；12 條 FK 全在 snake_case 表間、零指向 legacy 表、零 trigger（DB 層改名安全）；線上共 77 表。
 - **Phase 1 收攏：完成、未 commit**（分支 `chore/consolidate-migrations-knex`）。空庫 throwaway 驗證：`yarn migrate` → 132 支跑完 = **77 表（與線上一致）**、冪等、`Admin` 修復；`yarn knex seed:run` → 6 seeders OK。待 review 後 commit/PR。
-- **Phase 2 改名：未開始**，需部署窗口決策。
+- **Phase 2 改名：完成、未部署**（分支 `chore/rename-legacy-tables-snake`，stacked on PR#1）。改名 migration + 30 檔 code/test（13 表）；空庫驗證 → 77 表全 snake、PascalCase 殘留 0、冪等；離線測試 62 pass。**需 PR#1 先 merge+部署，再於部署窗口上這支（migration + code 同一 release）。**
 
 ## 背景事實（已驗證）
 


### PR DESCRIPTION
> **Stacked on #743**（base = `chore/consolidate-migrations-knex`）。待 #743 merge 後 GitHub 會自動把 base 改為 main。

## Summary

把殘留的 13 張 PascalCase 表名統一成 snake_case（表名專用，**欄位名不動**）。`User` 已於更早 migration 改為 `user`，不在此列。

**改名 migration** `20260626061708_rename_legacy_tables_to_snake.js`：`RENAME TABLE` 13 張、`hasTable` 守衛冪等。對應映射：
`Admin→admin`、`CustomerOrder→customer_order`、`GachaPool→gacha_pool`、`GlobalOrders→global_orders`、`Guild→guild`、`GuildBattleConfig→guild_battle_config`、`GuildBattleFinish→guild_battle_finish`、`GuildConfig→guild_config`、`GuildMembers→guild_members`、`Inventory→inventory`、`MessageRecord→message_record`、`PrincessUID→princess_uid`、`TotalEventTimes→total_event_times`。

**Code 同步**（30 檔 model/bin/seed/service/repo/test）：表名字串、knex 查詢參數、join 的 table-qualified 欄位前綴（如 `gacha_pool.ID`/`guild.uid`/`princess_uid.uid`/`message_record.id`）、`line.js` 的 `exports.table` 物件值。

**刻意保留**：欄位名（`GuildId`/`SourceId`…）、`GlobalOrders.js` 的快取鍵 `memKey`、`line.js` 物件 key、group-config 條目名 `"CustomerOrder"`、model 檔名/class、frontend（走 REST API、不直接查表）。

## 為什麼 DB 層安全

`RENAME TABLE` 為 metadata-only、毫秒級、不複製資料；這批表經 prod 盤點**無 FK、無 trigger 牽連**。風險僅在 **code↔schema 必須同一次 release 上線**。

## Test plan

- [x] 空庫 throwaway `mysql:9` 跑完整鏈（baseline+131+改名=133 支）→ **77 表、PascalCase 殘留 0、snake_case 13、冪等**
- [x] 殘留 grep：除刻意保留的 2 處（memKey、group-config 條目名）外，無舊表名引用
- [x] 欄位名未被誤改（diff `+`/`-` 等量）
- [x] 離線測試套件 4 suites / 62 tests pass；新舊 migration `eslint` 過
- [ ] 部署後冒煙：轉蛋、戰隊簽到/排行、背包、客製指令

## ⚠️ 部署 Runbook（會動到線上）

1. **前置**：#743（baseline 收攏）已 merge 並部署到 prod。
2. 選**低流量窗口**（reply-only bot；部署當下 code/schema 短暫不一致時少數訊息會報錯）。
3. **同一次 release** 一起上：部署本分支 code（bot + worker 映像）→ 跑改名 migration `docker exec redive_linebot-worker-1 yarn migrate`（13 個 RENAME，毫秒級）→ 重啟 bot + worker。frontend 不需重建（不直接查表）。
4. **冒煙**：轉蛋（inventory/gacha_pool）、戰隊（guild/guild_members/guild_config）、背包（inventory）、說話排行（guild_members/message_record）、客製/全域指令（customer_order/global_orders）。
5. **Rollback**：`docker exec redive_linebot-worker-1 yarn knex migrate:rollback`（本 migration 的 `down` 反向 rename）+ redeploy 舊映像。無 FK/trigger，rollback 乾淨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)