### PR TITLE
fix(db): 交易改用 callback-scoped，移除單例 this.trx 跨請求洩漏

### DIFF
--- a/app/__tests__/model/base.test.js
+++ b/app/__tests__/model/base.test.js
@@ -1,0 +1,64 @@
+// Regression guard for the transaction-scoping fix.
+// Before the fix, models were process-level singletons that stored the active
+// transaction on `this.trx` (via setTransaction/transaction()), so a concurrent
+// request could run inside another request's open transaction. The fix makes the
+// transaction a per-call parameter (`qb(trx)`) with no shared state.
+//
+// jest.mock is NOT hoisted here (app jest config uses transform:{}), so the mock
+// must precede the require.
+jest.mock("../../src/util/mysql", () => {
+  const makeBuilder = () => ({
+    insert: jest.fn().mockResolvedValue([1]),
+    update: jest.fn().mockResolvedValue(1),
+    delete: jest.fn().mockReturnThis(),
+    where: jest.fn().mockResolvedValue(1),
+    first: jest.fn().mockReturnThis(),
+  });
+  return jest.fn(() => makeBuilder());
+});
+
+const mysql = require("../../src/util/mysql");
+const Base = require("../../src/model/base");
+
+describe("base model transaction scoping", () => {
+  let model;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    model = new Base({ table: "widgets", fillable: ["a", "b"] });
+  });
+
+  it("routes to the global connection when no trx is passed", async () => {
+    await model.create({ a: 1, b: 2 });
+    expect(mysql).toHaveBeenCalledWith("widgets");
+  });
+
+  it("routes to the passed trx and never touches the global connection", async () => {
+    const trxBuilder = { insert: jest.fn().mockResolvedValue([9]) };
+    const trx = jest.fn(() => trxBuilder);
+
+    await model.create({ a: 1, b: 2 }, trx);
+
+    expect(trx).toHaveBeenCalledWith("widgets");
+    expect(trxBuilder.insert).toHaveBeenCalledTimes(1);
+    // the regression: a transactional write must not leak onto the global connection
+    expect(mysql).not.toHaveBeenCalled();
+  });
+
+  it("keeps no cross-call transaction state (the singleton leak is structurally gone)", async () => {
+    const trxA = jest.fn(() => ({ insert: jest.fn().mockResolvedValue([1]) }));
+    const trxB = jest.fn(() => ({ insert: jest.fn().mockResolvedValue([2]) }));
+
+    // two interleaved "requests" on the SAME singleton, each with its own trx
+    await Promise.all([model.create({ a: 1 }, trxA), model.create({ a: 2 }, trxB)]);
+
+    expect(trxA).toHaveBeenCalledWith("widgets");
+    expect(trxB).toHaveBeenCalledWith("widgets");
+    expect(mysql).not.toHaveBeenCalled();
+
+    // the footgun API is gone for good
+    expect(model.setTransaction).toBeUndefined();
+    expect(model.transaction).toBeUndefined();
+    expect(model.trx).toBeUndefined();
+  });
+});

--- a/app/__tests__/service/GachaService.test.js
+++ b/app/__tests__/service/GachaService.test.js
@@ -87,6 +87,7 @@ jest.mock("config", () => ({
 const GachaModel = require("../../src/model/princess/gacha");
 const GachaBanner = require("../../src/model/princess/GachaBanner");
 const GachaService = require("../../src/service/GachaService");
+const mysql = require("../../src/util/mysql");
 const EventCenterService = require("../../src/service/EventCenterService");
 const AchievementEngine = require("../../src/service/AchievementEngine");
 const signModel = require("../../src/model/application/SigninDays");
@@ -103,6 +104,12 @@ describe("GachaService.runDailyDraw", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     txInserts.length = 0;
+    // The write path now runs inside `mysql.transaction(async trx => ...)`.
+    // Invoke the callback with a capturing trx so inserts land in `txInserts`.
+    currentTrx = makeTrxBuilder();
+    mysql.transaction.mockImplementation(async cb =>
+      typeof cb === "function" ? cb(currentTrx) : currentTrx
+    );
     GachaModel.getDatabasePool.mockResolvedValue(makePool());
     GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([]);
   });
@@ -177,10 +184,13 @@ describe("GachaService.runDailyDraw", () => {
     }
   });
 
-  it("commits the transaction on success and does not rollback", async () => {
-    await GachaService.runDailyDraw("Ucommit");
-    expect(currentTrx.commit).toHaveBeenCalledTimes(1);
-    expect(currentTrx.rollback).not.toHaveBeenCalled();
+  it("runs the write path inside a single transaction and resolves on success", async () => {
+    const result = await GachaService.runDailyDraw("Ucommit");
+    // knex's callback form auto-commits on resolve; we assert the path ran once
+    // to completion (the gacha_record write was captured inside the trx).
+    expect(mysql.transaction).toHaveBeenCalledTimes(1);
+    expect(result).toBeDefined();
+    expect(txInserts.some(t => t.table === "gacha_record")).toBe(true);
   });
 
   it("accepts only a userId (no bottender context) without throwing", async () => {

--- a/app/__tests__/setup.js
+++ b/app/__tests__/setup.js
@@ -107,7 +107,12 @@ function createMockQueryBuilder() {
   qb.avg = jest.fn().mockResolvedValue([{ avg: null }]);
   qb.raw = jest.fn().mockResolvedValue([]);
   qb.transactionProvider = jest.fn().mockReturnValue(jest.fn().mockResolvedValue(qb));
-  qb.transaction = jest.fn().mockResolvedValue(qb);
+  // Support both knex transaction forms: callback `transaction(async trx => ...)`
+  // (runs the callback with the builder as trx) and promise `await transaction()`
+  // (resolves to the builder for manual commit/rollback).
+  qb.transaction = jest.fn(cb =>
+    typeof cb === "function" ? Promise.resolve(cb(qb)) : Promise.resolve(qb)
+  );
   qb.isCompleted = jest.fn().mockReturnValue(false);
   qb.commit = jest.fn().mockResolvedValue();
   qb.rollback = jest.fn().mockResolvedValue();

--- a/app/bin/ShapeInventory.js
+++ b/app/bin/ShapeInventory.js
@@ -1,4 +1,5 @@
 const { inventory: inventoryModel } = require("../src/model/application/Inventory");
+const mysql = require("../src/util/mysql");
 const { DefaultLogger } = require("../src/util/Logger");
 
 async function main() {
@@ -18,27 +19,24 @@ async function main() {
   }
 
   for (let i = 0; i < processList.length; i++) {
-    const trx = await inventoryModel.transaction();
+    const { userId, amount, count } = processList[i];
     try {
-      const { userId, amount, count } = processList[i];
-
-      await trx.delete().from(inventoryModel.table).where({ userId, itemId: 999 });
-      await trx
-        .insert({
-          userId,
-          itemId: 999,
-          itemAmount: amount,
-        })
-        .into(inventoryModel.table);
+      await mysql.transaction(async trx => {
+        await trx.delete().from(inventoryModel.table).where({ userId, itemId: 999 });
+        await trx
+          .insert({
+            userId,
+            itemId: 999,
+            itemAmount: amount,
+          })
+          .into(inventoryModel.table);
+      });
 
       DefaultLogger.info(
         `處理用戶 ${userId} 女神石瘦身成功，共處理 ${count} 筆數據，女神石總數 ${amount}`
       );
-
-      trx.commit();
     } catch (e) {
       console.log(e);
-      trx.rollback();
     }
   }
 }

--- a/app/src/controller/application/SubscribeController.js
+++ b/app/src/controller/application/SubscribeController.js
@@ -5,6 +5,7 @@ const SubscribeCard = require("../../model/application/SubscribeCard");
 const SubscribeCardCoupon = require("../../model/application/SubscribeCardCoupon");
 const SubscribeUser = require("../../model/application/SubscribeUser");
 const { inventory: inventoryModel } = require("../../model/application/Inventory");
+const mysql = require("../../util/mysql");
 const DailyRation = require("../../../bin/DailyRation");
 const mement = require("moment");
 const i18n = require("../../util/i18n");
@@ -54,9 +55,6 @@ async function buyMonthCard(context, props) {
     return;
   }
 
-  const trx = await inventoryModel.transaction();
-  SubscribeCardCoupon.setTransaction(trx);
-
   try {
     const coupons = Array.from({ length: number }).map(() => ({
       serial_number: uuid(),
@@ -64,12 +62,15 @@ async function buyMonthCard(context, props) {
       status: SubscribeCardCoupon.status.unused,
       issued_by: "system",
     }));
-    await SubscribeCardCoupon.insert(coupons);
 
-    await inventoryModel.decreaseGodStone({
-      userId,
-      amount: cost,
-      note: "buy_month_card",
+    await mysql.transaction(async trx => {
+      await SubscribeCardCoupon.insert(coupons, trx);
+      await inventoryModel.decreaseGodStone({
+        userId,
+        amount: cost,
+        note: "buy_month_card",
+        trx,
+      });
     });
 
     context.replyText(i18n.__("message.subscribe.buy_month_card_success"));
@@ -82,14 +83,11 @@ async function buyMonthCard(context, props) {
 
     await context.replyText(serialMessages.join("\n"));
 
-    trx.commit();
-
     const { unlocked } = await AchievementEngine.evaluate(userId, "subscribe").catch(() => ({
       unlocked: [],
     }));
     await notifyUnlocks(context, userId, unlocked);
   } catch (e) {
-    trx.rollback();
     console.error(e);
     await context.replyText(
       i18n.__("message.error_contact_admin", {
@@ -188,29 +186,26 @@ async function subscribeCouponExchange(context, props) {
     };
   }
 
-  const trx = await SubscribeCardCoupon.transaction();
   try {
-    SubscribeUser.setTransaction(trx);
-    if (needCreate) {
-      await SubscribeUser.create(userData);
-    } else {
-      await SubscribeUser.update(get(user, "id"), userData);
-    }
+    await mysql.transaction(async trx => {
+      if (needCreate) {
+        await SubscribeUser.create(userData, trx);
+      } else {
+        await SubscribeUser.update(get(user, "id"), userData, {}, trx);
+      }
 
-    await trx
-      .update({
-        status: SubscribeCardCoupon.status.used,
-        used_at: mement().toDate(),
-        used_by: userId,
-      })
-      .table(SubscribeCardCoupon.table)
-      .where({
-        id: get(coupon, "id"),
-      });
-
-    trx.commit();
+      await trx
+        .update({
+          status: SubscribeCardCoupon.status.used,
+          used_at: mement().toDate(),
+          used_by: userId,
+        })
+        .table(SubscribeCardCoupon.table)
+        .where({
+          id: get(coupon, "id"),
+        });
+    });
   } catch (e) {
-    trx.rollback();
     await context.replyText(
       i18n.__("message.error_contact_admin", {
         user_id: userId,

--- a/app/src/controller/princess/character.js
+++ b/app/src/controller/princess/character.js
@@ -7,6 +7,7 @@ const i18n = require("../../util/i18n");
 const characterTemplate = require("../../templates/princess/Character");
 const Inventory = require("../../model/application/Inventory");
 const { inventory: inventoryModel } = Inventory;
+const mysql = require("../../util/mysql");
 
 const showFullRankupManual = context =>
   context.replyText(i18n.__("message.character.full_rank_up_manual"));
@@ -76,19 +77,16 @@ async function fullRankup(context, props) {
     );
   }
 
-  const trx = await inventoryModel.transaction();
-
   try {
-    await inventoryModel.decreaseGodStone({ userId, amount: cost, note: "rank up" });
-    const itemAttributes = character.attributes;
-    const restAttributes = itemAttributes.filter(attr => attr.key !== "star");
-    const newAttributes = [...restAttributes, { key: "star", value: 5 }];
-    await inventoryModel.editAttributesByItemId(userId, character.itemId, newAttributes);
-
-    await trx.commit();
+    await mysql.transaction(async trx => {
+      await inventoryModel.decreaseGodStone({ userId, amount: cost, note: "rank up", trx });
+      const itemAttributes = character.attributes;
+      const restAttributes = itemAttributes.filter(attr => attr.key !== "star");
+      const newAttributes = [...restAttributes, { key: "star", value: 5 }];
+      await inventoryModel.editAttributesByItemId(userId, character.itemId, newAttributes, trx);
+    });
   } catch (e) {
     console.error(e);
-    trx.rollback();
   }
 
   context.replyText(
@@ -164,19 +162,16 @@ async function rankup(context, props) {
     );
   }
 
-  const trx = await inventoryModel.transaction();
-
   try {
-    await inventoryModel.decreaseGodStone({ userId, amount: cost, note: "rank up" });
-    const itemAttributes = character.attributes;
-    const restAttributes = itemAttributes.filter(attr => attr.key !== "star");
-    const newAttributes = [...restAttributes, { key: "star", value: costConfig.rank + 1 }];
-    await inventoryModel.editAttributesByItemId(userId, character.itemId, newAttributes);
-
-    await trx.commit();
+    await mysql.transaction(async trx => {
+      await inventoryModel.decreaseGodStone({ userId, amount: cost, note: "rank up", trx });
+      const itemAttributes = character.attributes;
+      const restAttributes = itemAttributes.filter(attr => attr.key !== "star");
+      const newAttributes = [...restAttributes, { key: "star", value: costConfig.rank + 1 }];
+      await inventoryModel.editAttributesByItemId(userId, character.itemId, newAttributes, trx);
+    });
   } catch (e) {
     console.error(e);
-    trx.rollback();
   }
 
   context.replyText(

--- a/app/src/handler/Market/index.js
+++ b/app/src/handler/Market/index.js
@@ -4,6 +4,7 @@ const { model: GachaPoolModel } = require("../../model/princess/gacha");
 const { get, isNull } = require("lodash");
 const i18n = require("../../util/i18n");
 const { inventory: InventoryModel } = require("../../model/application/Inventory");
+const mysql = require("../../util/mysql");
 const { DefaultLogger } = require("../../util/Logger");
 const moment = require("moment");
 const { resolveDisplayName } = require("../../service/ProfileService");
@@ -95,61 +96,68 @@ exports.transaction = async (req, res) => {
     });
   }
 
-  const trx = await InventoryModel.transaction();
+  const { seller_id: sellerId, item_id: itemId } = marketDetail;
 
   try {
-    // 1. 從賣方身上扣除該商品
-    const { seller_id: sellerId, item_id: itemId } = marketDetail;
-    const delResult = await InventoryModel.deleteUserItem(sellerId, itemId);
-    if (!delResult) throw i18n.__("api.error.transaction.removeItemFailed");
+    await mysql.transaction(async trx => {
+      // 1. 從賣方身上扣除該商品
+      const delResult = await InventoryModel.deleteUserItem(sellerId, itemId, trx);
+      if (!delResult) throw i18n.__("api.error.transaction.removeItemFailed");
 
-    const character = await GachaPoolModel.find(itemId);
+      const character = await GachaPoolModel.find(itemId);
 
-    // 2. 從買方身上新增該商品
-    const invId = await InventoryModel.create({
-      userId,
-      itemId,
-      itemAmount: 1,
-      attributes: JSON.stringify([{ key: "star", value: get(character, "star", 1) }]),
+      // 2. 從買方身上新增該商品
+      const invId = await InventoryModel.create(
+        {
+          userId,
+          itemId,
+          itemAmount: 1,
+          attributes: JSON.stringify([{ key: "star", value: get(character, "star", 1) }]),
+        },
+        trx
+      );
+      if (!invId) throw i18n.__("api.error.transaction.addItemFailed");
+
+      // 3. 從買方身上扣除該商品的價格
+      const decreaseId = await InventoryModel.create(
+        {
+          userId,
+          itemId: 999,
+          itemAmount: price * -1,
+        },
+        trx
+      );
+      if (!decreaseId) throw i18n.__("api.error.transaction.decreaseMoneyFailed");
+
+      // 4. 將買方的價錢轉給賣方
+      const increaseId = await InventoryModel.create(
+        {
+          userId: sellerId,
+          itemId: 999,
+          itemAmount: price,
+        },
+        trx
+      );
+      if (!increaseId) throw i18n.__("api.error.transaction.increaseMoneyFailed");
+
+      // 5. 更新交易狀態
+      const updateResult = await MarketDetailModel.setSold(id, trx);
+      if (!updateResult) throw i18n.__("api.error.transaction.updateMarketFailed");
+
+      // 6. 寫入交易歷史紀錄
+      const tradeHistoryId = await TradeHistoryModel.create(
+        {
+          seller_id: sellerId,
+          buyer_id: userId,
+          item_id: itemId,
+          price,
+          quantity: 1,
+        },
+        trx
+      );
+      if (!tradeHistoryId) throw i18n.__("api.error.transaction.createTradeHistoryFailed");
     });
-    if (!invId) throw i18n.__("api.error.transaction.addItemFailed");
 
-    // 3. 從買方身上扣除該商品的價格
-    const decreaseId = await InventoryModel.create({
-      userId,
-      itemId: 999,
-      itemAmount: price * -1,
-    });
-    if (!decreaseId) throw i18n.__("api.error.transaction.decreaseMoneyFailed");
-
-    // 4. 將買方的價錢轉給賣方
-    const increaseId = await InventoryModel.create({
-      userId: sellerId,
-      itemId: 999,
-      itemAmount: price,
-    });
-    if (!increaseId) throw i18n.__("api.error.transaction.increaseMoneyFailed");
-
-    // 設定 MarketDetailModel 的連線
-    MarketDetailModel.setTransaction(trx);
-
-    // 5. 更新交易狀態
-    const updateResult = await MarketDetailModel.setSold(id);
-    if (!updateResult) throw i18n.__("api.error.transaction.updateMarketFailed");
-
-    // 6. 寫入交易歷史紀錄
-    TradeHistoryModel.setTransaction(trx);
-    const tradeHistoryId = await TradeHistoryModel.create({
-      seller_id: sellerId,
-      buyer_id: userId,
-      item_id: itemId,
-      price,
-      quantity: 1,
-    });
-    if (!tradeHistoryId) throw i18n.__("api.error.transaction.createTradeHistoryFailed");
-
-    // commit
-    await trx.commit();
     DefaultLogger.info("success transaction item", {
       userId,
       itemId,
@@ -162,7 +170,6 @@ exports.transaction = async (req, res) => {
     });
   } catch (e) {
     DefaultLogger.error(e);
-    await trx.rollback();
     return res.status(500).json({
       message: i18n.__("api.error.transaction.failed"),
     });

--- a/app/src/handler/Market/index.js
+++ b/app/src/handler/Market/index.js
@@ -99,12 +99,13 @@ exports.transaction = async (req, res) => {
   const { seller_id: sellerId, item_id: itemId } = marketDetail;
 
   try {
+    // 靜態查表，先讀好再開交易，避免持鎖期間還在等這筆讀取
+    const character = await GachaPoolModel.find(itemId);
+
     await mysql.transaction(async trx => {
       // 1. 從賣方身上扣除該商品
       const delResult = await InventoryModel.deleteUserItem(sellerId, itemId, trx);
       if (!delResult) throw i18n.__("api.error.transaction.removeItemFailed");
-
-      const character = await GachaPoolModel.find(itemId);
 
       // 2. 從買方身上新增該商品
       const invId = await InventoryModel.create(

--- a/app/src/model/application/Inventory.js
+++ b/app/src/model/application/Inventory.js
@@ -107,8 +107,8 @@ class Inventory extends base {
    * @param {Number} param0.amount
    * @returns {Promise}
    */
-  async transferGodStone({ sourceId, targetId, amount }) {
-    return this.knex.insert([
+  async transferGodStone({ sourceId, targetId, amount, trx }) {
+    return this.qb(trx).insert([
       { userId: sourceId, itemId: 999, itemAmount: `${-amount}`, note: "atm" },
       { userId: targetId, itemId: 999, itemAmount: amount, note: "atm" },
     ]);

--- a/app/src/model/application/Inventory.js
+++ b/app/src/model/application/Inventory.js
@@ -71,8 +71,10 @@ class Inventory extends base {
       .whereNot({ itemId: 999 });
   }
 
-  editAttributesByItemId(userId, itemId, attributes) {
-    return this.knex.where({ userId, itemId }).update({ attributes: JSON.stringify(attributes) });
+  editAttributesByItemId(userId, itemId, attributes, trx) {
+    return this.qb(trx)
+      .where({ userId, itemId })
+      .update({ attributes: JSON.stringify(attributes) });
   }
 
   getUserOwnCountByItemId(userId, itemId) {
@@ -83,8 +85,8 @@ class Inventory extends base {
     return this.getUserOwnCountByItemId(userId, 999);
   }
 
-  deleteUserItem(userId, itemId) {
-    return this.knex.where({ userId, itemId }).del();
+  deleteUserItem(userId, itemId, trx) {
+    return this.qb(trx).where({ userId, itemId }).del();
   }
 
   getGodStoneRank({ limit }) {
@@ -113,13 +115,11 @@ class Inventory extends base {
   }
 
   async increaseGodStone({ userId, amount, note, trx }) {
-    const db = trx ? trx(this.table) : this.knex;
-    return db.insert([{ userId, itemId: 999, itemAmount: amount, note }]);
+    return this.qb(trx).insert([{ userId, itemId: 999, itemAmount: amount, note }]);
   }
 
   async decreaseGodStone({ userId, amount, note, trx }) {
-    const db = trx ? trx(this.table) : this.knex;
-    return db.insert([{ userId, itemId: 999, itemAmount: `${-amount}`, note }]);
+    return this.qb(trx).insert([{ userId, itemId: 999, itemAmount: `${-amount}`, note }]);
   }
 }
 

--- a/app/src/model/application/MarketDetail.js
+++ b/app/src/model/application/MarketDetail.js
@@ -27,8 +27,8 @@ class MarketDetail extends base {
     return this.update(id, { status: 1, sold_at: new Date() }, {}, trx);
   }
 
-  setClosed(id) {
-    return this.update(id, { status: -1, closed_at: new Date() });
+  setClosed(id, trx) {
+    return this.update(id, { status: -1, closed_at: new Date() }, {}, trx);
   }
 }
 

--- a/app/src/model/application/MarketDetail.js
+++ b/app/src/model/application/MarketDetail.js
@@ -23,8 +23,8 @@ class MarketDetail extends base {
       .first();
   }
 
-  setSold(id) {
-    return this.update(id, { status: 1, sold_at: new Date() });
+  setSold(id, trx) {
+    return this.update(id, { status: 1, sold_at: new Date() }, {}, trx);
   }
 
   setClosed(id) {

--- a/app/src/model/base.js
+++ b/app/src/model/base.js
@@ -1,24 +1,28 @@
 const mysql = require("../util/mysql");
 const { get, pick } = require("lodash");
-const trxProvider = mysql.transactionProvider();
 
 class Base {
   constructor({ table, fillable }) {
     this.table = table;
     this.fillable = fillable;
-    this.trx = null;
-    this.trxProvider = trxProvider;
   }
 
   /**
-   * @returns { import("knex").Knex }
+   * 取得綁定本表的 query builder。
+   * 交易一律由呼叫端用 `mysql.transaction(async trx => ...)` 建立並把 `trx` 往下傳，
+   * 不再存在實例上 —— 否則 model 是行程級單例，並發請求會共用同一條交易而互相汙染。
+   * @param {import("knex").Knex.Transaction} [trx] 選填；傳入則在該交易內執行
+   * @returns {import("knex").Knex.QueryBuilder}
+   */
+  qb(trx) {
+    return (trx || mysql)(this.table);
+  }
+
+  /**
+   * @returns { import("knex").Knex.QueryBuilder }
    */
   get knex() {
-    if (this.trx && !this.trx.isCompleted()) {
-      return this.trx(this.table);
-    } else {
-      return mysql(this.table);
-    }
+    return mysql(this.table);
   }
 
   /**
@@ -26,18 +30,6 @@ class Base {
    */
   get connection() {
     return mysql;
-  }
-
-  setTransaction(trx) {
-    this.trx = trx;
-  }
-
-  /**
-   * @returns {Promise<import("knex").Knex.Transaction>}
-   */
-  async transaction() {
-    this.trx = await mysql.transaction();
-    return this.trx;
   }
 
   /**
@@ -50,16 +42,17 @@ class Base {
    * @param {Array<{column: String, direction: String}>} options.order 排序設定
    * @param {Array}  options.select 選擇欄位
    * @param {Number} options.limit  限制數量
+   * @param {import("knex").Knex.Transaction} [trx] 選填交易
    * @returns {import("knex").Knex.QueryBuilder}
    */
-  all(options = {}) {
+  all(options = {}, trx) {
     const filter = get(options, "filter", {});
     const pagination = get(options, "pagination", {});
     const order = get(options, "order", []);
     const select = get(options, "select", ["*"]);
     const limit = get(options, "limit", null);
 
-    let query = this.knex;
+    let query = this.qb(trx);
 
     Object.keys(filter).forEach(key => {
       query = query.where(
@@ -90,14 +83,15 @@ class Base {
    * @param {Object} options.filter 過濾條件
    * @param {Array<{column: String, direction: String}>} options.order 排序設定
    * @param {Array}  options.select 選擇欄位
+   * @param {import("knex").Knex.Transaction} [trx] 選填交易
    * @returns {import("knex").Knex.QueryBuilder}
    */
-  first(options = {}) {
+  first(options = {}, trx) {
     const filter = get(options, "filter", {});
     const order = get(options, "order", []);
     const select = get(options, "select", ["*"]);
 
-    let query = this.knex;
+    let query = this.qb(trx);
 
     Object.keys(filter).forEach(key => {
       query = query.where(
@@ -119,35 +113,38 @@ class Base {
   /**
    * 查找單筆資料
    * @param {Number} id
+   * @param {import("knex").Knex.Transaction} [trx] 選填交易
    * @returns {Promise<?Object>}
    */
-  async find(id) {
-    return await this.knex.first().where({ id });
+  async find(id, trx) {
+    return await this.qb(trx).first().where({ id });
   }
 
   /**
    * Alias of `find`
    * @param {Number} id
+   * @param {import("knex").Knex.Transaction} [trx] 選填交易
    * @returns {Promise<?Object>}
    */
-  findById(id) {
-    return this.find(id);
+  findById(id, trx) {
+    return this.find(id, trx);
   }
 
   /**
    * 新增資料
    * @param {Object} attributes 屬性
+   * @param {import("knex").Knex.Transaction} [trx] 選填交易
    * @returns {Promise<Number>}
    */
-  async create(attributes = {}) {
+  async create(attributes = {}, trx) {
     let data = pick(attributes, this.fillable);
-    const [id] = await this.knex.insert(data);
+    const [id] = await this.qb(trx).insert(data);
 
     return id;
   }
 
-  async insert(data = []) {
-    return await this.knex.insert(data);
+  async insert(data = [], trx) {
+    return await this.qb(trx).insert(data);
   }
 
   /**
@@ -155,11 +152,12 @@ class Base {
    * @param {Number} id
    * @param {Object} attributes
    * @param {Object} options
+   * @param {import("knex").Knex.Transaction} [trx] 選填交易
    * @returns {Promise<Number>}
    */
-  async update(id, attributes = {}, options = {}) {
+  async update(id, attributes = {}, options = {}, trx) {
     let data = pick(attributes, this.fillable);
-    const query = this.knex.update(data);
+    const query = this.qb(trx).update(data);
 
     const pk = get(options, "pk", "id");
     query.where({
@@ -172,10 +170,11 @@ class Base {
   /**
    * 刪除資料
    * @param {Number} id
+   * @param {import("knex").Knex.Transaction} [trx] 選填交易
    * @returns {Promise<Number>}
    */
-  async delete(id) {
-    return await this.knex.delete().where({ id });
+  async delete(id, trx) {
+    return await this.qb(trx).delete().where({ id });
   }
 
   getColumnName(column) {

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -4,6 +4,7 @@ const { countBy, shuffle, uniqBy, difference, sum, uniq, pullAt } = require("lod
 
 const GachaModel = require("../model/princess/gacha");
 const InventoryModel = require("../model/application/Inventory");
+const mysql = require("../util/mysql");
 const { inventory } = InventoryModel;
 const GachaRecord = require("../model/princess/GachaRecord");
 const GachaRecordDetail = require("../model/princess/GachaRecordDetail");
@@ -251,8 +252,7 @@ async function runDailyDraw(userId, opts = {}) {
   const newCharacters = uniqRewards.filter(r => newItemIds.includes(r.id));
 
   await time("rd.tx", async () => {
-    const trx = await inventory.transaction();
-    try {
+    await mysql.transaction(async trx => {
       if (cost.amount > 0) {
         await trx(inventory.table).insert({
           userId,
@@ -304,12 +304,7 @@ async function runDailyDraw(userId, opts = {}) {
           }))
         );
       }
-
-      await trx.commit();
-    } catch (err) {
-      await trx.rollback();
-      throw err;
-    }
+    });
   });
 
   await time("rd.side", () =>


### PR DESCRIPTION
## Summary

修掉資料層一個真實的並發 bug：model 以 `module.exports = new X()` 匯出成**行程級單例**，但 `base.js` 把交易存進 `this.trx`（`transaction()` / `setTransaction()`）。在開交易到 commit 之間的 `await` 空窗裡，任何打到同一單例的並發請求都會跑進別人那條交易，造成跨請求資料汙染／鎖競爭。最熱的 `inventory`（升階／轉蛋／市場同時用）風險最高。

改用 knex 慣用的 **callback-scoped 交易**，`trx` 一律當參數往下傳，移除實例狀態這個 footgun。

### 主要變更
- **`model/base.js`**：刪除 `this.trx` / `setTransaction()` / `transaction()` 與死碼 `trxProvider`；新增 `qb(trx) = (trx || mysql)(this.table)` 作唯一執行器解析；CRUD 方法加選填 `trx`。
- **7 個開交易點**（character ×2、subscribe ×2、market、gacha）改用 `mysql.transaction(async trx => ...)`，由 knex 自動 commit/rollback。
- 交易內用到的 model 方法（`Inventory`、`MarketDetail`）改吃 `trx`。
- **`bin/ShapeInventory.js`**：修掉對已刪除 `inventoryModel.transaction()` 的呼叫，順手移除未 await 的 commit/rollback。
- `__tests__/setup.js` mock 同時支援 callback 與 promise 兩種交易形式；新增 `__tests__/model/base.test.js` 守住「trx 一律當參數、單例不存交易狀態」。
- 第二個 commit 為 `/simplify` 清理（market 先把靜態查表移出交易外、`transferGodStone`/`setClosed` 補上 trx 參數等）。
- `GachaBanner` 的 `this.connection.transaction()` 為獨立 promise 形式、不污染單例，維持原狀。

背景與證據：見 ADR-0001 §2.3 / §4。

## Test plan
- [x] `yarn lint` 全綠
- [x] 新增 `base.test.js` 回歸測試 3/3（trx 逐次路由、舊 API 已消失）
- [x] 受影響套件通過：GachaService 11/11、market、subscribe、character
- [x] grep 確認 `app/` 內已無任何對已刪除 API 的呼叫
- [x] code-reviewer 獨立審查（money path）→ approve
- [ ] 其餘 7 個失敗套件為 Janken/topic 整合測試，需本機 MySQL，與本 PR 無關

🤖 Generated with [Claude Code](https://claude.com/claude-code)