### PR TITLE
fix(db): 清除 baseline 在 prod 復活的 10 張空殭屍表

### DIFF
--- a/app/migrations/20260626084954_drop_baseline_zombie_tables.js
+++ b/app/migrations/20260626084954_drop_baseline_zombie_tables.js
@@ -1,0 +1,40 @@
+/**
+ * 清掉 baseline（20210101000000）在 prod 晚跑時用 `CREATE TABLE IF NOT EXISTS`
+ * 復活的 10 張空殭屍表。
+ *
+ * 成因：baseline 忠實重現原 Princess.sql 的 26 張表，但其中 10 張早已被後續
+ * migration drop / rename（且那些 migration 在 prod 已套用、不會再跑）。
+ * 在 lower_case_table_names=0 的 prod 上，IF NOT EXISTS 對不上現況 → 重建成空表。
+ * （全新環境不受影響：drop/rename migration 會在 baseline 之後重新清掉它們。）
+ *
+ * 安全性：每張表「存在且 0 列」才 drop；若意外有資料則 throw 中止（不誤刪）。
+ * 這道 0 列防呆也能擋住萬一某環境 lctn≠0 導致 "User" 撞到 live 的 "user"（會有列數 → 中止）。
+ */
+const ZOMBIE_TABLES = [
+  "User", // batch 38 已改名為 user（live，2.7 萬列）；此處只清空殼 User
+  "GachaSignin",
+  "chat_level_title",
+  "chat_range_title",
+  "BulletIn",
+  "sent_bulletin",
+  "notify_list",
+  "subscribe_type",
+  "arena_records",
+  "arena_like_records",
+];
+
+exports.up = async function (knex) {
+  for (const table of ZOMBIE_TABLES) {
+    if (!(await knex.schema.hasTable(table))) continue;
+    const [{ cnt }] = await knex(table).count({ cnt: "*" });
+    if (Number(cnt) > 0) {
+      throw new Error(
+        `Refusing to drop "${table}": expected 0 rows but found ${cnt}. Investigate before re-running.`
+      );
+    }
+    await knex.schema.dropTableIfExists(table);
+  }
+};
+
+// 不重建殭屍表（它們本就該不存在）。
+exports.down = async function () {};


### PR DESCRIPTION
## 背景（#743 的副作用）

#743 的 baseline migration（`20210101000000`）忠實重現原 `Princess.sql` 的 26 張表（`CREATE TABLE IF NOT EXISTS`）。但其中 **10 張**早被後續 migration drop / rename（batch 27–48）。baseline 在 prod 是**晚跑**的（batch 53）——那些 drop/rename migration 早已套用、不會再跑——加上 prod `lower_case_table_names=0`，`IF NOT EXISTS` 對不上現況，於是把這 10 張**復活成空表**。

> 全新環境不受影響：drop/rename migration 會在 baseline 之後重新清掉它們（throwaway 實測 fresh = 77 表，無殭屍）。問題只發生在「baseline 晚跑於已遷移的 prod」。

線上 agent 盤點確認：13 張改名乾淨、資料零損失、FK/trigger 正常；唯獨這 10 張空殭屍（全 0 列）需清。其中 `User`（空）會遮蔽 live 的 `user`（2.7 萬列）——是首要該清的。

## 殭屍清單（全 0 列）

`User`（已改名為 `user`）、`GachaSignin`、`chat_level_title`、`chat_range_title`、`BulletIn`、`sent_bulletin`、`notify_list`、`subscribe_type`、`arena_records`、`arena_like_records`。

## 修法

新增 migration `drop_baseline_zombie_tables`：逐張 drop，**只在「存在且 0 列」才動手；非 0 則 throw 中止**。這道 0 列防呆同時擋住萬一某環境 `lctn≠0` 導致 `"User"` 撞到 live `"user"`（有列數 → 中止、不誤刪）。

baseline 檔**保留原貌**（它是忠實的歷史 init）；本 migration 永久在鏈上，任何環境跑完 baseline 都會接著被清乾淨。

## Test plan（throwaway `mysql:9` 實測）

- [x] Fresh migrate（134 支，含本支）→ 77 表，本支在 fresh 為 no-op
- [x] **模擬 prod**：手動復活 10 張空殭屍（→87 表）+ live `user` 塞 1 列 → 重跑 → **10 張全清、`user` 完好（大小寫敏感未誤動）、回到 77**
- [x] **防呆**：殭屍含 1 列時 → migration 中止（`Refusing to drop "BulletIn"...found 1`），未誤刪
- [x] `eslint` 通過

## 部署

走正常 `docker exec redive_linebot-worker-1 yarn migrate` 即可。只 drop 已驗證為空、且無人寫入的廢表，**不需停機窗口、無 code 連動**。

## 額外發現（不在本 PR 範圍）

`chat_level_title`/`chat_range_title` 僅被 `app/src/model/application/ChatLevelModel.js` 參照，而該檔**全 app 零 import = 死碼**（稱號系統於 batch 48 廢除後的殘留）。可另開一支 PR 刪除清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)