### PR TITLE
fix(ci): 產出 arm64 image、GHCR、移除失效的 Portainer deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,21 +5,26 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
-  # Backend build and push job
+  # Backend build and push job — native arm64 runner (free for public repos),
+  # no QEMU: better-sqlite3 / @node-rs/jieba are native modules and emulated
+  # compilation would be unacceptably slow. amd64 has no consumer (the only
+  # deploy target is a Graviton/arm64 EC2 host), so we don't build it.
   backend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -28,27 +33,26 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./app
+          platforms: linux/arm64
           push: true
           tags: |
-            hanshino/redive_backend:latest
-            hanshino/redive_backend:${{ github.sha }}
-          cache-from: type=registry,ref=hanshino/redive_backend:buildcache
-          cache-to: type=registry,ref=hanshino/redive_backend:buildcache,mode=max
+            ghcr.io/hanshino/redive_backend:latest
+            ghcr.io/hanshino/redive_backend:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/hanshino/redive_backend:buildcache
+          cache-to: type=registry,ref=ghcr.io/hanshino/redive_backend:buildcache,mode=max
 
   # Frontend build and push job, executed in parallel with backend
   frontend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -57,104 +61,26 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./frontend
+          platforms: linux/arm64
           push: true
           tags: |
-            hanshino/redive_frontend:latest
-            hanshino/redive_frontend:${{ github.sha }}
-          cache-from: type=registry,ref=hanshino/redive_frontend:buildcache
-          cache-to: type=registry,ref=hanshino/redive_frontend:buildcache,mode=max
+            ghcr.io/hanshino/redive_frontend:latest
+            ghcr.io/hanshino/redive_frontend:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/hanshino/redive_frontend:buildcache
+          cache-to: type=registry,ref=ghcr.io/hanshino/redive_frontend:buildcache,mode=max
 
-  # Deployment via Portainer API
-  deploy:
+  # There is no CD: the EC2 host (~/stack) pulls and restarts manually.
+  # Portainer, which the old deploy job talked to, is not deployed on the
+  # new machine. This job only fires once both images are pushed — GitHub
+  # Actions skips a job when any of its `needs` fails, so a failed build
+  # never sends a false "done" notification.
+  notify:
     runs-on: ubuntu-latest
     needs: [backend, frontend]
     steps:
-      - name: Redeploy stack with new image tags
-        run: |
-          # Pin BACKEND_IMAGE_TAG / FRONTEND_IMAGE_TAG to this commit SHA so
-          # docker-compose pulls the freshly-pushed images. We fetch the full
-          # current env, replace just these two, and POST it back via
-          # /git/redeploy with pullImage:true to force a recreate.
-          SHA="${{ github.sha }}"
-
-          CURRENT_ENV=$(curl -sf \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}" \
-            | jq '.Env')
-
-          NEW_ENV=$(jq --arg sha "$SHA" '
-            map(select(.name != "BACKEND_IMAGE_TAG" and .name != "FRONTEND_IMAGE_TAG"))
-            + [{name: "BACKEND_IMAGE_TAG", value: $sha}, {name: "FRONTEND_IMAGE_TAG", value: $sha}]
-          ' <<< "$CURRENT_ENV")
-
-          BODY=$(jq -n --argjson env "$NEW_ENV" '{
-            repositoryReferenceName: "refs/heads/main",
-            repositoryAuthentication: false,
-            env: $env,
-            prune: true,
-            pullImage: true
-          }')
-
-          HTTP_STATUS=$(curl -s -o /tmp/redeploy-response -w "%{http_code}" \
-            -X PUT \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}/git/redeploy?endpointId=${{ secrets.PORTAINER_ENDPOINT_ID }}" \
-            -d "$BODY")
-
-          if [ "$HTTP_STATUS" != "200" ]; then
-            echo "::error::git/redeploy failed with HTTP $HTTP_STATUS"
-            echo "Response body:"
-            cat /tmp/redeploy-response
-            exit 1
-          fi
-          echo "Stack redeployed at SHA $SHA"
-
-      - name: Wait for containers to be ready
-        run: sleep 30
-
-      - name: Run database migrations
-        run: |
-          # Create exec instance
-          EXEC_ID=$(curl -sf \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -X POST \
-            "${{ secrets.PORTAINER_URL }}/api/endpoints/${{ secrets.PORTAINER_ENDPOINT_ID }}/docker/containers/${{ secrets.PORTAINER_BOT_CONTAINER }}/exec" \
-            -d '{"AttachStdout":true,"AttachStderr":true,"Cmd":["yarn","migrate"]}' \
-            | jq -r '.Id')
-
-          if [ -z "$EXEC_ID" ] || [ "$EXEC_ID" = "null" ]; then
-            echo "::error::Failed to create exec instance"
-            exit 1
-          fi
-
-          # Run exec
-          RESULT=$(curl -sf \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -X POST \
-            "${{ secrets.PORTAINER_URL }}/api/endpoints/${{ secrets.PORTAINER_ENDPOINT_ID }}/docker/exec/$EXEC_ID/start" \
-            -d '{"Detach":false,"Tty":false}')
-
-          echo "Migration output: $RESULT"
-
-          # Check exec exit code
-          EXIT_CODE=$(curl -sf \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            "${{ secrets.PORTAINER_URL }}/api/endpoints/${{ secrets.PORTAINER_ENDPOINT_ID }}/docker/exec/$EXEC_ID/json" \
-            | jq -r '.ExitCode')
-
-          if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Migration failed with exit code $EXIT_CODE"
-            exit 1
-          fi
-
-          echo "Migration completed successfully"
-
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
-          args: "{{ EVENT_PAYLOAD.repository.full_name }} 已完成部署"
+          args: "{{ EVENT_PAYLOAD.repository.full_name }} image 已建置並推送到 GHCR（尚未自動部署，需在機器上手動 pull + restart）"

--- a/.omc/skills/portainer-git-stack-cicd-expertise.md
+++ b/.omc/skills/portainer-git-stack-cicd-expertise.md
@@ -1,5 +1,11 @@
 # Portainer Git-Managed Stack CI/CD via API
 
+> **DEPRECATED as of 2026-07-29.** The self-hosted machine this described died
+> on 2026-07-27; production moved to a single AWS EC2 arm64 host with no
+> Portainer. `.github/workflows/main.yml`'s `deploy` job (Portainer API calls)
+> was removed. This file is kept only as historical record of the gotchas —
+> do not follow it for the current stack.
+
 ## The Insight
 
 Portainer's "redeploy from git" does **not** recreate containers unless the rendered compose file's text changes. Webhook fire / API call returns success and the stack's `ConfigHash` updates to the new commit, but `UpdateDate` and container `CreatedAt` stay the same. With `:latest` hard-coded in compose, **CI silently deploys nothing** even though new images were pushed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,11 @@ There is no `job/` package — cron is `yarn worker` inside `app/` (see below).
 
 ### Production
 
-- Defined in `docker-compose.traefik.yml` (referenced but deployed via Portainer stacks — see memory).
+- Since 2026-07-29: single AWS EC2 `t4g.medium` (Graviton/arm64, Ubuntu 24.04, `ap-east-2`), one docker compose stack in `~/stack` on the host — **not** in this repo, and **not** Portainer-managed (Portainer is not deployed on this machine).
+- Reverse proxy is **Caddy** (not Traefik) fronting `pudding.hanshino.dev`.
 - Three services: **bot** (`yarn start`), **frontend** (pre-built static), **worker** (`yarn worker`).
-- Traefik terminates TLS and routes `/api`, `/webhooks`, `/bot-assets`, `/socket.io` → bot; everything else → frontend.
+- CI (`.github/workflows/main.yml`) only builds `linux/arm64` images and pushes to `ghcr.io/hanshino/redive_backend` / `ghcr.io/hanshino/redive_frontend` (tags `latest` and the commit SHA). There is no CD step — the host pulls and restarts the stack manually; `docker/setup-qemu-action` and any amd64 build were removed since the only deploy target is arm64.
+- `docker-compose.traefik.yml` in this repo is stale (Traefik + Portainer-era, `hanshino/redive_backend` on Docker Hub) and not used by the running stack, but it's kept as the canonical source for the four path prefixes Caddy routes to the bot — `/api`, `/webhooks`, `/bot-assets`, `/socket.io` — do not delete without carrying that list somewhere else first.
 
 ### Bot process vs worker process
 
@@ -70,7 +72,7 @@ Command routing in `OrderBased` composes routers from every domain controller (g
 - **MySQL** via Knex (`app/knexfile.js`) — database is hardcoded `Princess`. Host-run migrations read the root `.env` (`DB_HOST=mysql` maps to the docker-exposed port 3306 on localhost).
 - **Redis** — Bottender session store + general cache (`app/src/util/redis.js`). Session TTL 60 min, state TTL 15 min (`app/bottender.config.js`).
 - **SQLite** — read-only game data (`app/assets/redive_tw.db`) and a local task log (`app/assets/task.db`); accessed via `better-sqlite3` through `app/src/model/princess/character/index.js`, with `app/src/util/sqlite.js` as the connection factory.
-- **Migrations** — `app/migrations/`. Create new ones with `cd app && yarn knex migrate:make <name>` — never hand-write. knex is the single schema source (the old docker `Princess.sql` init was folded into the `20210101000000_baseline_initial_schema` migration). **Fresh DB bootstrap**: `cd app && yarn migrate && yarn knex seed:run` (migrate builds all tables, seeders fill `chat_exp_unit` / `GachaPool` / etc.) — there is no more SQL injected at container first-boot.
+- **Migrations** — `app/migrations/`. Create new ones with `cd app && yarn knex migrate:make <name>` — never hand-write. knex is the single schema source (the old docker `Princess.sql` init was folded into the `20210101000000_baseline_initial_schema` migration). **Fresh DB bootstrap**: `cd app && yarn migrate && yarn knex seed:run` (migrate builds all tables, seeders fill `chat_exp_unit` / `GachaPool` / etc.) — there is no more SQL injected at container first-boot. **Do not specify a collation when creating the database** (or specify `utf8mb4_0900_ai_ci` explicitly) — MySQL 8's default must match what `20260327_unify_all_collation_to_0900.js` assumes, or later migrations fail with `Illegal mix of collations`; see the comment in `20210101000000_baseline_initial_schema.js` for the full story.
 
 ### Socket.IO
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -30,4 +30,4 @@ COPY --chown=node:node . /usr/src/app
 
 CMD [ "dumb-init", "yarn", "start" ]
 
-EXPOSE 5000
+EXPOSE 9527

--- a/app/migrations/20210101000000_baseline_initial_schema.js
+++ b/app/migrations/20210101000000_baseline_initial_schema.js
@@ -14,6 +14,23 @@
  *     確保 fresh DB 上後續 alterTable 能找到底表。
  *
  * ponytail: 直接讀同名 .sql 逐句執行，省掉把含反引號/單引號的 DDL 硬塞進 JS 字串。
+ *
+ * 建全新資料庫時，**不要**指定 CHARACTER SET / COLLATE（讓 MySQL 8 預設的
+ * utf8mb4_0900_ai_ci 生效），或者明確指定 utf8mb4_0900_ai_ci。**不要**指定
+ * utf8mb4_unicode_ci，即使這份 baseline 裡的 26 張表全部寫死 unicode_ci。
+ *
+ * 為什麼：`20260327_unify_all_collation_to_0900.js` 只把 10 張「舊表」
+ * CONVERT TO 0900，從來不碰資料庫本身的預設 collation。正式環境沒事，
+ * 是因為它的 DB 預設本來就是 0900 —— 所以這份 baseline 跑完之後才由 knex
+ * 建的表（例如 user_achievements）全部繼承 0900，只有那 10 張舊表需要靠
+ * 那支 migration 轉過去對齊。
+ *
+ * 如果建 DB 時手動指定了 unicode_ci，上面那段邏輯整個反過來：舊表被轉去
+ * 0900，但後面才建的新表繼承 unicode_ci，新舊表一 JOIN 就是
+ * `Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and
+ * (utf8mb4_0900_ai_ci,IMPLICIT)`。2026-07-29 遷移到新 EC2 host 時，
+ * 因為看到這份 baseline 裡的 unicode_ci 字樣就手動指定了它，
+ * 結果在第 122 支 migration（grant_legacy_tier_achievements）就這樣炸了一次。
  */
 const fs = require("fs");
 const path = require("path");

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,8 @@
     "worker": "node tasks.js",
     "debug": "DEBUG=bottender:action node server.js",
     "test": "jest",
-    "migrate": "knex migrate:latest"
+    "migrate": "knex migrate:latest",
+    "seed": "knex seed:run"
   },
   "dependencies": {
     "@google/genai": "^2.12.0",


### PR DESCRIPTION
## 背景
自架主機 2026-07-27 掛掉，2026-07-29 遷移到 AWS EC2 t4g.medium (Graviton/arm64)。CI 尚未跟上：
1. image 只有 amd64，在 arm64 host 上起不來
2. deploy job 打的是已不存在的 Portainer API，push main 必定失敗
3. 全新 DB 的 collation 要求沒寫在任何地方（已踩坑一次）

## 改動
- **`.github/workflows/main.yml`**：`runs-on: ubuntu-24.04-arm` native runner（public repo 免費），移除 QEMU，`build-push-action` 加 `platforms: linux/arm64`；registry 從 Docker Hub 換成 `ghcr.io/hanshino/redive_{backend,frontend}`（用內建 `GITHUB_TOKEN`，不需額外 secret，跟同 stack 的 maple-hub 一致）；刪除打 Portainer API 的 `deploy` job，換成只發 Discord 通知的 `notify` job，明講「尚未自動部署」。
- **`app/migrations/20210101000000_baseline_initial_schema.js`**：註解補上 collation 要求與根因（`20260327_unify_all_collation_to_0900.js` 只轉 10 張舊表、不動 DB 預設，指定 `unicode_ci` 會讓繼承方向反過來）。
- **`CLAUDE.md`**：`### Production` 段落更新為 EC2 + Caddy + 無 Portainer 現況；Migrations 那行補 collation 警告。
- **`app/package.json`**：補 `seed` script，對齊文件裡的 bootstrap 流程。
- **`app/Dockerfile`**：`EXPOSE 5000` → `9527`，對齊實際 listen port。
- **`.omc/skills/portainer-git-stack-cicd-expertise.md`**：標記 DEPRECATED。

## 驗收
- `actionlint` 通過
- 所有 pinned action SHA 已確認存在（`docker/login-action`、`build-push-action`）
- 未動 `app/`、`frontend/` 執行期程式碼，Dockerfile 只碰 `EXPOSE`

## 待 merge 後手動確認
- image 第一次 push 後用 `docker buildx imagetools inspect ghcr.io/hanshino/redive_backend:latest` 確認 manifest 只有 `linux/arm64`
- GHCR package 預設 visibility 可能是 private，需要手動設成 public 或準備 PAT 給機器 pull