### PR TITLE
fix(auth): gate POST /api/images behind admin privilege check

### DIFF
--- a/app/__tests__/api/images.test.js
+++ b/app/__tests__/api/images.test.js
@@ -1,0 +1,68 @@
+const request = require("supertest");
+const createApp = require("../helpers/createApp");
+
+jest.mock("../../src/util/pictshare", () => ({
+  uploadBase64: jest.fn().mockResolvedValue({ url: "https://img.hanshino.dev/test.png" }),
+}));
+
+const pictshare = require("../../src/util/pictshare");
+
+let app;
+beforeAll(() => {
+  app = createApp();
+});
+
+describe("POST /api/images", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 and uploads when caller has privilege >= 5 (default test mock)", async () => {
+    const res = await request(app)
+      .post("/api/images")
+      .set("Authorization", "Bearer test-token")
+      .send({ image: "aGVsbG8=" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, link: "https://img.hanshino.dev/test.png" });
+    expect(pictshare.uploadBase64).toHaveBeenCalledWith("aGVsbG8=");
+  });
+
+  it("rejects when privilege is below the required level (5)", async () => {
+    // Re-mock validation for this test only: simulate an authenticated but
+    // under-privileged admin to prove the gate actually checks privilege,
+    // not just presence of the middleware chain.
+    jest.resetModules();
+    jest.doMock("../../src/middleware/validation", () => {
+      const actual = jest.requireActual("../../src/middleware/validation");
+      return {
+        ...actual,
+        verifyToken: (req, _res, next) => {
+          req.profile = { userId: "U" + "a".repeat(32) };
+          next();
+        },
+        verifyAdmin: (req, _res, next) => {
+          req.profile = { ...req.profile, privilege: 1 };
+          next();
+        },
+      };
+    });
+    jest.doMock("../../src/util/pictshare", () => ({
+      uploadBase64: jest.fn().mockResolvedValue({ url: "https://img.hanshino.dev/test.png" }),
+    }));
+
+    const isolatedCreateApp = require("../helpers/createApp");
+    const isolatedApp = isolatedCreateApp();
+
+    const res = await request(isolatedApp)
+      .post("/api/images")
+      .set("Authorization", "Bearer test-token")
+      .send({ image: "aGVsbG8=" });
+
+    expect(res.status).toBe(403);
+
+    jest.dontMock("../../src/middleware/validation");
+    jest.dontMock("../../src/util/pictshare");
+    jest.resetModules();
+  });
+});

--- a/app/src/router/Imgur/index.js
+++ b/app/src/router/Imgur/index.js
@@ -1,8 +1,9 @@
 const router = require("express").Router();
 const i18n = require("../../util/i18n");
 const pictshare = require("../../util/pictshare");
+const { verifyToken, verifyAdmin, verifyPrivilege } = require("../../middleware/validation");
 
-router.post("/images", async (req, res) => {
+router.post("/images", verifyToken, verifyAdmin, verifyPrivilege(5), async (req, res) => {
   try {
     const { image } = req.body;
     const result = await pictshare.uploadBase64(image);


### PR DESCRIPTION
## Summary
- `POST /api/images` had no middleware. `pictshare.js` server-side injects `PICTSHARE_UPLOAD_CODE` into the upload form, so any anonymous request was silently upgraded to an authorized PictShare upload — a confused-deputy anonymous image-upload proxy against the company-billed image host.
- Fix: added `verifyToken, verifyAdmin, verifyPrivilege(5)` to `POST /images` in `app/src/router/Imgur/index.js` — same middleware chain and privilege level already used for `/admin/*` in `api.js:45`.
- Path unchanged (`/api/images`) — the only frontend caller (`Admin/Worldboss.jsx`) already sends the LIFF bearer token via `useAxios`, so no frontend changes needed.
- Added `app/__tests__/api/images.test.js` covering the authorized (200) and under-privileged (403) cases.

Scanned other root-mounted routers (`Market`, `Inventory`, `Trade`, `GodStoneShop`) — no other confused-deputy issues found; all `/admin/*` paths route through the `api.js:45` gate regardless of mount order, and public reads are intentionally public.

## Test plan
- [x] `yarn jest __tests__/api/images.test.js` — both cases pass
- [x] `yarn test:app` full suite — same 11 pre-existing DB-connection failures as baseline (unrelated integration tests requiring live MySQL), no regressions; new suite adds 2 passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)