### PR TITLE
feat(chat-weather): 啟用每日天氣(flag on),防護購買維持關閉

### DIFF
--- a/app/config/default.json
+++ b/app/config/default.json
@@ -171,7 +171,7 @@
       }
     },
     "dailyWeather": {
-      "enabled": false,
+      "enabled": true,
       "purchaseEnabled": false,
       "weights": { "buff": 60, "debuff": 40 },
       "defaultProtectionCost": 30,

--- a/app/src/controller/application/WeatherController.js
+++ b/app/src/controller/application/WeatherController.js
@@ -31,6 +31,7 @@ exports.apiGetToday = async (req, res) => {
       weather: status.weather,
       protection: status.protection,
       god_stone_balance: status.godStoneBalance,
+      purchase_enabled: status.purchaseEnabled,
     });
   } catch (e) {
     DefaultLogger.error("[chat-weather/today]", e);

--- a/app/src/controller/application/__tests__/WeatherController.api.test.js
+++ b/app/src/controller/application/__tests__/WeatherController.api.test.js
@@ -23,6 +23,7 @@ describe("apiGetToday", () => {
       weather: { weather_key: "noisy_wind" },
       protection: null,
       godStoneBalance: 860,
+      purchaseEnabled: false,
     });
     const res = makeRes();
     await WeatherController.apiGetToday(req, res);
@@ -31,6 +32,7 @@ describe("apiGetToday", () => {
       weather: { weather_key: "noisy_wind" },
       protection: null,
       god_stone_balance: 860,
+      purchase_enabled: false,
     });
   });
 });

--- a/app/src/service/ChatWeatherService.js
+++ b/app/src/service/ChatWeatherService.js
@@ -69,6 +69,7 @@ async function getTodayStatus(userId) {
     weather,
     protection: protection || null,
     godStoneBalance: Number(godStoneBalance),
+    purchaseEnabled: Boolean(cfg().enabled && cfg().purchaseEnabled),
   };
 }
 

--- a/app/src/service/chatXp/__tests__/weatherConfig.test.js
+++ b/app/src/service/chatXp/__tests__/weatherConfig.test.js
@@ -3,8 +3,8 @@ const config = require("config");
 describe("chat_level.dailyWeather config", () => {
   const cfg = config.get("chat_level.dailyWeather");
 
-  it("is present and defaults to disabled", () => {
-    expect(cfg.enabled).toBe(false);
+  it("has weather enabled with protection purchase still gated off", () => {
+    expect(cfg.enabled).toBe(true);
     expect(cfg.purchaseEnabled).toBe(false);
     expect(cfg.weights).toEqual({ buff: 60, debuff: 40 });
   });

--- a/app/src/templates/application/Weather.js
+++ b/app/src/templates/application/Weather.js
@@ -16,8 +16,16 @@ const MUTED_NOTE = { margin: "md", size: "xs", color: SURFACE.textMuted };
  * @param {object|null} p.protection 使用者當日防護列或 null
  * @param {number} p.godStoneBalance
  * @param {string} p.liffUri 由 controller 傳入的 LIFF 連結
+ * @param {boolean} [p.purchaseEnabled=true] 防護購買總開關；關閉時隱藏購買相關文案/CTA
  */
-function generateWeatherBubble({ date, weather, protection, godStoneBalance, liffUri }) {
+function generateWeatherBubble({
+  date,
+  weather,
+  protection,
+  godStoneBalance,
+  liffUri,
+  purchaseEnabled = true,
+}) {
   const accent = ACCENT[weather.category] || SEMANTIC.success;
   const isDebuff = weather.category === "debuff";
   const isProtected = isDebuff && Boolean(protection);
@@ -44,7 +52,7 @@ function generateWeatherBubble({ date, weather, protection, godStoneBalance, lif
           weight: "bold",
         })
       );
-    } else {
+    } else if (purchaseEnabled) {
       body.push(
         textNode(
           `防護：${weather.protection_name} · ${weather.protection_cost} 女神石`,
@@ -56,12 +64,14 @@ function generateWeatherBubble({ date, weather, protection, godStoneBalance, lif
           weight: "bold",
         })
       );
+    } else {
+      body.push(textNode("今日為減益天氣。", MUTED_NOTE));
     }
   } else {
     body.push(textNode("今日為增益天氣，無需防護。", MUTED_NOTE));
   }
 
-  const needsProtection = isDebuff && !isProtected;
+  const needsProtection = isDebuff && !isProtected && purchaseEnabled;
   const cta = needsProtection ? "前往購買防護" : "查看經驗歷程";
 
   return {

--- a/app/src/templates/application/__tests__/Weather.test.js
+++ b/app/src/templates/application/__tests__/Weather.test.js
@@ -53,6 +53,15 @@ describe("generateWeatherBubble", () => {
     expect(collectVisibleStrings(b)).not.toContain("前往購買防護");
   });
 
+  it("hides purchase copy and CTA on an unprotected debuff when purchaseEnabled is false", () => {
+    const b = generateWeatherBubble({ ...debuff, purchaseEnabled: false });
+    const texts = collect(b, "text").join("");
+    expect(texts).toContain("沉默霧氣"); // weather still shown
+    expect(texts).not.toContain("破霧鈴"); // protection name hidden
+    expect(collectVisibleStrings(b)).not.toContain("前往購買防護");
+    expect(collectVisibleStrings(b)).toContain("查看經驗歷程"); // CTA falls back to history link
+  });
+
   it("shows no protection section on a buff day", () => {
     const b = generateWeatherBubble({
       ...debuff,

--- a/frontend/src/pages/XpHistory/TodayWeather.jsx
+++ b/frontend/src/pages/XpHistory/TodayWeather.jsx
@@ -49,7 +49,7 @@ export default function TodayWeather() {
 
   if (!data || !data.weather) return null;
 
-  const { weather, protection, god_stone_balance } = data;
+  const { weather, protection, god_stone_balance, purchase_enabled } = data;
   const cat = CATEGORY[weather.category] || CATEGORY.buff;
   const isDebuff = weather.category === "debuff";
   const protectedActive = isDebuff && Boolean(protection);
@@ -110,7 +110,7 @@ export default function TodayWeather() {
           )}
         </Stack>
 
-        {isDebuff && !protectedActive && (
+        {isDebuff && !protectedActive && purchase_enabled && (
           <Box
             sx={{
               mt: 2,


### PR DESCRIPTION
## Summary
上線後發現「每日奇異天氣」完全沒觸發 —— 原因是 PR #755/#756 刻意帶著旗標關閉上線(commit message 的 `flags off`),`config/default.json` 的 `chat_level.dailyWeather.enabled` 是 `false`,gate 在 `ChatWeatherService.js:47` 直接 `return null`,連每日天氣都不會生成。

本 PR 開啟天氣,但**防護道具(購買)先維持關閉**:

- `config/default.json`:`dailyWeather.enabled` `false → true`;`purchaseEnabled` 維持 `false`
- `getTodayStatus` 回傳 `purchaseEnabled`,`GET /api/me/chat-weather/today` 帶 `purchase_enabled`
- 前端 `TodayWeather.jsx` 依 `purchase_enabled` 隱藏購買區塊
- Flex `Weather.js` 依 `purchaseEnabled`(預設 `true`)隱藏「前往購買防護」CTA 與防護報價,改顯示「今日為減益天氣。」
- 目的:購買未啟用時,不再於 debuff 日出現「點了只回 `DISABLED`」的死按鈕

## Test plan
- [x] `yarn test "Weather|weather"` — 39 passed / 8 suites(含 DB 整合測試,已起 infra)
- [x] ESLint app + frontend 皆 clean
- [x] 新增 Flex template `purchaseEnabled:false` 路徑測試
- [x] 更新 `weatherConfig` / `WeatherController.api` 斷言

## 部署備註
`config/default.json` 打包進 `hanshino/redive_backend` image(prod 只掛載 `assets/`),因此需**重 build + push backend image**,並重部署 **bot 與 worker**(worker 跑 pipeline 套天氣效果)。無新 migration / 無新環境變數。

🤖 Generated with [Claude Code](https://claude.com/claude-code)