### PR TITLE
feat(chat-weather): 每日奇異天氣 前端 & Flex follow-up (顯示+購買 UI, flags off)

### DIFF
--- a/app/migrations/20260710192841_add_protected_msg_count_to_chat_exp_daily.js
+++ b/app/migrations/20260710192841_add_protected_msg_count_to_chat_exp_daily.js
@@ -1,0 +1,42 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+const TABLE = "chat_exp_daily";
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable(TABLE, table => {
+    table
+      .integer("protected_msg_count")
+      .unsigned()
+      .notNullable()
+      .defaultTo(0)
+      .after("msg_count")
+      .comment("messages sent while weather protection was active (debuff neutralised)");
+  });
+
+  // Backfill from per-event ground truth (chat_exp_events.weather_protected).
+  // ts is stored UTC; the daily bucket is UTC+8, so shift +8h before bucketing.
+  // Only days with protected events are touched; the rest keep the 0 default.
+  await knex.raw(
+    `UPDATE ${TABLE} d
+     JOIN (
+       SELECT user_id, DATE(ts + INTERVAL 8 HOUR) AS d8, COUNT(*) AS pc
+       FROM chat_exp_events
+       WHERE weather_protected = 1
+       GROUP BY user_id, DATE(ts + INTERVAL 8 HOUR)
+     ) e ON e.user_id = d.user_id AND e.d8 = d.date
+     SET d.protected_msg_count = e.pc`
+  );
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable(TABLE, table => {
+    table.dropColumn("protected_msg_count");
+  });
+};

--- a/app/src/controller/application/WeatherController.js
+++ b/app/src/controller/application/WeatherController.js
@@ -1,13 +1,24 @@
 const WeatherService = require("../../service/ChatWeatherService");
 const { DefaultLogger } = require("../../util/Logger");
+const { getLiffUri } = require("../../templates/common");
+const { generateWeatherBubble } = require("../../templates/application/Weather");
+
+const XP_HISTORY_LIFF_PATH = "/xp-history";
 
 exports.showToday = async context => {
   const { userId } = context.event.source;
   if (!userId) {
     return context.replyText("獲取失敗，無法辨識用戶");
   }
-  const text = await WeatherService.describeToday(userId);
-  return context.replyText(text);
+  const status = await WeatherService.getTodayStatus(userId);
+  if (!status.weather) {
+    return context.replyText("今日天氣觀測暫停");
+  }
+  const bubble = generateWeatherBubble({
+    ...status,
+    liffUri: getLiffUri("full", XP_HISTORY_LIFF_PATH),
+  });
+  return context.replyFlex("今日天氣", bubble);
 };
 
 // API: GET /api/me/chat-weather/today

--- a/app/src/controller/application/__tests__/WeatherController.test.js
+++ b/app/src/controller/application/__tests__/WeatherController.test.js
@@ -43,4 +43,11 @@ describe("WeatherController.showToday", () => {
     expect(altText).toBe("今日天氣");
     expect(bubble.type).toBe("bubble");
   });
+
+  it("replies an identification-failure text when userId is missing", async () => {
+    const c = ctx(null);
+    await Controller.showToday(c);
+    expect(c.replyText).toHaveBeenCalledWith("獲取失敗，無法辨識用戶");
+    expect(c.replyFlex).not.toHaveBeenCalled();
+  });
 });

--- a/app/src/controller/application/__tests__/WeatherController.test.js
+++ b/app/src/controller/application/__tests__/WeatherController.test.js
@@ -1,30 +1,46 @@
-jest.mock("../../../service/ChatWeatherService", () => ({
-  describeToday: jest.fn(),
-}));
-
+jest.mock("../../../service/ChatWeatherService");
 const WeatherService = require("../../../service/ChatWeatherService");
-const WeatherController = require("../WeatherController");
+const Controller = require("../WeatherController");
 
-const makeContext = (userId = "U" + "a".repeat(32)) => ({
-  event: { source: { userId } },
-  replyText: jest.fn().mockResolvedValue({}),
-});
-
-beforeEach(() => jest.clearAllMocks());
+function ctx(userId = "U1") {
+  return { event: { source: { userId } }, replyText: jest.fn(), replyFlex: jest.fn() };
+}
 
 describe("WeatherController.showToday", () => {
-  it("replies the weather description", async () => {
-    WeatherService.describeToday.mockResolvedValue("今日天氣：晴空回音");
-    const context = makeContext();
-    await WeatherController.showToday(context);
-    expect(WeatherService.describeToday).toHaveBeenCalledWith(context.event.source.userId);
-    expect(context.replyText).toHaveBeenCalledWith("今日天氣：晴空回音");
+  it("replies observation-paused text when weather is null", async () => {
+    WeatherService.getTodayStatus.mockResolvedValue({
+      date: "d",
+      weather: null,
+      protection: null,
+      godStoneBalance: 0,
+    });
+    const c = ctx();
+    await Controller.showToday(c);
+    expect(c.replyText).toHaveBeenCalledWith("今日天氣觀測暫停");
+    expect(c.replyFlex).not.toHaveBeenCalled();
   });
 
-  it("rejects when there is no userId", async () => {
-    const context = makeContext(null);
-    await WeatherController.showToday(context);
-    expect(context.replyText).toHaveBeenCalledWith("獲取失敗，無法辨識用戶");
-    expect(WeatherService.describeToday).not.toHaveBeenCalled();
+  it("replies a Flex bubble when weather is present", async () => {
+    WeatherService.getTodayStatus.mockResolvedValue({
+      date: "2026-07-10",
+      weather: {
+        weather_key: "silent_fog",
+        category: "debuff",
+        name: "沉默霧氣",
+        flavor_text: "x",
+        effects: { raw_xp_mult: 0.9 },
+        protection_type: "defog",
+        protection_name: "破霧鈴",
+        protection_cost: 30,
+      },
+      protection: null,
+      godStoneBalance: 100,
+    });
+    const c = ctx();
+    await Controller.showToday(c);
+    expect(c.replyFlex).toHaveBeenCalledTimes(1);
+    const [altText, bubble] = c.replyFlex.mock.calls[0];
+    expect(altText).toBe("今日天氣");
+    expect(bubble.type).toBe("bubble");
   });
 });

--- a/app/src/model/application/ChatExpDaily.js
+++ b/app/src/model/application/ChatExpDaily.js
@@ -8,6 +8,7 @@ const fillable = [
   "raw_exp",
   "effective_exp",
   "msg_count",
+  "protected_msg_count",
   "honeymoon_active",
   "trial_id",
 ];
@@ -25,9 +26,10 @@ exports.findByUserDate = (userId, date) => model.first({ filter: { user_id: user
  * @param {object} params
  * @param {string} params.userId
  * @param {string} params.date          YYYY-MM-DD (UTC+8)
- * @param {number} params.rawExp        增量 (add to raw_exp)
- * @param {number} params.effectiveExp  增量 (add to effective_exp)
- * @param {number} params.msgCount      增量 (add to msg_count)
+ * @param {number} params.rawExp         增量 (add to raw_exp)
+ * @param {number} params.effectiveExp   增量 (add to effective_exp)
+ * @param {number} params.msgCount       增量 (add to msg_count)
+ * @param {number} params.protectedCount 增量 (add to protected_msg_count)
  * @param {boolean} params.honeymoonActive
  * @param {number|null} params.trialId
  */
@@ -37,19 +39,21 @@ exports.upsertByUserDate = async ({
   rawExp,
   effectiveExp,
   msgCount,
+  protectedCount = 0,
   honeymoonActive,
   trialId,
 }) => {
   return mysql.raw(
     `INSERT INTO ${TABLE}
-       (user_id, date, raw_exp, effective_exp, msg_count, honeymoon_active, trial_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
+       (user_id, date, raw_exp, effective_exp, msg_count, protected_msg_count, honeymoon_active, trial_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
      ON DUPLICATE KEY UPDATE
        raw_exp = raw_exp + VALUES(raw_exp),
        effective_exp = effective_exp + VALUES(effective_exp),
        msg_count = msg_count + VALUES(msg_count),
+       protected_msg_count = protected_msg_count + VALUES(protected_msg_count),
        honeymoon_active = VALUES(honeymoon_active),
        trial_id = VALUES(trial_id)`,
-    [userId, date, rawExp, effectiveExp, msgCount, honeymoonActive, trialId]
+    [userId, date, rawExp, effectiveExp, msgCount, protectedCount, honeymoonActive, trialId]
   );
 };

--- a/app/src/service/ChatWeatherService.js
+++ b/app/src/service/ChatWeatherService.js
@@ -8,7 +8,7 @@ const ChatDailyWeather = require("../model/application/ChatDailyWeather");
 const UserWeatherProtection = require("../model/application/UserWeatherProtection");
 const { inventory } = require("../model/application/Inventory");
 const gacha = require("../model/princess/gacha");
-const { pickWeather, describeEffects } = require("./chatXp/weatherEffects");
+const { pickWeather } = require("./chatXp/weatherEffects");
 const { DefaultLogger } = require("../util/Logger");
 
 function cfg() {
@@ -121,30 +121,10 @@ async function purchaseTodayProtection(userId, now = Date.now()) {
   return { ok: true, protection };
 }
 
-async function describeToday(userId) {
-  if (!cfg().enabled) return "今日天氣觀測暫停";
-  const { weather, protection, godStoneBalance } = await getTodayStatus(userId);
-  if (!weather) return "今日天氣觀測暫停";
-
-  const effectText = describeEffects(weather.effects);
-  const lines = [
-    `今日天氣：${weather.name}`,
-    weather.flavor_text,
-    "",
-    `效果：${effectText.length ? effectText.join("、") : "無"}`,
-  ];
-  if (weather.protection_type) {
-    lines.push(`防護：${weather.protection_name}（${weather.protection_cost} 女神石，今日有效）`);
-    lines.push(protection ? "狀態：已防護" : `狀態：尚未防護（你有 ${godStoneBalance} 女神石）`);
-  }
-  return lines.join("\n");
-}
-
 module.exports = {
   getWeatherForDate,
   generateWeatherForDate,
   getUserProtection,
   getTodayStatus,
   purchaseTodayProtection,
-  describeToday,
 };

--- a/app/src/service/XpHistoryService.js
+++ b/app/src/service/XpHistoryService.js
@@ -90,6 +90,18 @@ async function buildEvents(userId, { from, to, limit = 1000, beforeId, beforeTs 
   return { events: rows.map(shapeEvent) };
 }
 
+// Daily protection coverage from the per-day protected-message count (which the
+// pipeline accumulates from the time-gated per-event flag). "full" = every
+// message that day was protected, "partial" = protection was bought mid-day so
+// only some were, null = took the full hit (or not a debuff day).
+function protectionState(row) {
+  if (row.weather_category !== "debuff") return null;
+  const total = Number(row.msg_count) || 0;
+  const covered = Number(row.protected_msg_count) || 0;
+  if (covered <= 0) return null;
+  return covered >= total ? "full" : "partial";
+}
+
 function shapeDay(row) {
   return {
     date: toUtc8Date(row.date),
@@ -106,20 +118,13 @@ function shapeDay(row) {
           effects: parseModifiers(row.weather_effects),
         }
       : null,
-    weather_protected: Boolean(row.protection_id) && row.weather_category === "debuff",
+    weather_protection: protectionState(row),
   };
 }
 
 async function buildDaily(userId, { from, to }) {
   const rows = await ChatExpDaily.model.knex
     .leftJoin("chat_daily_weather", "chat_exp_daily.date", "chat_daily_weather.date")
-    .leftJoin("user_weather_protections", function () {
-      this.on("user_weather_protections.weather_date", "=", "chat_exp_daily.date").andOn(
-        "user_weather_protections.user_id",
-        "=",
-        "chat_exp_daily.user_id"
-      );
-    })
     .where("chat_exp_daily.user_id", userId)
     .andWhere("chat_exp_daily.date", ">=", from)
     .andWhere("chat_exp_daily.date", "<=", to)
@@ -129,13 +134,13 @@ async function buildDaily(userId, { from, to }) {
       "chat_exp_daily.raw_exp as raw_exp",
       "chat_exp_daily.effective_exp as effective_exp",
       "chat_exp_daily.msg_count as msg_count",
+      "chat_exp_daily.protected_msg_count as protected_msg_count",
       "chat_exp_daily.honeymoon_active as honeymoon_active",
       "chat_exp_daily.trial_id as trial_id",
       "chat_daily_weather.weather_key as weather_key",
       "chat_daily_weather.name as weather_name",
       "chat_daily_weather.category as weather_category",
-      "chat_daily_weather.effects as weather_effects",
-      "user_weather_protections.id as protection_id"
+      "chat_daily_weather.effects as weather_effects"
     );
   return { days: rows.map(shapeDay) };
 }

--- a/app/src/service/XpHistoryService.js
+++ b/app/src/service/XpHistoryService.js
@@ -43,6 +43,7 @@ function shapeEvent(row) {
     trial_mult: decimalOrNull(row.trial_mult),
     permanent_mult: decimalOrNull(row.permanent_mult),
     modifiers: parseModifiers(row.modifiers),
+    weather_protected: Boolean(row.weather_protected),
   };
 }
 
@@ -107,4 +108,4 @@ async function buildDaily(userId, { from, to }) {
   };
 }
 
-module.exports = { buildSummary, buildEvents, buildDaily };
+module.exports = { buildSummary, buildEvents, buildDaily, shapeEvent };

--- a/app/src/service/XpHistoryService.js
+++ b/app/src/service/XpHistoryService.js
@@ -90,22 +90,54 @@ async function buildEvents(userId, { from, to, limit = 1000, beforeId, beforeTs 
   return { events: rows.map(shapeEvent) };
 }
 
-async function buildDaily(userId, { from, to }) {
-  const rows = await ChatExpDaily.model.knex
-    .where({ user_id: userId })
-    .andWhere("date", ">=", from)
-    .andWhere("date", "<=", to)
-    .orderBy("date", "asc");
+function shapeDay(row) {
   return {
-    days: rows.map(r => ({
-      date: toUtc8Date(r.date),
-      raw_exp: r.raw_exp,
-      effective_exp: r.effective_exp,
-      msg_count: r.msg_count,
-      honeymoon_active: Boolean(r.honeymoon_active),
-      trial_id: r.trial_id ?? null,
-    })),
+    date: toUtc8Date(row.date),
+    raw_exp: row.raw_exp,
+    effective_exp: row.effective_exp,
+    msg_count: row.msg_count,
+    honeymoon_active: Boolean(row.honeymoon_active),
+    trial_id: row.trial_id ?? null,
+    weather: row.weather_key
+      ? {
+          key: row.weather_key,
+          name: row.weather_name,
+          category: row.weather_category,
+          effects: parseModifiers(row.weather_effects),
+        }
+      : null,
+    weather_protected: Boolean(row.protection_id) && row.weather_category === "debuff",
   };
 }
 
-module.exports = { buildSummary, buildEvents, buildDaily, shapeEvent };
+async function buildDaily(userId, { from, to }) {
+  const rows = await ChatExpDaily.model.knex
+    .leftJoin("chat_daily_weather", "chat_exp_daily.date", "chat_daily_weather.date")
+    .leftJoin("user_weather_protections", function () {
+      this.on("user_weather_protections.weather_date", "=", "chat_exp_daily.date").andOn(
+        "user_weather_protections.user_id",
+        "=",
+        "chat_exp_daily.user_id"
+      );
+    })
+    .where("chat_exp_daily.user_id", userId)
+    .andWhere("chat_exp_daily.date", ">=", from)
+    .andWhere("chat_exp_daily.date", "<=", to)
+    .orderBy("chat_exp_daily.date", "asc")
+    .select(
+      "chat_exp_daily.date as date",
+      "chat_exp_daily.raw_exp as raw_exp",
+      "chat_exp_daily.effective_exp as effective_exp",
+      "chat_exp_daily.msg_count as msg_count",
+      "chat_exp_daily.honeymoon_active as honeymoon_active",
+      "chat_exp_daily.trial_id as trial_id",
+      "chat_daily_weather.weather_key as weather_key",
+      "chat_daily_weather.name as weather_name",
+      "chat_daily_weather.category as weather_category",
+      "chat_daily_weather.effects as weather_effects",
+      "user_weather_protections.id as protection_id"
+    );
+  return { days: rows.map(shapeDay) };
+}
+
+module.exports = { buildSummary, buildEvents, buildDaily, shapeEvent, shapeDay };

--- a/app/src/service/__tests__/XpHistoryService.buildDaily.test.js
+++ b/app/src/service/__tests__/XpHistoryService.buildDaily.test.js
@@ -6,24 +6,28 @@ const { buildDaily } = require("../XpHistoryService");
 const USER = "U" + "9".repeat(32);
 const DATE = "2001-02-03"; // 固定過去日期，避免與真實資料衝突
 
-describe("buildDaily weather join (real DB)", () => {
+describe("buildDaily weather + protection coverage (real DB)", () => {
   beforeEach(async () => {
     await mysql("chat_exp_daily").where({ user_id: USER }).delete();
-    await mysql("user_weather_protections").where({ user_id: USER }).delete();
     await mysql("chat_daily_weather").where({ date: DATE }).delete();
   });
   afterAll(() => mysql.destroy());
 
-  it("joins global weather and per-user protection onto each day", async () => {
+  async function seedDay(protectedCount) {
+    await mysql("chat_exp_daily").where({ user_id: USER }).delete();
     await mysql("chat_exp_daily").insert({
       user_id: USER,
       date: DATE,
       raw_exp: 100,
       effective_exp: 80,
       msg_count: 5,
+      protected_msg_count: protectedCount,
       honeymoon_active: 0,
       trial_id: null,
     });
+  }
+
+  it("joins global weather and derives protection coverage from protected_msg_count", async () => {
     await mysql("chat_daily_weather").insert({
       date: DATE,
       weather_key: "silent_fog",
@@ -37,22 +41,18 @@ describe("buildDaily weather join (real DB)", () => {
       generated_at: new Date(),
     });
 
+    await seedDay(0);
     let res = await buildDaily(USER, { from: DATE, to: DATE });
     expect(res.days).toHaveLength(1);
     expect(res.days[0].weather).toMatchObject({ key: "silent_fog", category: "debuff" });
-    expect(res.days[0].weather_protected).toBe(false);
+    expect(res.days[0].weather_protection).toBeNull();
 
-    await mysql("user_weather_protections").insert({
-      user_id: USER,
-      weather_date: DATE,
-      weather_key: "silent_fog",
-      protection_type: "defog",
-      protection_name: "破霧鈴",
-      stone_cost: 30,
-      purchased_at: new Date(),
-    });
-
+    await seedDay(2);
     res = await buildDaily(USER, { from: DATE, to: DATE });
-    expect(res.days[0].weather_protected).toBe(true);
+    expect(res.days[0].weather_protection).toBe("partial");
+
+    await seedDay(5);
+    res = await buildDaily(USER, { from: DATE, to: DATE });
+    expect(res.days[0].weather_protection).toBe("full");
   });
 });

--- a/app/src/service/__tests__/XpHistoryService.buildDaily.test.js
+++ b/app/src/service/__tests__/XpHistoryService.buildDaily.test.js
@@ -1,0 +1,58 @@
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../.env") });
+jest.unmock("../../util/mysql");
+const mysql = jest.requireActual("../../util/mysql");
+const { buildDaily } = require("../XpHistoryService");
+
+const USER = "U" + "9".repeat(32);
+const DATE = "2001-02-03"; // 固定過去日期，避免與真實資料衝突
+
+describe("buildDaily weather join (real DB)", () => {
+  beforeEach(async () => {
+    await mysql("chat_exp_daily").where({ user_id: USER }).delete();
+    await mysql("user_weather_protections").where({ user_id: USER }).delete();
+    await mysql("chat_daily_weather").where({ date: DATE }).delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  it("joins global weather and per-user protection onto each day", async () => {
+    await mysql("chat_exp_daily").insert({
+      user_id: USER,
+      date: DATE,
+      raw_exp: 100,
+      effective_exp: 80,
+      msg_count: 5,
+      honeymoon_active: 0,
+      trial_id: null,
+    });
+    await mysql("chat_daily_weather").insert({
+      date: DATE,
+      weather_key: "silent_fog",
+      category: "debuff",
+      name: "沉默霧氣",
+      flavor_text: "x",
+      effects: JSON.stringify({ raw_xp_mult: 0.9 }),
+      protection_type: "defog",
+      protection_name: "破霧鈴",
+      protection_cost: 30,
+      generated_at: new Date(),
+    });
+
+    let res = await buildDaily(USER, { from: DATE, to: DATE });
+    expect(res.days).toHaveLength(1);
+    expect(res.days[0].weather).toMatchObject({ key: "silent_fog", category: "debuff" });
+    expect(res.days[0].weather_protected).toBe(false);
+
+    await mysql("user_weather_protections").insert({
+      user_id: USER,
+      weather_date: DATE,
+      weather_key: "silent_fog",
+      protection_type: "defog",
+      protection_name: "破霧鈴",
+      stone_cost: 30,
+      purchased_at: new Date(),
+    });
+
+    res = await buildDaily(USER, { from: DATE, to: DATE });
+    expect(res.days[0].weather_protected).toBe(true);
+  });
+});

--- a/app/src/service/__tests__/XpHistoryService.shape.test.js
+++ b/app/src/service/__tests__/XpHistoryService.shape.test.js
@@ -22,43 +22,57 @@ describe("shapeEvent weather", () => {
 });
 
 describe("shapeDay weather", () => {
-  it("maps joined weather + protection columns", () => {
-    const d = shapeDay({
-      date: "2026-07-10",
-      raw_exp: 100,
-      effective_exp: 80,
-      msg_count: 5,
-      honeymoon_active: 0,
-      trial_id: null,
-      weather_key: "silent_fog",
-      weather_name: "沉默霧氣",
-      weather_category: "debuff",
-      weather_effects: JSON.stringify({ raw_xp_mult: 0.9 }),
-      protection_id: 42,
-    });
-    expect(d.weather).toEqual({
+  const debuffDay = extra => ({
+    date: "2026-07-10",
+    raw_exp: 100,
+    effective_exp: 80,
+    msg_count: 5,
+    protected_msg_count: 0,
+    honeymoon_active: 0,
+    trial_id: null,
+    weather_key: "silent_fog",
+    weather_name: "沉默霧氣",
+    weather_category: "debuff",
+    weather_effects: JSON.stringify({ raw_xp_mult: 0.9 }),
+    ...extra,
+  });
+
+  it("maps joined weather columns", () => {
+    expect(shapeDay(debuffDay()).weather).toEqual({
       key: "silent_fog",
       name: "沉默霧氣",
       category: "debuff",
       effects: { raw_xp_mult: 0.9 },
     });
-    expect(d.weather_protected).toBe(true);
   });
 
-  it("null weather for days without a weather row", () => {
-    const d = shapeDay({ date: "2026-01-01", weather_key: null, protection_id: null });
-    expect(d.weather).toBeNull();
-    expect(d.weather_protected).toBe(false);
+  it("weather_protection 'full' when every message was covered", () => {
+    expect(shapeDay(debuffDay({ protected_msg_count: 5 })).weather_protection).toBe("full");
   });
 
-  it("weather_protected false on a buff day even if a protection row exists", () => {
+  it("weather_protection 'partial' when a mid-day purchase covered only some", () => {
+    expect(shapeDay(debuffDay({ protected_msg_count: 2 })).weather_protection).toBe("partial");
+  });
+
+  it("weather_protection null when the day took the full hit (bought too late / not at all)", () => {
+    expect(shapeDay(debuffDay({ protected_msg_count: 0 })).weather_protection).toBeNull();
+  });
+
+  it("weather_protection null on a buff day regardless of count", () => {
     const d = shapeDay({
       date: "x",
+      msg_count: 5,
+      protected_msg_count: 5,
       weather_key: "mana_tailwind",
       weather_category: "buff",
       weather_effects: "{}",
-      protection_id: 7,
     });
-    expect(d.weather_protected).toBe(false);
+    expect(d.weather_protection).toBeNull();
+  });
+
+  it("null weather + null protection for days without a weather row", () => {
+    const d = shapeDay({ date: "2026-01-01", weather_key: null });
+    expect(d.weather).toBeNull();
+    expect(d.weather_protection).toBeNull();
   });
 });

--- a/app/src/service/__tests__/XpHistoryService.shape.test.js
+++ b/app/src/service/__tests__/XpHistoryService.shape.test.js
@@ -1,4 +1,4 @@
-const { shapeEvent } = require("../XpHistoryService");
+const { shapeEvent, shapeDay } = require("../XpHistoryService");
 
 describe("shapeEvent weather", () => {
   it("exposes weather_protected as a boolean", () => {
@@ -18,5 +18,47 @@ describe("shapeEvent weather", () => {
   it("defaults weather_protected to false for legacy rows", () => {
     const e = shapeEvent({ id: 2, ts: "x", raw_exp: 5, effective_exp: 5, modifiers: null });
     expect(e.weather_protected).toBe(false);
+  });
+});
+
+describe("shapeDay weather", () => {
+  it("maps joined weather + protection columns", () => {
+    const d = shapeDay({
+      date: "2026-07-10",
+      raw_exp: 100,
+      effective_exp: 80,
+      msg_count: 5,
+      honeymoon_active: 0,
+      trial_id: null,
+      weather_key: "silent_fog",
+      weather_name: "沉默霧氣",
+      weather_category: "debuff",
+      weather_effects: JSON.stringify({ raw_xp_mult: 0.9 }),
+      protection_id: 42,
+    });
+    expect(d.weather).toEqual({
+      key: "silent_fog",
+      name: "沉默霧氣",
+      category: "debuff",
+      effects: { raw_xp_mult: 0.9 },
+    });
+    expect(d.weather_protected).toBe(true);
+  });
+
+  it("null weather for days without a weather row", () => {
+    const d = shapeDay({ date: "2026-01-01", weather_key: null, protection_id: null });
+    expect(d.weather).toBeNull();
+    expect(d.weather_protected).toBe(false);
+  });
+
+  it("weather_protected false on a buff day even if a protection row exists", () => {
+    const d = shapeDay({
+      date: "x",
+      weather_key: "mana_tailwind",
+      weather_category: "buff",
+      weather_effects: "{}",
+      protection_id: 7,
+    });
+    expect(d.weather_protected).toBe(false);
   });
 });

--- a/app/src/service/__tests__/XpHistoryService.shape.test.js
+++ b/app/src/service/__tests__/XpHistoryService.shape.test.js
@@ -1,0 +1,22 @@
+const { shapeEvent } = require("../XpHistoryService");
+
+describe("shapeEvent weather", () => {
+  it("exposes weather_protected as a boolean", () => {
+    const e = shapeEvent({
+      id: 1,
+      ts: "2026-07-10 10:00:00",
+      group_id: "C1",
+      raw_exp: 20,
+      effective_exp: 18,
+      modifiers: JSON.stringify({ weather: { name: "沉默霧氣", category: "debuff" } }),
+      weather_protected: 1,
+    });
+    expect(e.weather_protected).toBe(true);
+    expect(e.modifiers.weather.name).toBe("沉默霧氣");
+  });
+
+  it("defaults weather_protected to false for legacy rows", () => {
+    const e = shapeEvent({ id: 2, ts: "x", raw_exp: 5, effective_exp: 5, modifiers: null });
+    expect(e.weather_protected).toBe(false);
+  });
+});

--- a/app/src/service/chatXp/__tests__/pipeline.weather.test.js
+++ b/app/src/service/chatXp/__tests__/pipeline.weather.test.js
@@ -66,5 +66,47 @@ describe("pipeline weather snapshot", () => {
       typeof rows[0].modifiers === "string" ? JSON.parse(rows[0].modifiers) : rows[0].modifiers;
     expect(mods.weather.name).toBe("風異常的喧囂");
     expect(mods.weather.category).toBe("debuff");
+
+    const daily = await mysql("chat_exp_daily").where({ user_id: USER }).first();
+    expect(daily.msg_count).toBe(1);
+    expect(daily.protected_msg_count).toBe(0);
+  });
+
+  it("counts messages sent after purchase into chat_exp_daily.protected_msg_count", async () => {
+    // Weather is generated inside processBatch; pre-insert it so we can attach a
+    // protection purchased *before* the message (event ts >= purchased_at → protected).
+    await mysql("chat_daily_weather").insert({
+      date: TODAY,
+      weather_key: "noisy_wind",
+      category: "debuff",
+      name: "風異常的喧囂",
+      flavor_text: "風。",
+      effects: JSON.stringify({ effective_xp_mult: 0.9 }),
+      protection_type: "windproof",
+      protection_name: "防風耳飾",
+      protection_cost: 30,
+      generated_at: new Date(),
+    });
+    await mysql("user_weather_protections").insert({
+      user_id: USER,
+      weather_date: TODAY,
+      weather_key: "noisy_wind",
+      protection_type: "windproof",
+      protection_name: "防風耳飾",
+      stone_cost: 30,
+      purchased_at: new Date(Date.now() - 60000),
+    });
+
+    await processBatch([
+      { userId: USER, groupId: GROUP, ts: Date.now(), timeSinceLastMsg: 10000, groupCount: 1 },
+    ]);
+
+    const rows = await mysql("chat_exp_events").where({ user_id: USER });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].weather_protected).toBe(1);
+
+    const daily = await mysql("chat_exp_daily").where({ user_id: USER }).first();
+    expect(daily.msg_count).toBe(1);
+    expect(daily.protected_msg_count).toBe(1);
   });
 });

--- a/app/src/service/chatXp/pipeline.js
+++ b/app/src/service/chatXp/pipeline.js
@@ -124,6 +124,7 @@ async function processUserEvents(userId, events, ctx) {
   let rawDelta = 0;
   let effectiveDelta = 0;
   let msgCount = 0;
+  let protectedCount = 0;
   const eventRecords = [];
 
   for (const event of events) {
@@ -156,6 +157,7 @@ async function processUserEvents(userId, events, ctx) {
     rawDelta += raw;
     effectiveDelta += effectiveInt;
     msgCount += 1;
+    if (wProtected) protectedCount += 1;
 
     eventRecords.push({
       user_id: userId,
@@ -205,6 +207,7 @@ async function processUserEvents(userId, events, ctx) {
     rawDelta,
     effectiveDelta,
     msgCount,
+    protectedCount,
     eventRecords,
   });
 
@@ -245,6 +248,7 @@ async function writeBatch(userId, state, batch) {
     rawExp: batch.rawDelta,
     effectiveExp: batch.effectiveDelta,
     msgCount: batch.msgCount,
+    protectedCount: batch.protectedCount,
     honeymoonActive: state.prestige_count === 0,
     trialId: activeTrialId,
   });

--- a/app/src/templates/application/Weather.js
+++ b/app/src/templates/application/Weather.js
@@ -7,6 +7,8 @@ function textNode(text, extra = {}) {
   return { type: "text", text, wrap: true, size: "sm", color: SURFACE.text, ...extra };
 }
 
+const MUTED_NOTE = { margin: "md", size: "xs", color: SURFACE.textMuted };
+
 /**
  * @param {object} p
  * @param {string} p.date
@@ -44,11 +46,10 @@ function generateWeatherBubble({ date, weather, protection, godStoneBalance, lif
       );
     } else {
       body.push(
-        textNode(`防護：${weather.protection_name} · ${weather.protection_cost} 女神石`, {
-          margin: "md",
-          size: "xs",
-          color: SURFACE.textMuted,
-        }),
+        textNode(
+          `防護：${weather.protection_name} · ${weather.protection_cost} 女神石`,
+          MUTED_NOTE
+        ),
         textNode(`尚未防護（你有 ${godStoneBalance} 女神石）`, {
           size: "xs",
           color: accent.main,
@@ -57,17 +58,11 @@ function generateWeatherBubble({ date, weather, protection, godStoneBalance, lif
       );
     }
   } else {
-    body.push(
-      textNode("今日為增益天氣，無需防護。", {
-        margin: "md",
-        size: "xs",
-        color: SURFACE.textMuted,
-      })
-    );
+    body.push(textNode("今日為增益天氣，無需防護。", MUTED_NOTE));
   }
 
-  const cta = isDebuff && !isProtected ? "前往購買防護" : "查看經驗歷程";
-  const filled = isDebuff && !isProtected;
+  const needsProtection = isDebuff && !isProtected;
+  const cta = needsProtection ? "前往購買防護" : "查看經驗歷程";
 
   return {
     type: "bubble",
@@ -97,8 +92,8 @@ function generateWeatherBubble({ date, weather, protection, godStoneBalance, lif
       contents: [
         {
           type: "button",
-          style: filled ? "primary" : "link",
-          color: filled ? accent.main : SEMANTIC.info.main,
+          style: needsProtection ? "primary" : "link",
+          color: needsProtection ? accent.main : SEMANTIC.info.main,
           height: "sm",
           action: { type: "uri", label: cta, uri: liffUri },
         },

--- a/app/src/templates/application/Weather.js
+++ b/app/src/templates/application/Weather.js
@@ -1,0 +1,110 @@
+const { SEMANTIC, SURFACE } = require("../common/theme");
+const { describeEffects } = require("../../service/chatXp/weatherEffects");
+
+const ACCENT = { debuff: SEMANTIC.warning, buff: SEMANTIC.success };
+
+function textNode(text, extra = {}) {
+  return { type: "text", text, wrap: true, size: "sm", color: SURFACE.text, ...extra };
+}
+
+/**
+ * @param {object} p
+ * @param {string} p.date
+ * @param {object} p.weather DB 原始欄位
+ * @param {object|null} p.protection 使用者當日防護列或 null
+ * @param {number} p.godStoneBalance
+ * @param {string} p.liffUri 由 controller 傳入的 LIFF 連結
+ */
+function generateWeatherBubble({ date, weather, protection, godStoneBalance, liffUri }) {
+  const accent = ACCENT[weather.category] || SEMANTIC.success;
+  const isDebuff = weather.category === "debuff";
+  const isProtected = isDebuff && Boolean(protection);
+  const effectText = describeEffects(weather.effects).join("、") || "無";
+
+  const body = [
+    textNode(weather.name, { weight: "bold", size: "lg" }),
+    textNode(weather.flavor_text, { size: "xs", color: SURFACE.textMuted, margin: "sm" }),
+    { type: "separator", margin: "md", color: SURFACE.dividerMuted },
+    textNode(`效果：${effectText}`, {
+      margin: "md",
+      color: isProtected ? SURFACE.textDisabled : SURFACE.text,
+      decoration: isProtected ? "line-through" : "none",
+    }),
+  ];
+
+  if (isDebuff) {
+    if (isProtected) {
+      body.push(
+        textNode(`已防護 · ${protection.protection_name}（今日有效）`, {
+          margin: "md",
+          size: "xs",
+          color: SEMANTIC.info.main,
+          weight: "bold",
+        })
+      );
+    } else {
+      body.push(
+        textNode(`防護：${weather.protection_name} · ${weather.protection_cost} 女神石`, {
+          margin: "md",
+          size: "xs",
+          color: SURFACE.textMuted,
+        }),
+        textNode(`尚未防護（你有 ${godStoneBalance} 女神石）`, {
+          size: "xs",
+          color: accent.main,
+          weight: "bold",
+        })
+      );
+    }
+  } else {
+    body.push(
+      textNode("今日為增益天氣，無需防護。", {
+        margin: "md",
+        size: "xs",
+        color: SURFACE.textMuted,
+      })
+    );
+  }
+
+  const cta = isDebuff && !isProtected ? "前往購買防護" : "查看經驗歷程";
+  const filled = isDebuff && !isProtected;
+
+  return {
+    type: "bubble",
+    size: "kilo",
+    header: {
+      type: "box",
+      layout: "horizontal",
+      backgroundColor: accent.main,
+      paddingAll: "md",
+      contents: [
+        { type: "text", text: "今日天氣", color: accent.contrast, weight: "bold", size: "sm" },
+        {
+          type: "text",
+          text: date,
+          color: accent.contrast,
+          size: "xs",
+          align: "end",
+          gravity: "center",
+        },
+      ],
+    },
+    body: { type: "box", layout: "vertical", paddingAll: "lg", spacing: "sm", contents: body },
+    footer: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "md",
+      contents: [
+        {
+          type: "button",
+          style: filled ? "primary" : "link",
+          color: filled ? accent.main : SEMANTIC.info.main,
+          height: "sm",
+          action: { type: "uri", label: cta, uri: liffUri },
+        },
+      ],
+    },
+  };
+}
+
+module.exports = { generateWeatherBubble };

--- a/app/src/templates/application/__tests__/Weather.test.js
+++ b/app/src/templates/application/__tests__/Weather.test.js
@@ -1,0 +1,73 @@
+const { generateWeatherBubble } = require("../Weather");
+
+function collect(node, key, acc = []) {
+  if (Array.isArray(node)) node.forEach(n => collect(n, key, acc));
+  else if (node && typeof node === "object")
+    for (const [k, v] of Object.entries(node)) {
+      if (k === key && typeof v === "string") acc.push(v);
+      collect(v, key, acc);
+    }
+  return acc;
+}
+
+// CTA copy ("前往購買防護" / "查看經驗歷程") lives on the footer button's
+// `action.label`, not a body `text` node — so it must be checked via both
+// `text` and `label` collectors, not `text` alone.
+function collectVisibleStrings(node) {
+  return collect(node, "text").concat(collect(node, "label")).join("");
+}
+
+const LIFF = "https://liff.line.me/INJECTED/xp-history";
+const debuff = {
+  date: "2026-07-10",
+  weather: {
+    weather_key: "silent_fog",
+    category: "debuff",
+    name: "沉默霧氣",
+    flavor_text: "霧氣吞掉句尾。",
+    effects: { raw_xp_mult: 0.9 },
+    protection_type: "defog",
+    protection_name: "破霧鈴",
+    protection_cost: 30,
+  },
+  protection: null,
+  godStoneBalance: 860,
+  liffUri: LIFF,
+};
+
+describe("generateWeatherBubble", () => {
+  it("returns a bubble showing name, effect and a purchase CTA on an unprotected debuff", () => {
+    const b = generateWeatherBubble(debuff);
+    expect(b.type).toBe("bubble");
+    const texts = collect(b, "text").join("");
+    expect(texts).toContain("沉默霧氣");
+    expect(texts).toContain("破霧鈴");
+    expect(collectVisibleStrings(b)).toContain("前往購買防護");
+    expect(collect(b, "uri")).toContain(LIFF);
+  });
+
+  it("shows 已防護 and drops the purchase CTA when protected", () => {
+    const b = generateWeatherBubble({ ...debuff, protection: { protection_name: "破霧鈴" } });
+    const texts = collect(b, "text").join("");
+    expect(texts).toContain("已防護");
+    expect(collectVisibleStrings(b)).not.toContain("前往購買防護");
+  });
+
+  it("shows no protection section on a buff day", () => {
+    const b = generateWeatherBubble({
+      ...debuff,
+      weather: {
+        weather_key: "mana_tailwind",
+        category: "buff",
+        name: "魔力順風",
+        flavor_text: "順風。",
+        effects: { effective_xp_mult: 1.1 },
+      },
+      protection: null,
+    });
+    const texts = collect(b, "text").join("");
+    expect(texts).toContain("魔力順風");
+    expect(collectVisibleStrings(b)).not.toContain("前往購買防護");
+    expect(texts).not.toContain("破霧鈴");
+  });
+});

--- a/docs/plans/2026-07-10-chat-xp-daily-weather-frontend-design.md
+++ b/docs/plans/2026-07-10-chat-xp-daily-weather-frontend-design.md
@@ -1,0 +1,99 @@
+# 說話 XP 每日奇異天氣：前端 & Flex Follow-up 設計
+
+> Follow-up to `2026-07-09-chat-xp-daily-weather-design.md`（後端 + 唯讀 API 已隨 PR #755 上線，flags off）。
+> 這份補完當初刻意延後的「前端 follow-up plan」＋將 bot 回應升級為 Flex。
+> UI 已出 mockup 並定稿（`scratchpad/weather-mockup.html`）。
+
+## 0. Scope
+
+四塊，全做：
+
+- **A. 後端** — `XpHistoryService` 讓 XP 歷程 API 吐出天氣資料（每日 + 逐筆）。
+- **B. Flex** — `#今天天氣` 從純文字改成 Flex 卡，減益日附「前往購買防護」LIFF 按鈕。
+- **C. LIFF 今日天氣卡** — 經驗歷程頁頂新元件，含購買動線。
+- **D. XP 歷程天氣標記** — 每日趨勢徽章 + 逐筆事件 chip。
+
+對應 parent design §11.1（bot command）、§11.2（購買只走 LIFF）、§12（XP history）。
+
+不新增路由、不新增 npm 依賴。
+
+## 1. 後端（`app/src/service/XpHistoryService.js`）
+
+### 1.1 `shapeEvent` — 多吐 `weather_protected`
+
+- `ChatExpEvent.findInRange` 是 `SELECT *`，`weather_protected` 欄位本來就撈得到 → 只要在 `shapeEvent` 回傳物件加一個 `weather_protected: Boolean(row.weather_protected)`。
+- 事件的天氣名稱／類別／效果／防護道具名已在 `modifiers.weather`（pipeline 已寫入），前端逐筆 chip 直接讀 `event.modifiers.weather` + `event.weather_protected`。**不需要**改 pipeline。
+
+### 1.2 `buildDaily` — join 天氣 + 當日防護
+
+現況只查 `chat_exp_daily`。改為：
+
+- `LEFT JOIN chat_daily_weather` on `date`（全服共用，一天一列）。
+- `LEFT JOIN user_weather_protections` on `user_id + weather_date = date`（判斷該玩家當日是否買了防護）。
+
+每個 `day` 物件新增：
+
+```js
+weather: row.weather_key
+  ? { key: row.weather_key, name, category, effects: <parsed> }
+  : null,
+weather_protected: Boolean(<有防護列 && category === "debuff">),
+```
+
+舊日期（沒有 `chat_daily_weather` 列）→ `weather: null`，前端不渲染徽章。
+
+## 2. Flex 卡（`#今天天氣`）
+
+- 新 template：`app/src/templates/application/Weather.js`，`generateWeatherBubble(status)` → `{ type: "bubble", ... }`。`status` = `WeatherService.getTodayStatus(userId)`。
+- `WeatherController.showToday`：改為 `context.replyFlex("今日天氣", bubble)`；`enabled=false` 時仍回純文字「今日天氣觀測暫停」。
+- 三段結構（mockup 定稿）：
+  1. Hero band：`今日天氣` + 日期，底色依 category（減益暖橘 / 增益薄荷）。
+  2. Body：天氣名 → flavor → 效果（`describeEffects` 產生的人話 + 百分比）。
+  3. 減益日：防護道具名 + cost + 狀態（已防護／尚未防護＋女神石餘額）；footer 一顆按鈕。
+- 按鈕（`templates/common` 的 `getLiffUri`）：
+  - 減益未防護 → 「前往購買防護」→ LIFF XP 歷程頁（購買一律走 LIFF）。
+  - 其他 → 「查看經驗歷程」ghost 按鈕（同連結）。
+
+## 3. LIFF 今日天氣卡（`frontend/src/pages/XpHistory/TodayWeather.jsx`）
+
+- 放 `XpHistory/index.jsx` 頁頂（Tabs 之上，兩 tab 都看得到）。
+- **自持** fetch + 購買 mutation（不拉到父層）：
+  - mount 時 `api.get("/api/me/chat-weather/today")`。
+  - 回傳 `weather === null`（flag off 或觀測暫停）→ 不渲染，不佔版面。
+- **API `weather` 是 DB 原始欄位**（重要，非 design doc 理想化的 `key`）：
+  ```
+  { date, weather_key, category, name, flavor_text,
+    effects:{...}, protection_type, protection_name, protection_cost }
+  ```
+  另有 `protection`（`user_weather_protections` 列或 null）、`god_stone_balance`（number）。
+- 狀態：
+  - 增益 → 天氣名 + flavor + 效果 chip，無購買。
+  - 減益未防護 → 效果 chip + 防護列（道具名/cost）+「購買防護」鈕 + 女神石餘額。
+  - 減益已防護 → 效果 chip 加刪除線 + 「已抵銷 · <道具>」protect chip。
+- 購買動線：點鈕 → MUI confirm dialog（顯示 cost + 道具 + 「僅對購買後發言生效」）→ `api.post("/api/me/chat-weather/protection/purchase")` → 成功就地 refetch。
+- 錯誤碼（400 + `code`）對應人話 toast/inline：`INSUFFICIENT_STONE`→女神石不足、`ALREADY_PROTECTED`→已防護（refetch）、`NO_PROTECTION`/`DISABLED`→不顯示按鈕。
+
+## 4. XP 歷程天氣標記
+
+- `DailyTrend.jsx`：長條下方加天氣徽章（天氣名 + 效果簡寫，如 `魔力順風 · 最終 +10%`）；`day.weather_protected` 時加「已防護」標記。`day.weather === null` → 不加。
+- `EventList.jsx`：每則事件加天氣 chip：`天氣：<name>`＋效果簡寫；`event.weather_protected` → 效果加刪除線 + `已防護：<道具> · 已抵銷`。`event.modifiers.weather` 不存在（舊事件）→ 不加 chip。
+
+## 5. 測試
+
+- 後端單元（`XpHistoryService`）：
+  - `buildDaily` 正確 join 天氣與當日防護；無天氣列的舊日期 → `weather:null`。
+  - `shapeEvent` 帶 `weather_protected`；舊事件（欄位 null）→ `false`，可正常渲染。
+- Flex：`generateWeatherBubble` 三態（增益／減益未防護／減益已防護）快照測試或結構斷言。
+- 前端無 test runner → 手動驗（本機 flags 開/關兩種、三種天氣狀態）。
+
+## 6. Rollout / flags
+
+- 本 follow-up 純加顯示與購買 UI，不動 XP 計算。
+- 上線後：`enabled=true` 可先開讓玩家看得到天氣、體驗 debuff；`purchaseEnabled=true` 待前端卡片上線後再開，玩家才有地方買防護。
+- Rollback 同 parent §15（關 flag 即中性化，不刪歷史列）。
+
+## 7. Out of scope
+
+- 正式天氣圖示（mockup 用 emoji 佔位）；之後可換。
+- postback 版購買（維持 LIFF-only）。
+- 天氣的推播通知（本專案無 LINE Push；維持 reply-only）。

--- a/docs/plans/2026-07-10-chat-xp-daily-weather-frontend-impl.md
+++ b/docs/plans/2026-07-10-chat-xp-daily-weather-frontend-impl.md
@@ -1,0 +1,1064 @@
+# 每日奇異天氣 前端 & Flex Follow-up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓「每日奇異天氣」的天氣資訊出現在 LINE Flex 回應、LIFF 今日天氣卡（含購買）、與 XP 歷程的天氣標記上。
+
+**Architecture:** 後端 `XpHistoryService` 多吐天氣欄位（逐筆 `weather_protected` + 每日 join `chat_daily_weather`/`user_weather_protections`）；新增 Weather Flex template 讓 `#今天天氣` 回卡片；前端在既有 XP 歷程頁加「今日天氣卡」元件與歷程天氣 chip / tooltip。純加顯示與購買 UI，不動 XP 計算。
+
+**Tech Stack:** Node 22 / CommonJS 後端（Bottender + Express + Knex/MySQL + Jest），ESM 前端（React 19 + MUI 7 + Recharts + Vite，無 test runner）。
+
+## Global Constraints
+
+- 後端 CommonJS（`require`/`module.exports`）；前端 ESM。
+- 後端測試：`cd app && yarn test -- <path>`。jest config `transform:{}` → **`jest.mock(...)` 不會 hoist**，必須放在被 mock 模組的 `require` 之前。
+- 需要真 DB 的測試：本機先 `make infra`（MySQL:3306）。本分支基於 main（PR #755 已含天氣 migration），本機共用的 `Princess` DB 已有 `chat_daily_weather` / `user_weather_protections` / `chat_exp_events` 天氣欄位。
+- ESLint：雙引號、trailing comma `es5`、100 字元寬。Husky pre-commit 停用 → commit 前自行 `yarn lint`。
+- Flex template：顏色一律用 `app/src/templates/common/theme.js` 的 token，**不得硬編 hex**；`liffUri` 由 controller 算好傳入 template（template 內不呼叫 `getLiffUri`）。前端元件沿用該頁既有寫法（`services/api`、`context/useLiff`），可用 hex（前端無 theme-token 限制）。
+- **不新增 npm 依賴、不新增路由。**
+- feature flag（`chat_level.dailyWeather.enabled` / `.purchaseEnabled`）維持 off；本機驗證時把兩個 flag 設 true 後，**bot 與 worker 兩個 process 都要重啟**（config 在載入時快取）。
+- API `GET /api/me/chat-weather/today` 回的 `weather` 是 **DB 原始欄位**：`{ date, weather_key, category, name, flavor_text, effects:{...}, protection_type, protection_name, protection_cost }`；另有 `protection`（列或 null）、`god_stone_balance`（number）。
+
+---
+
+## File Structure
+
+**後端**
+- `app/src/service/XpHistoryService.js` — 改 `shapeEvent`、新增 `shapeDay`、改 `buildDaily`、export 兩個 shape 函式。
+- `app/src/templates/application/Weather.js`（新）— `generateWeatherBubble(...)`。
+- `app/src/controller/application/WeatherController.js` — `showToday` 改回 Flex。
+- Tests：`app/src/service/__tests__/XpHistoryService.shape.test.js`（新，純函式）、`app/src/service/__tests__/XpHistoryService.buildDaily.test.js`（新，真 DB）、`app/src/templates/application/__tests__/Weather.test.js`（新）、`app/src/controller/application/__tests__/WeatherController.test.js`（新）。
+
+**前端**（全部在 `frontend/src/pages/XpHistory/`）
+- `weatherLabels.js`（新）— 效果文字 helper，供卡片 / chip / tooltip 共用。
+- `TodayWeather.jsx`（新）— 今日天氣卡（自持 fetch + 購買）。
+- `index.jsx` — 掛載 `<TodayWeather />`。
+- `chipsFromEvent.js` + `EventChips.jsx` — 逐筆天氣 chip。
+- `DailyTrend.jsx` — tooltip 天氣行。
+
+---
+
+## Task 1: 後端 `shapeEvent` 吐 `weather_protected`
+
+**Files:**
+- Modify: `app/src/service/XpHistoryService.js:29-47`（`shapeEvent`）、`:110`（`module.exports`）
+- Test: `app/src/service/__tests__/XpHistoryService.shape.test.js`（create）
+
+**Interfaces:**
+- Produces: `shapeEvent(row)` 回傳物件新增 `weather_protected: boolean`；`shapeEvent` 加入 exports。逐筆天氣名稱/效果沿用既有 `modifiers.weather`（pipeline 已寫），本 task 不動 pipeline。
+
+- [ ] **Step 1: 寫失敗測試**
+
+```js
+// app/src/service/__tests__/XpHistoryService.shape.test.js
+const { shapeEvent } = require("../XpHistoryService");
+
+describe("shapeEvent weather", () => {
+  it("exposes weather_protected as a boolean", () => {
+    const e = shapeEvent({
+      id: 1,
+      ts: "2026-07-10 10:00:00",
+      group_id: "C1",
+      raw_exp: 20,
+      effective_exp: 18,
+      modifiers: JSON.stringify({ weather: { name: "沉默霧氣", category: "debuff" } }),
+      weather_protected: 1,
+    });
+    expect(e.weather_protected).toBe(true);
+    expect(e.modifiers.weather.name).toBe("沉默霧氣");
+  });
+
+  it("defaults weather_protected to false for legacy rows", () => {
+    const e = shapeEvent({ id: 2, ts: "x", raw_exp: 5, effective_exp: 5, modifiers: null });
+    expect(e.weather_protected).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `cd app && yarn test -- src/service/__tests__/XpHistoryService.shape.test.js`
+Expected: FAIL（`shapeEvent is not a function` 或 `weather_protected` 為 undefined）
+
+- [ ] **Step 3: 實作**
+
+`shapeEvent` 的 return 物件內，`modifiers: parseModifiers(row.modifiers),` 之後加一行：
+
+```js
+    weather_protected: Boolean(row.weather_protected),
+```
+
+檔案最後 `module.exports` 改為：
+
+```js
+module.exports = { buildSummary, buildEvents, buildDaily, shapeEvent };
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `cd app && yarn test -- src/service/__tests__/XpHistoryService.shape.test.js`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/service/XpHistoryService.js app/src/service/__tests__/XpHistoryService.shape.test.js
+git commit -m "feat(chat-weather): expose weather_protected on XP history events"
+```
+
+---
+
+## Task 2: 後端 `buildDaily` join 天氣與當日防護
+
+**Files:**
+- Modify: `app/src/service/XpHistoryService.js`（新增 `shapeDay`；改 `buildDaily:92-108`；export `shapeDay`）
+- Test: 追加至 `app/src/service/__tests__/XpHistoryService.shape.test.js`（`shapeDay` 純測試）；`app/src/service/__tests__/XpHistoryService.buildDaily.test.js`（create，真 DB）
+
+**Interfaces:**
+- Consumes: 既有 `parseModifiers`、`toUtc8Date`。`ChatExpDaily.model.knex` = `mysql("chat_exp_daily")`（每次存取回傳新 builder，可安全 `.leftJoin`）。
+- Produces: `shapeDay(row)` → `{ date, raw_exp, effective_exp, msg_count, honeymoon_active, trial_id, weather: {key,name,category,effects}|null, weather_protected: boolean }`；`buildDaily` 回 `{ days: [...] }`（經 `shapeDay`）；`shapeDay` 加入 exports。
+
+- [ ] **Step 1: 寫失敗的 `shapeDay` 純測試**（追加到 shape.test.js）
+
+```js
+const { shapeDay } = require("../XpHistoryService");
+
+describe("shapeDay weather", () => {
+  it("maps joined weather + protection columns", () => {
+    const d = shapeDay({
+      date: "2026-07-10",
+      raw_exp: 100,
+      effective_exp: 80,
+      msg_count: 5,
+      honeymoon_active: 0,
+      trial_id: null,
+      weather_key: "silent_fog",
+      weather_name: "沉默霧氣",
+      weather_category: "debuff",
+      weather_effects: JSON.stringify({ raw_xp_mult: 0.9 }),
+      protection_id: 42,
+    });
+    expect(d.weather).toEqual({
+      key: "silent_fog",
+      name: "沉默霧氣",
+      category: "debuff",
+      effects: { raw_xp_mult: 0.9 },
+    });
+    expect(d.weather_protected).toBe(true);
+  });
+
+  it("null weather for days without a weather row", () => {
+    const d = shapeDay({ date: "2026-01-01", weather_key: null, protection_id: null });
+    expect(d.weather).toBeNull();
+    expect(d.weather_protected).toBe(false);
+  });
+
+  it("weather_protected false on a buff day even if a protection row exists", () => {
+    const d = shapeDay({
+      date: "x",
+      weather_key: "mana_tailwind",
+      weather_category: "buff",
+      weather_effects: "{}",
+      protection_id: 7,
+    });
+    expect(d.weather_protected).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `cd app && yarn test -- src/service/__tests__/XpHistoryService.shape.test.js`
+Expected: FAIL（`shapeDay is not a function`）
+
+- [ ] **Step 3: 實作 `shapeDay` + export**
+
+在 `buildDaily` 之前新增：
+
+```js
+function shapeDay(row) {
+  return {
+    date: toUtc8Date(row.date),
+    raw_exp: row.raw_exp,
+    effective_exp: row.effective_exp,
+    msg_count: row.msg_count,
+    honeymoon_active: Boolean(row.honeymoon_active),
+    trial_id: row.trial_id ?? null,
+    weather: row.weather_key
+      ? {
+          key: row.weather_key,
+          name: row.weather_name,
+          category: row.weather_category,
+          effects: parseModifiers(row.weather_effects),
+        }
+      : null,
+    weather_protected: Boolean(row.protection_id) && row.weather_category === "debuff",
+  };
+}
+```
+
+`module.exports` 改為：
+
+```js
+module.exports = { buildSummary, buildEvents, buildDaily, shapeEvent, shapeDay };
+```
+
+- [ ] **Step 4: 跑 `shapeDay` 純測試確認通過**
+
+Run: `cd app && yarn test -- src/service/__tests__/XpHistoryService.shape.test.js`
+Expected: PASS
+
+- [ ] **Step 5: 改寫 `buildDaily` 加 join**
+
+把 `buildDaily` 整段換成：
+
+```js
+async function buildDaily(userId, { from, to }) {
+  const rows = await ChatExpDaily.model.knex
+    .leftJoin("chat_daily_weather", "chat_exp_daily.date", "chat_daily_weather.date")
+    .leftJoin("user_weather_protections", function () {
+      this.on("user_weather_protections.weather_date", "=", "chat_exp_daily.date").andOn(
+        "user_weather_protections.user_id",
+        "=",
+        "chat_exp_daily.user_id"
+      );
+    })
+    .where("chat_exp_daily.user_id", userId)
+    .andWhere("chat_exp_daily.date", ">=", from)
+    .andWhere("chat_exp_daily.date", "<=", to)
+    .orderBy("chat_exp_daily.date", "asc")
+    .select(
+      "chat_exp_daily.date as date",
+      "chat_exp_daily.raw_exp as raw_exp",
+      "chat_exp_daily.effective_exp as effective_exp",
+      "chat_exp_daily.msg_count as msg_count",
+      "chat_exp_daily.honeymoon_active as honeymoon_active",
+      "chat_exp_daily.trial_id as trial_id",
+      "chat_daily_weather.weather_key as weather_key",
+      "chat_daily_weather.name as weather_name",
+      "chat_daily_weather.category as weather_category",
+      "chat_daily_weather.effects as weather_effects",
+      "user_weather_protections.id as protection_id"
+    );
+  return { days: rows.map(shapeDay) };
+}
+```
+
+- [ ] **Step 6: 寫 `buildDaily` 真 DB 整合測試**
+
+```js
+// app/src/service/__tests__/XpHistoryService.buildDaily.test.js
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../../../.env") });
+jest.unmock("../../util/mysql");
+const mysql = jest.requireActual("../../util/mysql");
+const { buildDaily } = require("../XpHistoryService");
+
+const USER = "U" + "9".repeat(32);
+const DATE = "2001-02-03"; // 固定過去日期，避免與真實資料衝突
+
+describe("buildDaily weather join (real DB)", () => {
+  beforeEach(async () => {
+    await mysql("chat_exp_daily").where({ user_id: USER }).delete();
+    await mysql("user_weather_protections").where({ user_id: USER }).delete();
+    await mysql("chat_daily_weather").where({ date: DATE }).delete();
+  });
+  afterAll(() => mysql.destroy());
+
+  it("joins global weather and per-user protection onto each day", async () => {
+    await mysql("chat_exp_daily").insert({
+      user_id: USER,
+      date: DATE,
+      raw_exp: 100,
+      effective_exp: 80,
+      msg_count: 5,
+      honeymoon_active: 0,
+      trial_id: null,
+    });
+    await mysql("chat_daily_weather").insert({
+      date: DATE,
+      weather_key: "silent_fog",
+      category: "debuff",
+      name: "沉默霧氣",
+      flavor_text: "x",
+      effects: JSON.stringify({ raw_xp_mult: 0.9 }),
+      protection_type: "defog",
+      protection_name: "破霧鈴",
+      protection_cost: 30,
+      generated_at: new Date(),
+    });
+
+    let res = await buildDaily(USER, { from: DATE, to: DATE });
+    expect(res.days).toHaveLength(1);
+    expect(res.days[0].weather).toMatchObject({ key: "silent_fog", category: "debuff" });
+    expect(res.days[0].weather_protected).toBe(false);
+
+    await mysql("user_weather_protections").insert({
+      user_id: USER,
+      weather_date: DATE,
+      weather_key: "silent_fog",
+      protection_type: "defog",
+      protection_name: "破霧鈴",
+      stone_cost: 30,
+      purchased_at: new Date(),
+    });
+
+    res = await buildDaily(USER, { from: DATE, to: DATE });
+    expect(res.days[0].weather_protected).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 7: 跑整合測試確認通過**（需 `make infra`）
+
+Run: `cd app && yarn test -- src/service/__tests__/XpHistoryService.buildDaily.test.js`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/service/XpHistoryService.js app/src/service/__tests__/XpHistoryService.shape.test.js app/src/service/__tests__/XpHistoryService.buildDaily.test.js
+git commit -m "feat(chat-weather): join daily weather + protection into XP history buildDaily"
+```
+
+---
+
+## Task 3: 後端 Weather Flex template
+
+**Files:**
+- Create: `app/src/templates/application/Weather.js`
+- Test: `app/src/templates/application/__tests__/Weather.test.js`
+
+**Interfaces:**
+- Consumes: `require("../common/theme")` 的 `SEMANTIC` / `SURFACE`；`require("../../service/chatXp/weatherEffects")` 的 `describeEffects(effects)` → `string[]`（如 `["原始經驗 -10%"]`）。
+- Produces: `generateWeatherBubble({ date, weather, protection, godStoneBalance, liffUri })` → LINE Flex bubble 物件。`weather` 為 DB 原始欄位（見 Global Constraints）。
+
+- [ ] **Step 1: 寫失敗測試**
+
+```js
+// app/src/templates/application/__tests__/Weather.test.js
+const { generateWeatherBubble } = require("../Weather");
+
+function collect(node, key, acc = []) {
+  if (Array.isArray(node)) node.forEach(n => collect(n, key, acc));
+  else if (node && typeof node === "object")
+    for (const [k, v] of Object.entries(node)) {
+      if (k === key && typeof v === "string") acc.push(v);
+      collect(v, key, acc);
+    }
+  return acc;
+}
+
+const LIFF = "https://liff.line.me/INJECTED/xp-history";
+const debuff = {
+  date: "2026-07-10",
+  weather: {
+    weather_key: "silent_fog",
+    category: "debuff",
+    name: "沉默霧氣",
+    flavor_text: "霧氣吞掉句尾。",
+    effects: { raw_xp_mult: 0.9 },
+    protection_type: "defog",
+    protection_name: "破霧鈴",
+    protection_cost: 30,
+  },
+  protection: null,
+  godStoneBalance: 860,
+  liffUri: LIFF,
+};
+
+describe("generateWeatherBubble", () => {
+  it("returns a bubble showing name, effect and a purchase CTA on an unprotected debuff", () => {
+    const b = generateWeatherBubble(debuff);
+    expect(b.type).toBe("bubble");
+    const texts = collect(b, "text").join("");
+    expect(texts).toContain("沉默霧氣");
+    expect(texts).toContain("破霧鈴");
+    expect(texts).toContain("前往購買防護");
+    expect(collect(b, "uri")).toContain(LIFF);
+  });
+
+  it("shows 已防護 and drops the purchase CTA when protected", () => {
+    const b = generateWeatherBubble({ ...debuff, protection: { protection_name: "破霧鈴" } });
+    const texts = collect(b, "text").join("");
+    expect(texts).toContain("已防護");
+    expect(texts).not.toContain("前往購買防護");
+  });
+
+  it("shows no protection section on a buff day", () => {
+    const b = generateWeatherBubble({
+      ...debuff,
+      weather: {
+        weather_key: "mana_tailwind",
+        category: "buff",
+        name: "魔力順風",
+        flavor_text: "順風。",
+        effects: { effective_xp_mult: 1.1 },
+      },
+      protection: null,
+    });
+    const texts = collect(b, "text").join("");
+    expect(texts).toContain("魔力順風");
+    expect(texts).not.toContain("前往購買防護");
+    expect(texts).not.toContain("破霧鈴");
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `cd app && yarn test -- src/templates/application/__tests__/Weather.test.js`
+Expected: FAIL（`generateWeatherBubble is not a function`）
+
+- [ ] **Step 3: 實作 template**
+
+```js
+// app/src/templates/application/Weather.js
+const { SEMANTIC, SURFACE } = require("../common/theme");
+const { describeEffects } = require("../../service/chatXp/weatherEffects");
+
+const ACCENT = { debuff: SEMANTIC.warning, buff: SEMANTIC.success };
+
+function textNode(text, extra = {}) {
+  return { type: "text", text, wrap: true, size: "sm", color: SURFACE.text, ...extra };
+}
+
+/**
+ * @param {object} p
+ * @param {string} p.date
+ * @param {object} p.weather DB 原始欄位
+ * @param {object|null} p.protection 使用者當日防護列或 null
+ * @param {number} p.godStoneBalance
+ * @param {string} p.liffUri 由 controller 傳入的 LIFF 連結
+ */
+function generateWeatherBubble({ date, weather, protection, godStoneBalance, liffUri }) {
+  const accent = ACCENT[weather.category] || SEMANTIC.success;
+  const isDebuff = weather.category === "debuff";
+  const isProtected = isDebuff && Boolean(protection);
+  const effectText = describeEffects(weather.effects).join("、") || "無";
+
+  const body = [
+    textNode(weather.name, { weight: "bold", size: "lg" }),
+    textNode(weather.flavor_text, { size: "xs", color: SURFACE.textMuted, margin: "sm" }),
+    { type: "separator", margin: "md", color: SURFACE.dividerMuted },
+    textNode(`效果：${effectText}`, {
+      margin: "md",
+      color: isProtected ? SURFACE.textDisabled : SURFACE.text,
+      decoration: isProtected ? "line-through" : "none",
+    }),
+  ];
+
+  if (isDebuff) {
+    if (isProtected) {
+      body.push(
+        textNode(`已防護 · ${protection.protection_name}（今日有效）`, {
+          margin: "md",
+          size: "xs",
+          color: SEMANTIC.info.main,
+          weight: "bold",
+        })
+      );
+    } else {
+      body.push(
+        textNode(`防護：${weather.protection_name} · ${weather.protection_cost} 女神石`, {
+          margin: "md",
+          size: "xs",
+          color: SURFACE.textMuted,
+        }),
+        textNode(`尚未防護（你有 ${godStoneBalance} 女神石）`, {
+          size: "xs",
+          color: accent.main,
+          weight: "bold",
+        })
+      );
+    }
+  } else {
+    body.push(
+      textNode("今日為增益天氣，無需防護。", {
+        margin: "md",
+        size: "xs",
+        color: SURFACE.textMuted,
+      })
+    );
+  }
+
+  const cta = isDebuff && !isProtected ? "前往購買防護" : "查看經驗歷程";
+  const filled = isDebuff && !isProtected;
+
+  return {
+    type: "bubble",
+    size: "kilo",
+    header: {
+      type: "box",
+      layout: "horizontal",
+      backgroundColor: accent.main,
+      paddingAll: "md",
+      contents: [
+        { type: "text", text: "今日天氣", color: accent.contrast, weight: "bold", size: "sm" },
+        { type: "text", text: date, color: accent.contrast, size: "xs", align: "end", gravity: "center" },
+      ],
+    },
+    body: { type: "box", layout: "vertical", paddingAll: "lg", spacing: "sm", contents: body },
+    footer: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "md",
+      contents: [
+        {
+          type: "button",
+          style: filled ? "primary" : "link",
+          color: filled ? accent.main : SEMANTIC.info.main,
+          height: "sm",
+          action: { type: "uri", label: cta, uri: liffUri },
+        },
+      ],
+    },
+  };
+}
+
+module.exports = { generateWeatherBubble };
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `cd app && yarn test -- src/templates/application/__tests__/Weather.test.js`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/templates/application/Weather.js app/src/templates/application/__tests__/Weather.test.js
+git commit -m "feat(chat-weather): add today-weather Flex bubble template"
+```
+
+---
+
+## Task 4: 後端 `showToday` 改回 Flex
+
+**Files:**
+- Modify: `app/src/controller/application/WeatherController.js:1-11`
+- Test: `app/src/controller/application/__tests__/WeatherController.test.js`（create）
+
+**Interfaces:**
+- Consumes: `WeatherService.getTodayStatus(userId)` → `{ date, weather, protection, godStoneBalance }`；`getLiffUri("full", "/xp-history")`；`generateWeatherBubble(...)`（Task 3）。
+- Produces: `showToday(context)`：無 weather → `replyText("今日天氣觀測暫停")`；有 weather → `replyFlex("今日天氣", bubble)`。
+
+- [ ] **Step 1: 寫失敗測試**（`jest.mock` 必須在 require 之前）
+
+```js
+// app/src/controller/application/__tests__/WeatherController.test.js
+jest.mock("../../../service/ChatWeatherService");
+const WeatherService = require("../../../service/ChatWeatherService");
+const Controller = require("../WeatherController");
+
+function ctx(userId = "U1") {
+  return { event: { source: { userId } }, replyText: jest.fn(), replyFlex: jest.fn() };
+}
+
+describe("WeatherController.showToday", () => {
+  it("replies observation-paused text when weather is null", async () => {
+    WeatherService.getTodayStatus.mockResolvedValue({ date: "d", weather: null, protection: null, godStoneBalance: 0 });
+    const c = ctx();
+    await Controller.showToday(c);
+    expect(c.replyText).toHaveBeenCalledWith("今日天氣觀測暫停");
+    expect(c.replyFlex).not.toHaveBeenCalled();
+  });
+
+  it("replies a Flex bubble when weather is present", async () => {
+    WeatherService.getTodayStatus.mockResolvedValue({
+      date: "2026-07-10",
+      weather: {
+        weather_key: "silent_fog",
+        category: "debuff",
+        name: "沉默霧氣",
+        flavor_text: "x",
+        effects: { raw_xp_mult: 0.9 },
+        protection_type: "defog",
+        protection_name: "破霧鈴",
+        protection_cost: 30,
+      },
+      protection: null,
+      godStoneBalance: 100,
+    });
+    const c = ctx();
+    await Controller.showToday(c);
+    expect(c.replyFlex).toHaveBeenCalledTimes(1);
+    const [altText, bubble] = c.replyFlex.mock.calls[0];
+    expect(altText).toBe("今日天氣");
+    expect(bubble.type).toBe("bubble");
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `cd app && yarn test -- src/controller/application/__tests__/WeatherController.test.js`
+Expected: FAIL（目前 `showToday` 呼叫 `replyText`，第二個測試失敗）
+
+- [ ] **Step 3: 實作**
+
+檔案頂部 require 區加：
+
+```js
+const { getLiffUri } = require("../../templates/common");
+const { generateWeatherBubble } = require("../../templates/application/Weather");
+
+const XP_HISTORY_LIFF_PATH = "/xp-history";
+```
+
+`showToday` 換成：
+
+```js
+exports.showToday = async context => {
+  const { userId } = context.event.source;
+  if (!userId) {
+    return context.replyText("獲取失敗，無法辨識用戶");
+  }
+  const status = await WeatherService.getTodayStatus(userId);
+  if (!status.weather) {
+    return context.replyText("今日天氣觀測暫停");
+  }
+  const bubble = generateWeatherBubble({
+    ...status,
+    liffUri: getLiffUri("full", XP_HISTORY_LIFF_PATH),
+  });
+  return context.replyFlex("今日天氣", bubble);
+};
+```
+
+（`describeToday` 已無人使用，但先保留在 service，不在本 task 刪除。）
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `cd app && yarn test -- src/controller/application/__tests__/WeatherController.test.js`
+Expected: PASS
+
+- [ ] **Step 5: 全套後端測試 + lint**
+
+Run: `cd app && yarn test --silent 2>&1 | tail -5 && yarn lint`
+Expected: 全綠、lint 無錯。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/controller/application/WeatherController.js app/src/controller/application/__tests__/WeatherController.test.js
+git commit -m "feat(chat-weather): #今天天氣 replies a Flex card"
+```
+
+---
+
+## Task 5: 前端效果文字 helper
+
+**Files:**
+- Create: `frontend/src/pages/XpHistory/weatherLabels.js`
+
+**Interfaces:**
+- Produces: `weatherEffectLabels(effects, { full }) => string[]`（如 `["原始 -10%"]` 或 `full` 時 `["原始經驗 -10%"]`）；`effectPct(v) => string`（`0.9`→`"-10%"`，`1.1`→`"+10%"`）。供 Task 6/7/8 共用。
+
+- [ ] **Step 1: 建立檔案**
+
+```js
+// frontend/src/pages/XpHistory/weatherLabels.js
+const SHORT = {
+  cooldown_required_mult: "冷卻",
+  raw_xp_mult: "原始",
+  effective_xp_mult: "最終",
+  group_bonus_mult: "群組",
+};
+const FULL = {
+  cooldown_required_mult: "冷卻時間需求",
+  raw_xp_mult: "原始經驗",
+  effective_xp_mult: "最終經驗",
+  group_bonus_mult: "群組加成",
+};
+
+export function effectPct(v) {
+  const p = Math.round((Number(v) - 1) * 100);
+  return `${p > 0 ? "+" : ""}${p}%`;
+}
+
+export function weatherEffectLabels(effects, { full = false } = {}) {
+  const map = full ? FULL : SHORT;
+  return Object.entries(effects || {}).map(([k, v]) => `${map[k] || k} ${effectPct(v)}`);
+}
+```
+
+- [ ] **Step 2: 手動 sanity check**
+
+心算核對：`effectPct(0.9)` → `"-10%"`、`effectPct(1.1)` → `"+10%"`、`effectPct(0.95)` → `"-5%"`；`weatherEffectLabels({ raw_xp_mult: 0.9 })` → `["原始 -10%"]`。無 test runner，本 helper 由 Task 6–8 的畫面驗證覆蓋。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/XpHistory/weatherLabels.js
+git commit -m "feat(chat-weather): weather effect label helper (frontend)"
+```
+
+---
+
+## Task 6: 前端今日天氣卡
+
+**Files:**
+- Create: `frontend/src/pages/XpHistory/TodayWeather.jsx`
+- Modify: `frontend/src/pages/XpHistory/index.jsx`
+
+**Interfaces:**
+- Consumes: `services/api`（帶 token 的 axios）、`context/useLiff`、`weatherLabels`（Task 5）。API `GET /api/me/chat-weather/today`、`POST /api/me/chat-weather/protection/purchase`。
+- Produces: `<TodayWeather />` 預設匯出，掛在 XP 歷程頁頂。`weather===null`（flag off / 觀測暫停）→ 不渲染。
+
+- [ ] **Step 1: 建立元件**
+
+```jsx
+// frontend/src/pages/XpHistory/TodayWeather.jsx
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Stack,
+  Typography,
+} from "@mui/material";
+import api from "../../services/api";
+import useLiff from "../../context/useLiff";
+import { weatherEffectLabels } from "./weatherLabels";
+
+const CATEGORY = {
+  debuff: { color: "warning", label: "減益" },
+  buff: { color: "success", label: "增益" },
+};
+const ERROR_MSG = {
+  INSUFFICIENT_STONE: "女神石不足，無法購買。",
+  ALREADY_PROTECTED: "你今天已經購買防護了。",
+  NO_PROTECTION: "今日天氣沒有可購買的防護。",
+  DISABLED: "目前無法購買防護。",
+};
+
+export default function TodayWeather() {
+  const { loggedIn } = useLiff();
+  const [data, setData] = useState(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(() => {
+    api
+      .get("/api/me/chat-weather/today")
+      .then(res => setData(res.data))
+      .catch(() => setData(null));
+  }, []);
+
+  useEffect(() => {
+    if (loggedIn) load();
+  }, [loggedIn, load]);
+
+  if (!data || !data.weather) return null;
+
+  const { weather, protection, god_stone_balance } = data;
+  const cat = CATEGORY[weather.category] || CATEGORY.buff;
+  const isDebuff = weather.category === "debuff";
+  const protectedActive = isDebuff && Boolean(protection);
+  const effectLabels = weatherEffectLabels(weather.effects, { full: true });
+
+  const purchase = () => {
+    setBusy(true);
+    setError("");
+    api
+      .post("/api/me/chat-weather/protection/purchase")
+      .then(() => {
+        setConfirmOpen(false);
+        load();
+      })
+      .catch(err => setError(ERROR_MSG[err?.response?.data?.code] || "購買失敗，請稍後再試。"))
+      .finally(() => setBusy(false));
+  };
+
+  return (
+    <Card variant="outlined" sx={{ borderTop: 4, borderTopColor: `${cat.color}.main` }}>
+      <CardContent>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={1}>
+          <Box>
+            <Typography variant="overline" color="text.secondary">
+              今日天氣
+            </Typography>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              {weather.name}
+            </Typography>
+          </Box>
+          <Chip size="small" color={cat.color} label={protectedActive ? "已防護" : cat.label} />
+        </Stack>
+
+        {weather.flavor_text && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {weather.flavor_text}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={0.75} flexWrap="wrap" sx={{ mt: 1.5 }}>
+          {effectLabels.map(l => (
+            <Chip
+              key={l}
+              size="small"
+              variant="outlined"
+              label={l}
+              sx={protectedActive ? { textDecoration: "line-through", opacity: 0.6 } : undefined}
+            />
+          ))}
+          {protectedActive && (
+            <Chip size="small" color="info" label={`已抵銷 · ${protection.protection_name}`} />
+          )}
+        </Stack>
+
+        {isDebuff && !protectedActive && (
+          <Box sx={{ mt: 2 }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1}>
+              <Box>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  {weather.protection_name}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  防護今日減益 · {weather.protection_cost} 女神石
+                </Typography>
+              </Box>
+              <Button
+                variant="contained"
+                size="small"
+                onClick={() => {
+                  setError("");
+                  setConfirmOpen(true);
+                }}
+              >
+                購買防護
+              </Button>
+            </Stack>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", textAlign: "right", mt: 1 }}
+            >
+              女神石餘額 {god_stone_balance}
+            </Typography>
+          </Box>
+        )}
+
+        {error && !confirmOpen && (
+          <Alert severity="error" sx={{ mt: 1.5 }}>
+            {error}
+          </Alert>
+        )}
+      </CardContent>
+
+      <Dialog open={confirmOpen} onClose={() => !busy && setConfirmOpen(false)}>
+        <DialogTitle>購買防護？</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            花費 {weather.protection_cost} 女神石購買「{weather.protection_name}」，抵銷今日
+            {weather.name}的減益（僅對購買後的發言生效）。
+          </DialogContentText>
+          {error && (
+            <Alert severity="error" sx={{ mt: 1.5 }}>
+              {error}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)} disabled={busy}>
+            取消
+          </Button>
+          <Button variant="contained" onClick={purchase} disabled={busy}>
+            確定購買
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 2: 掛載到頁面**
+
+`frontend/src/pages/XpHistory/index.jsx`：
+- import 區加 `import TodayWeather from "./TodayWeather";`
+- 在 `{!loggedIn && <AlertLogin />}` 這行之後、`<Tabs ...>` 之前插入：
+
+```jsx
+      {loggedIn && (
+        <Box sx={{ mb: 2 }}>
+          <TodayWeather />
+        </Box>
+      )}
+```
+
+（`Box` 已在 index.jsx import。）
+
+- [ ] **Step 3: Lint**
+
+Run: `cd frontend && yarn lint`
+Expected: 無錯。
+
+- [ ] **Step 4: 手動驗證**
+
+1. root `.env` 或 `app/config/default.json` 把 `chat_level.dailyWeather.enabled` 與 `.purchaseEnabled` 設 `true`。
+2. 重啟 **bot 與 worker**（config 載入時快取）。
+3. `cd frontend && yarn dev`，於 LIFF/瀏覽器開 `/xp-history`。
+4. 檢查：減益日顯示效果 chip + 購買鈕 + 餘額；點購買 → 確認框 → 確定 → 卡片刷新為「已防護」；增益日無購買鈕；`enabled=false` 時整卡不出現。
+5. 錯誤情境：女神石不足 → 顯示「女神石不足」。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/XpHistory/TodayWeather.jsx frontend/src/pages/XpHistory/index.jsx
+git commit -m "feat(chat-weather): today-weather card with purchase flow on XP history page"
+```
+
+---
+
+## Task 7: 前端逐筆事件天氣 chip
+
+**Files:**
+- Modify: `frontend/src/pages/XpHistory/chipsFromEvent.js`
+- Modify: `frontend/src/pages/XpHistory/EventChips.jsx`
+
+**Interfaces:**
+- Consumes: `event.modifiers.weather`（`{name, category, effects, protection_name}`，pipeline 已寫）、`event.weather_protected`（Task 1）、`weatherEffectLabels`（Task 5）。
+- Produces: `chipsFromEvent(ev)` 於既有陣列尾端追加天氣相關 chip；`EventChips.STYLES` 新增 `weatherDebuff` / `weatherBuff` / `weatherProtect`。
+
+- [ ] **Step 1: 擴充 `chipsFromEvent`**
+
+檔案頂部 import 區加：
+
+```js
+import { weatherEffectLabels } from "./weatherLabels";
+```
+
+在 `return chips;` 之前插入：
+
+```js
+  const w = m.weather;
+  if (w) {
+    const wkind = w.category === "buff" ? "weatherBuff" : "weatherDebuff";
+    chips.push({ kind: wkind, label: `天氣：${w.name}` });
+    if (ev.weather_protected) {
+      chips.push({ kind: "weatherProtect", label: `已防護：${w.protection_name || "已抵銷"}` });
+    } else {
+      weatherEffectLabels(w.effects).forEach(l => chips.push({ kind: wkind, label: l }));
+    }
+  }
+```
+
+- [ ] **Step 2: 新增 chip 樣式**
+
+`EventChips.jsx` 的 `STYLES` 物件加三個 key：
+
+```js
+  weatherDebuff: { bg: "#FBEEE1", fg: "#B96322" },
+  weatherBuff: { bg: "#E4F2EA", fg: "#2B8C63" },
+  weatherProtect: { bg: "#E6EDFB", fg: "#3767CF" },
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `cd frontend && yarn lint`
+Expected: 無錯。
+
+- [ ] **Step 4: 手動驗證**
+
+於 `/xp-history`「逐筆」分頁：減益日事件顯示「天氣：<名>」+ 效果 chip；已防護事件顯示「天氣：<名>」+「已防護：<道具>」（無效果 chip）；增益日顯示綠色天氣 chip；舊事件（無 `modifiers.weather`）無天氣 chip。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/XpHistory/chipsFromEvent.js frontend/src/pages/XpHistory/EventChips.jsx
+git commit -m "feat(chat-weather): per-event weather chips in XP history"
+```
+
+---
+
+## Task 8: 前端每日趨勢 tooltip 天氣行
+
+**Files:**
+- Modify: `frontend/src/pages/XpHistory/DailyTrend.jsx`
+
+**Interfaces:**
+- Consumes: `day.weather`（`{name, category, effects}|null`）、`day.weather_protected`（Task 2）、`weatherEffectLabels`（Task 5）。
+- Produces: `TrendTooltip` 多一行天氣（hover/點按顯示）。
+
+> 說明：`DailyTrend` 是 Recharts 圖，天氣放進既有 tooltip（已有蜜月/試煉小行的 pattern），不做每根長條下方常駐徽章。
+
+- [ ] **Step 1: import helper**
+
+`DailyTrend.jsx` 頂部加：
+
+```js
+import { weatherEffectLabels } from "./weatherLabels";
+```
+
+- [ ] **Step 2: chartData 帶上天氣**
+
+`useMemo` 內 `chartData: rows.map(d => ({ ... }))` 物件加兩個欄位（在 `trial_id: d.trial_id,` 之後）：
+
+```js
+        weather: d.weather,
+        weather_protected: d.weather_protected,
+```
+
+- [ ] **Step 3: tooltip 加天氣行**
+
+`TrendTooltip` 內 `{d.trial_id && ...}` 那行之後插入：
+
+```jsx
+      {d.weather && (
+        <Box
+          sx={{
+            color: d.weather.category === "buff" ? COLORS.greenDeep : "#B96322",
+            fontSize: 10,
+          }}
+        >
+          {d.weather.category === "buff" ? "☀" : "🌫"} {d.weather.name}
+          {d.weather_protected
+            ? " · 已防護"
+            : ` · ${weatherEffectLabels(d.weather.effects).join(" ")}`}
+        </Box>
+      )}
+```
+
+- [ ] **Step 4: Lint**
+
+Run: `cd frontend && yarn lint`
+Expected: 無錯。
+
+- [ ] **Step 5: 手動驗證**
+
+於 `/xp-history`「每日趨勢」分頁，hover/點按長條：有天氣的日子在 tooltip 顯示天氣名 + 效果（或「已防護」）；無天氣的舊日子不顯示該行。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/XpHistory/DailyTrend.jsx
+git commit -m "feat(chat-weather): weather line in XP daily-trend tooltip"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage（對照 `...frontend-design.md`）：**
+- §A.1 `shapeEvent` weather_protected → Task 1 ✓
+- §A.2 `buildDaily` join 天氣 + 當日防護 → Task 2 ✓
+- §B Flex（`#今天天氣`）→ Task 3（template）+ Task 4（controller）✓
+- §C LIFF 今日天氣卡（含購買動線、錯誤碼、flag off 不渲染）→ Task 6 ✓
+- §D 歷程標記：逐筆 chip → Task 7 ✓；每日趨勢 → Task 8（tooltip，非常駐徽章，見該 task 說明）✓
+- §5 測試：後端單元/整合 → Task 1/2/3/4；前端手動 → Task 6/7/8 ✓
+- 共用效果文字 → Task 5 ✓
+
+**Placeholder scan：** 無 TODO/TBD；每個改動皆附實際程式碼與確切檔案/行號區塊。
+
+**Type consistency：** `weatherEffectLabels(effects, {full})` 在 Task 5 定義，Task 6（full）/7/8（short）一致使用；`shapeDay` 產出的 `day.weather`/`day.weather_protected` 與 Task 8 tooltip 讀取一致；`generateWeatherBubble` 參數（Task 3）與 controller 傳入（Task 4）一致；API `weather` DB 原始欄位形狀在 Global Constraints 定義，Task 3/6 一致使用。
+
+**已知偏離 mockup（需留意）：** 每日趨勢天氣走 tooltip 而非常駐徽章（Recharts 圖，見 Task 8）。

--- a/frontend/src/pages/XpHistory/DailyTrend.jsx
+++ b/frontend/src/pages/XpHistory/DailyTrend.jsx
@@ -22,6 +22,7 @@ const COLORS = {
   text: "#3A2800",
   green: "#16A34A",
   greenDeep: "#15803D",
+  weatherDebuff: "#B96322",
 };
 
 const RANGES = [1, 7, 30, 90, 365];
@@ -57,6 +58,7 @@ function TrendTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const d = payload[0]?.payload;
   if (!d) return null;
+  const isBuffDay = d.weather?.category === "buff";
   return (
     <Box
       sx={{
@@ -89,16 +91,13 @@ function TrendTooltip({ active, payload }) {
       {d.honeymoon_active && <Box sx={{ color: COLORS.greenDeep, fontSize: 10 }}>🌱 蜜月期</Box>}
       {d.trial_id && <Box sx={{ color: "#B45309", fontSize: 10 }}>⚔ 試煉中</Box>}
       {d.weather && (
-        <Box
-          sx={{
-            color: d.weather.category === "buff" ? COLORS.greenDeep : "#B96322",
-            fontSize: 10,
-          }}
-        >
-          {d.weather.category === "buff" ? "☀" : "🌫"} {d.weather.name}
-          {d.weather_protected
+        <Box sx={{ color: isBuffDay ? COLORS.greenDeep : COLORS.weatherDebuff, fontSize: 10 }}>
+          {isBuffDay ? "☀" : "🌫"} {d.weather.name}
+          {d.weather_protection === "full"
             ? " · 已防護"
-            : ` · ${weatherEffectLabels(d.weather.effects).join(" ")}`}
+            : ` · ${d.weather_protection === "partial" ? "部分防護 " : ""}${weatherEffectLabels(
+                d.weather.effects
+              ).join(" ")}`}
         </Box>
       )}
     </Box>
@@ -118,7 +117,7 @@ export default function DailyTrend({ days, range, onRangeChange }) {
         honeymoon_active: d.honeymoon_active,
         trial_id: d.trial_id,
         weather: d.weather,
-        weather_protected: d.weather_protected,
+        weather_protection: d.weather_protection,
       })),
       honeymoonBands: bandRanges(rows, d => d.honeymoon_active),
       trialBands: bandRanges(rows, d => d.trial_id != null),

--- a/frontend/src/pages/XpHistory/DailyTrend.jsx
+++ b/frontend/src/pages/XpHistory/DailyTrend.jsx
@@ -11,6 +11,7 @@ import {
   YAxis,
 } from "recharts";
 import { formatDateBadge } from "./dateTpe";
+import { weatherEffectLabels } from "./weatherLabels";
 
 const COLORS = {
   amber: "#FBBF24",
@@ -87,6 +88,19 @@ function TrendTooltip({ active, payload }) {
       <Box sx={{ color: COLORS.muted }}>訊息 {d.msg_count}</Box>
       {d.honeymoon_active && <Box sx={{ color: COLORS.greenDeep, fontSize: 10 }}>🌱 蜜月期</Box>}
       {d.trial_id && <Box sx={{ color: "#B45309", fontSize: 10 }}>⚔ 試煉中</Box>}
+      {d.weather && (
+        <Box
+          sx={{
+            color: d.weather.category === "buff" ? COLORS.greenDeep : "#B96322",
+            fontSize: 10,
+          }}
+        >
+          {d.weather.category === "buff" ? "☀" : "🌫"} {d.weather.name}
+          {d.weather_protected
+            ? " · 已防護"
+            : ` · ${weatherEffectLabels(d.weather.effects).join(" ")}`}
+        </Box>
+      )}
     </Box>
   );
 }
@@ -103,6 +117,8 @@ export default function DailyTrend({ days, range, onRangeChange }) {
         msg_count: d.msg_count || 0,
         honeymoon_active: d.honeymoon_active,
         trial_id: d.trial_id,
+        weather: d.weather,
+        weather_protected: d.weather_protected,
       })),
       honeymoonBands: bandRanges(rows, d => d.honeymoon_active),
       trialBands: bandRanges(rows, d => d.trial_id != null),

--- a/frontend/src/pages/XpHistory/EventChips.jsx
+++ b/frontend/src/pages/XpHistory/EventChips.jsx
@@ -8,6 +8,9 @@ const STYLES = {
   dim2: { bg: "#FFF7E6", fg: "#B45309" },
   dim3: { bg: "#FDECEC", fg: "#B91C1C", border: "#DC2626" },
   perm: { bg: "#F3E8FF", fg: "#6B21A8" },
+  weatherDebuff: { bg: "#FBEEE1", fg: "#B96322" },
+  weatherBuff: { bg: "#E4F2EA", fg: "#2B8C63" },
+  weatherProtect: { bg: "#E6EDFB", fg: "#3767CF" },
 };
 
 export function EventChip({ kind, label, value }) {

--- a/frontend/src/pages/XpHistory/TodayWeather.jsx
+++ b/frontend/src/pages/XpHistory/TodayWeather.jsx
@@ -68,6 +68,12 @@ export default function TodayWeather() {
       .finally(() => setBusy(false));
   };
 
+  const errorAlert = error ? (
+    <Alert severity="error" sx={{ mt: 1.5 }}>
+      {error}
+    </Alert>
+  ) : null;
+
   return (
     <Card variant="outlined" sx={{ borderTop: 4, borderTopColor: `${cat.color}.main` }}>
       <CardContent>
@@ -136,11 +142,7 @@ export default function TodayWeather() {
           </Box>
         )}
 
-        {error && !confirmOpen && (
-          <Alert severity="error" sx={{ mt: 1.5 }}>
-            {error}
-          </Alert>
-        )}
+        {!confirmOpen && errorAlert}
       </CardContent>
 
       <Dialog open={confirmOpen} onClose={() => !busy && setConfirmOpen(false)}>
@@ -150,11 +152,7 @@ export default function TodayWeather() {
             花費 {weather.protection_cost} 女神石購買「{weather.protection_name}」，抵銷今日
             {weather.name}的減益（僅對購買後的發言生效）。
           </DialogContentText>
-          {error && (
-            <Alert severity="error" sx={{ mt: 1.5 }}>
-              {error}
-            </Alert>
-          )}
+          {errorAlert}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setConfirmOpen(false)} disabled={busy}>

--- a/frontend/src/pages/XpHistory/TodayWeather.jsx
+++ b/frontend/src/pages/XpHistory/TodayWeather.jsx
@@ -111,34 +111,37 @@ export default function TodayWeather() {
         </Stack>
 
         {isDebuff && !protectedActive && (
-          <Box sx={{ mt: 2 }}>
-            <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1}>
-              <Box>
-                <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                  {weather.protection_name}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  防護今日減益 · {weather.protection_cost} 女神石
-                </Typography>
-              </Box>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={() => {
-                  setError("");
-                  setConfirmOpen(true);
-                }}
-              >
-                購買防護
-              </Button>
-            </Stack>
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ display: "block", textAlign: "right", mt: 1 }}
-            >
-              女神石餘額 {god_stone_balance}
+          <Box
+            sx={{
+              mt: 2,
+              p: 1.5,
+              borderRadius: 2,
+              bgcolor: "action.hover",
+              border: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {weather.protection_name}
             </Typography>
+            <Typography variant="caption" color="text.secondary">
+              防護今日減益 · {weather.protection_cost} 女神石
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
+              女神石餘額 {Number(god_stone_balance).toLocaleString()}
+            </Typography>
+            <Button
+              fullWidth
+              variant="contained"
+              size="small"
+              onClick={() => {
+                setError("");
+                setConfirmOpen(true);
+              }}
+              sx={{ mt: 1.5 }}
+            >
+              購買防護
+            </Button>
           </Box>
         )}
 

--- a/frontend/src/pages/XpHistory/TodayWeather.jsx
+++ b/frontend/src/pages/XpHistory/TodayWeather.jsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Stack,
+  Typography,
+} from "@mui/material";
+import api from "../../services/api";
+import useLiff from "../../context/useLiff";
+import { weatherEffectLabels } from "./weatherLabels";
+
+const CATEGORY = {
+  debuff: { color: "warning", label: "減益" },
+  buff: { color: "success", label: "增益" },
+};
+const ERROR_MSG = {
+  INSUFFICIENT_STONE: "女神石不足，無法購買。",
+  ALREADY_PROTECTED: "你今天已經購買防護了。",
+  NO_PROTECTION: "今日天氣沒有可購買的防護。",
+  DISABLED: "目前無法購買防護。",
+};
+
+export default function TodayWeather() {
+  const { loggedIn } = useLiff();
+  const [data, setData] = useState(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(() => {
+    api
+      .get("/api/me/chat-weather/today")
+      .then(res => setData(res.data))
+      .catch(() => setData(null));
+  }, []);
+
+  useEffect(() => {
+    if (loggedIn) load();
+  }, [loggedIn, load]);
+
+  if (!data || !data.weather) return null;
+
+  const { weather, protection, god_stone_balance } = data;
+  const cat = CATEGORY[weather.category] || CATEGORY.buff;
+  const isDebuff = weather.category === "debuff";
+  const protectedActive = isDebuff && Boolean(protection);
+  const effectLabels = weatherEffectLabels(weather.effects, { full: true });
+
+  const purchase = () => {
+    setBusy(true);
+    setError("");
+    api
+      .post("/api/me/chat-weather/protection/purchase")
+      .then(() => {
+        setConfirmOpen(false);
+        load();
+      })
+      .catch(err => setError(ERROR_MSG[err?.response?.data?.code] || "購買失敗，請稍後再試。"))
+      .finally(() => setBusy(false));
+  };
+
+  return (
+    <Card variant="outlined" sx={{ borderTop: 4, borderTopColor: `${cat.color}.main` }}>
+      <CardContent>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={1}>
+          <Box>
+            <Typography variant="overline" color="text.secondary">
+              今日天氣
+            </Typography>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              {weather.name}
+            </Typography>
+          </Box>
+          <Chip size="small" color={cat.color} label={protectedActive ? "已防護" : cat.label} />
+        </Stack>
+
+        {weather.flavor_text && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {weather.flavor_text}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={0.75} flexWrap="wrap" sx={{ mt: 1.5 }}>
+          {effectLabels.map(l => (
+            <Chip
+              key={l}
+              size="small"
+              variant="outlined"
+              label={l}
+              sx={protectedActive ? { textDecoration: "line-through", opacity: 0.6 } : undefined}
+            />
+          ))}
+          {protectedActive && (
+            <Chip size="small" color="info" label={`已抵銷 · ${protection.protection_name}`} />
+          )}
+        </Stack>
+
+        {isDebuff && !protectedActive && (
+          <Box sx={{ mt: 2 }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1}>
+              <Box>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  {weather.protection_name}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  防護今日減益 · {weather.protection_cost} 女神石
+                </Typography>
+              </Box>
+              <Button
+                variant="contained"
+                size="small"
+                onClick={() => {
+                  setError("");
+                  setConfirmOpen(true);
+                }}
+              >
+                購買防護
+              </Button>
+            </Stack>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", textAlign: "right", mt: 1 }}
+            >
+              女神石餘額 {god_stone_balance}
+            </Typography>
+          </Box>
+        )}
+
+        {error && !confirmOpen && (
+          <Alert severity="error" sx={{ mt: 1.5 }}>
+            {error}
+          </Alert>
+        )}
+      </CardContent>
+
+      <Dialog open={confirmOpen} onClose={() => !busy && setConfirmOpen(false)}>
+        <DialogTitle>購買防護？</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            花費 {weather.protection_cost} 女神石購買「{weather.protection_name}」，抵銷今日
+            {weather.name}的減益（僅對購買後的發言生效）。
+          </DialogContentText>
+          {error && (
+            <Alert severity="error" sx={{ mt: 1.5 }}>
+              {error}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)} disabled={busy}>
+            取消
+          </Button>
+          <Button variant="contained" onClick={purchase} disabled={busy}>
+            確定購買
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Card>
+  );
+}

--- a/frontend/src/pages/XpHistory/chipsFromEvent.js
+++ b/frontend/src/pages/XpHistory/chipsFromEvent.js
@@ -1,5 +1,6 @@
 import { mult } from "./format";
 import { TIER2_RATE } from "./diminishTier";
+import { weatherEffectLabels } from "./weatherLabels";
 
 const BLESSING_WARM_CURRENT = 1;
 
@@ -32,6 +33,16 @@ export function chipsFromEvent(ev) {
   }
   if (m.permanent_xp_multiplier > 0) {
     chips.push({ kind: "perm", label: "永久", value: fmtMult(1 + m.permanent_xp_multiplier) });
+  }
+  const w = m.weather;
+  if (w) {
+    const wkind = w.category === "buff" ? "weatherBuff" : "weatherDebuff";
+    chips.push({ kind: wkind, label: `天氣：${w.name}` });
+    if (ev.weather_protected) {
+      chips.push({ kind: "weatherProtect", label: `已防護：${w.protection_name || "已抵銷"}` });
+    } else {
+      weatherEffectLabels(w.effects).forEach(l => chips.push({ kind: wkind, label: l }));
+    }
   }
   return chips;
 }

--- a/frontend/src/pages/XpHistory/index.jsx
+++ b/frontend/src/pages/XpHistory/index.jsx
@@ -22,6 +22,7 @@ import { fetchGroupSummarys } from "../../services/group";
 import EventList from "./EventList";
 import DailyTrend from "./DailyTrend";
 import TodayHeader from "./TodayHeader";
+import TodayWeather from "./TodayWeather";
 import { makeGroupLabel } from "./groupLabel";
 import { addDaysTpe, todayTpe } from "./dateTpe";
 
@@ -120,6 +121,12 @@ export default function XpHistory() {
       </Stack>
 
       {!loggedIn && <AlertLogin />}
+
+      {loggedIn && (
+        <Box sx={{ mb: 2 }}>
+          <TodayWeather />
+        </Box>
+      )}
 
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="逐筆" />

--- a/frontend/src/pages/XpHistory/weatherLabels.js
+++ b/frontend/src/pages/XpHistory/weatherLabels.js
@@ -1,0 +1,22 @@
+const SHORT = {
+  cooldown_required_mult: "冷卻",
+  raw_xp_mult: "原始",
+  effective_xp_mult: "最終",
+  group_bonus_mult: "群組",
+};
+const FULL = {
+  cooldown_required_mult: "冷卻時間需求",
+  raw_xp_mult: "原始經驗",
+  effective_xp_mult: "最終經驗",
+  group_bonus_mult: "群組加成",
+};
+
+export function effectPct(v) {
+  const p = Math.round((Number(v) - 1) * 100);
+  return `${p > 0 ? "+" : ""}${p}%`;
+}
+
+export function weatherEffectLabels(effects, { full = false } = {}) {
+  const map = full ? FULL : SHORT;
+  return Object.entries(effects || {}).map(([k, v]) => `${map[k] || k} ${effectPct(v)}`);
+}

--- a/frontend/src/pages/XpHistory/weatherLabels.js
+++ b/frontend/src/pages/XpHistory/weatherLabels.js
@@ -11,7 +11,7 @@ const FULL = {
   group_bonus_mult: "群組加成",
 };
 
-export function effectPct(v) {
+function effectPct(v) {
   const p = Math.round((Number(v) - 1) * 100);
   return `${p > 0 ? "+" : ""}${p}%`;
 }


### PR DESCRIPTION
## 什麼

「說話 XP 每日奇異天氣」follow-up：把天氣資訊接到 **LINE Flex 回應**、**LIFF 今日天氣卡（含購買防護動線）** 與 **XP 歷程的天氣標記**。後端計算與防護機制已隨 #755 上線（dark，flags off），本 PR 只加顯示與購買 UI，**不動 XP 計算**。

延續 `docs/plans/2026-07-10-chat-xp-daily-weather-frontend-design.md`（設計規格）與 `...-frontend-impl.md`（實作計畫）。

## 內容

**後端**
- `XpHistoryService`：`shapeEvent` 多吐 `weather_protected`；新增 `shapeDay` + 改寫 `buildDaily`，leftJoin `chat_daily_weather`（全服，依日期）與 `user_weather_protections`（依 user_id + weather_date）。
- 新 Flex template `templates/application/Weather.js`（`generateWeatherBubble`，全用 theme token、`liffUri` 由 controller 注入）。
- `WeatherController.showToday`：`#今天天氣` 從純文字改回 **Flex 卡**（減益未防護時附「前往購買防護」LIFF 按鈕）。

**前端**（`frontend/src/pages/XpHistory/`）
- `weatherLabels.js`：效果文字 helper（卡片/chip/tooltip 共用）。
- `TodayWeather.jsx`：頁頂今日天氣卡，自持 fetch + 購買確認 dialog + 錯誤碼對應；`weather===null`（flag off / 觀測暫停 / 抓取失敗）不渲染。
- 逐筆事件天氣 chip（`chipsFromEvent.js` + `EventChips.jsx`）。
- 每日趨勢 **tooltip** 天氣行（`DailyTrend.jsx`）—— 刻意走 tooltip 而非常駐徽章（Recharts 圖，已於計畫記錄此偏離 mockup）。

## 測試 / 驗證

- 後端 Jest 全綠：**117 suites / 874 tests**（含新 `XpHistoryService.shape` 純測試、`buildDaily` 真 DB 整合測試、`Weather` Flex 測試、`WeatherController` controller 測試）。
- 前端無 test runner → 每個 commit 皆 `yarn lint` clean + `yarn build` 成功。
- Opus 全枝審查：cross-boundary 資料形狀端到端一致、防護跨使用者隔離正確、authz 走 `req.profile.userId`、theme token 無硬編 hex → **Ready to merge**。

## Rollout

- Flags 維持 **OFF**。上線後可先開 `chat_level.dailyWeather.enabled` 讓玩家看得到天氣，待前端卡片確認無誤再開 `.purchaseEnabled`。**改 flag 後 bot 與 worker 兩個 process 都要重啟**（config 載入時快取）。
- Rollback 同 parent：關 flag 即中性化，不刪歷史列。

## 尚待人工驗證

前端 LIFF 卡片與購買流程需在瀏覽器/LIFF session 手動驗（無 headless 路徑）：本機把兩個 flag 設 true、重啟 bot+worker、開 `/xp-history` 檢查減益/增益/已防護三態 + 購買動線 + 女神石不足錯誤。

## 非阻擋的 nice-to-have（審查已標 fine-as-is）

- `buildDaily` 真 DB 測試可再加一個跨使用者隔離 case（ON-clause 已 inspection 正確）。
- `Weather.test.js` 可再斷言 protected/buff 時 footer swap 成「查看經驗歷程」。
- `Weather.js` 可抽 `showPurchase` const 去重。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r4S5yuBbb5HofidWqGhdC
