### PR TITLE
feat(achievement): add race, market, and prestige achievements

### DIFF
--- a/app/src/controller/application/CouponController.js
+++ b/app/src/controller/application/CouponController.js
@@ -8,6 +8,8 @@ const couponUsedHistory = require("../../model/application/CouponUsedHistory");
 const { inventory } = require("../../model/application/Inventory");
 const { DefaultLogger } = require("../../util/Logger");
 const moment = require("moment");
+const AchievementEngine = require("../../service/AchievementEngine");
+const { notifyUnlocks } = require("../../service/achievementNotifier");
 
 exports.adminRouter = [text(/^[!]coupon add/, adminAdd)];
 
@@ -99,6 +101,13 @@ async function userUse(context, props) {
       user_id: userId,
       coupon_code_id: coupon.id,
     });
+
+    const { unlocked } = await AchievementEngine.evaluate(userId, "coupon_redeem", {}).catch(
+      () => ({
+        unlocked: [],
+      })
+    );
+    await notifyUnlocks(context, userId, unlocked);
 
     return context.replyText(
       i18n.__("message.coupon.success", {

--- a/app/src/controller/application/MarketController.js
+++ b/app/src/controller/application/MarketController.js
@@ -13,6 +13,8 @@ const humanNumber = require("human-number");
 const redis = require("../../util/redis");
 const config = require("config");
 const { DefaultLogger } = require("../../util/Logger");
+const AchievementEngine = require("../../service/AchievementEngine");
+const { notifyUnlocks } = require("../../service/achievementNotifier");
 
 exports.router = [
   text(/^[./#](交易管理|trade-manage)$/i, showManage),
@@ -224,6 +226,10 @@ const doTransfer = async (context, { payload }) => {
   }
 
   removeTransfer(transferId);
+  const { unlocked } = await AchievementEngine.evaluate(sourceId, "atm_transfer", { amount }).catch(
+    () => ({ unlocked: [] })
+  );
+  await notifyUnlocks(context, sourceId, unlocked);
   context.replyText(
     i18n.__("message.trade.transfer_money_success", {
       displayName,

--- a/app/src/controller/application/RaceController.js
+++ b/app/src/controller/application/RaceController.js
@@ -1,5 +1,7 @@
 const { text } = require("bottender/router");
 const RaceService = require("../../service/RaceService");
+const AchievementEngine = require("../../service/AchievementEngine");
+const { notifyUnlocks } = require("../../service/achievementNotifier");
 const { race } = require("../../model/application/Race");
 const { raceRunner } = require("../../model/application/RaceRunner");
 const { raceBet } = require("../../model/application/RaceBet");
@@ -68,6 +70,11 @@ async function placeBet(context, { match }) {
     await context.replyText(result.error);
     return;
   }
+
+  const { unlocked } = await AchievementEngine.evaluate(userId, "race_bet_placed", {
+    isAllIn: result.isAllIn,
+  }).catch(() => ({ unlocked: [] }));
+  await notifyUnlocks(context, userId, unlocked);
 
   const odds = await RaceService.getOdds(activeRace.id);
   const targetOdd = odds.find(o => o.runnerId === target.id);

--- a/app/src/controller/princess/GodStoneShop/handler.js
+++ b/app/src/controller/princess/GodStoneShop/handler.js
@@ -3,6 +3,7 @@ const GodStoneShopModel = require("../../../model/princess/GodStoneShop");
 const GachaModel = require("../../../model/princess/gacha");
 const gacha = GachaModel.model;
 const i18n = require("../../../util/i18n");
+const AchievementEngine = require("../../../service/AchievementEngine");
 
 /**
  * 使用女神石兌換物品
@@ -54,6 +55,10 @@ exports.exchangeItem = async function (req, res) {
     },
     { userId, itemId: 999, itemAmount: remainGodStone },
   ]);
+
+  await AchievementEngine.evaluate(userId, "shop_exchange", {
+    spend: parseInt(itemInfo.price) * parseInt(itemCount),
+  }).catch(() => {});
 
   res.json({ userId, itemId, itemCount, remainGodStone });
 };

--- a/app/src/handler/Market/index.js
+++ b/app/src/handler/Market/index.js
@@ -8,6 +8,7 @@ const mysql = require("../../util/mysql");
 const { DefaultLogger } = require("../../util/Logger");
 const moment = require("moment");
 const { resolveDisplayName } = require("../../service/ProfileService");
+const AchievementEngine = require("../../service/AchievementEngine");
 
 /**
  * 顯示商品詳細資訊
@@ -158,6 +159,11 @@ exports.transaction = async (req, res) => {
       );
       if (!tradeHistoryId) throw i18n.__("api.error.transaction.createTradeHistoryFailed");
     });
+
+    await Promise.all([
+      AchievementEngine.evaluate(userId, "trade_complete", {}).catch(() => {}),
+      AchievementEngine.evaluate(sellerId, "trade_complete", {}).catch(() => {}),
+    ]);
 
     DefaultLogger.info("success transaction item", {
       userId,

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -96,6 +96,13 @@ const EVENT_ACHIEVEMENT_MAP = {
     "mention_memory_seeker_self",
     "mention_void_gazer_self",
   ],
+  race_bet_placed: ["race_first_bet", "race_all_in"],
+  race_bet_won: ["race_win_10", "race_big_win"],
+  trade_complete: ["trade_first", "trade_50"],
+  atm_transfer: ["atm_whale"],
+  coupon_redeem: ["coupon_first", "coupon_collector"],
+  shop_exchange: ["shop_first_exchange", "shop_big_spender"],
+  prestige_complete: ["prestige_first", "prestige_3"],
 };
 
 // --- Progress calculation strategies by achievement type ---
@@ -111,6 +118,16 @@ const STRATEGIES = {
     return context[contextKey] !== undefined ? context[contextKey] : currentValue;
   },
   threshold(currentValue, achievement, context, contextKey, minValue) {
+    return context[contextKey] >= minValue ? achievement.target_value : currentValue;
+  },
+  // Generic threshold check driven entirely by DB `condition` JSON — used for
+  // hidden achievements whose exact numeric threshold must NOT be hardcoded in
+  // this file (keeps secret thresholds out of git; only the DB row seeded via
+  // raw SQL knows the real number).
+  conditionThreshold(currentValue, achievement, context) {
+    const condition = achievement.condition || {};
+    const { contextKey, minValue } = condition;
+    if (!contextKey || minValue === undefined) return currentValue;
     return context[contextKey] >= minValue ? achievement.target_value : currentValue;
   },
   timeWindow(currentValue, achievement, startHour, endHour) {
@@ -189,6 +206,19 @@ const ACHIEVEMENT_STRATEGY = {
   mention_admin_hi_self: (cv, a, ctx) => STRATEGIES.receivedMentionKeyword(cv, a, ctx),
   mention_memory_seeker_self: (cv, a, ctx) => STRATEGIES.receivedMentionKeyword(cv, a, ctx),
   mention_void_gazer_self: (cv, a, ctx) => STRATEGIES.receivedMentionKeyword(cv, a, ctx),
+  race_first_bet: (cv, a) => STRATEGIES.instant(cv, a),
+  race_win_10: cv => STRATEGIES.increment(cv),
+  race_all_in: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
+  race_big_win: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
+  trade_first: (cv, a) => STRATEGIES.instant(cv, a),
+  trade_50: cv => STRATEGIES.increment(cv),
+  atm_whale: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
+  coupon_first: (cv, a) => STRATEGIES.instant(cv, a),
+  coupon_collector: cv => STRATEGIES.increment(cv),
+  shop_first_exchange: (cv, a) => STRATEGIES.instant(cv, a),
+  shop_big_spender: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
+  prestige_first: (cv, a) => STRATEGIES.instant(cv, a),
+  prestige_3: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
 };
 
 const GODDESS_STONE_ITEM_ID = 999;

--- a/app/src/service/PrestigeService.js
+++ b/app/src/service/PrestigeService.js
@@ -301,6 +301,10 @@ async function prestige(userId, blessingId) {
 
   await chatUserState.invalidate(userId);
 
+  await AchievementEngine.evaluate(userId, "prestige_complete", {
+    prestigeCount: newPrestigeCount,
+  }).catch(() => {});
+
   const groupId = await resolveLastGroup(userId);
   const displayName = await resolveDisplayName(groupId, userId);
   await broadcastQueue.pushEvent(groupId, {

--- a/app/src/service/RaceService.js
+++ b/app/src/service/RaceService.js
@@ -1,5 +1,6 @@
 const config = require("config");
 const mysql = require("../util/mysql");
+const AchievementEngine = require("./AchievementEngine");
 const { race } = require("../model/application/Race");
 const { raceRunner } = require("../model/application/RaceRunner");
 const { raceBet } = require("../model/application/RaceBet");
@@ -105,7 +106,7 @@ exports.placeBet = async function (userId, raceId, runnerId, amount) {
       note: "race_bet",
     });
 
-    return { success: true };
+    return { success: true, isAllIn: balance === amount ? 1 : 0 };
   });
 };
 
@@ -251,6 +252,14 @@ exports.settleBets = async function (raceId) {
       .where("runner_id", "!=", currentRace.winner_runner_id)
       .update({ payout: 0 });
   });
+
+  await Promise.all(
+    winnerBets.map(bet => {
+      const payout = Math.floor(prizePool * (bet.amount / winnerTotal));
+      const odds = bet.amount > 0 ? payout / bet.amount : 0;
+      return AchievementEngine.evaluate(bet.user_id, "race_bet_won", { odds }).catch(() => {});
+    })
+  );
 
   return { refunded: false, prizePool, fee, winners: winnerBets.length };
 };


### PR DESCRIPTION
## Summary
- Add generic `conditionThreshold` strategy to `AchievementEngine` so hidden-achievement numeric thresholds live only in the DB `condition` JSON, never hardcoded in committed source (players dig migration files for answers — this closes that leak).
- Wire 7 new event types: `race_bet_placed`, `race_bet_won`, `trade_complete`, `atm_transfer`, `coupon_redeem`, `shop_exchange`, `prestige_complete`.
- Add achievement evaluation call sites in `RaceController`/`RaceService`, `MarketController`, `Market` handler, `CouponController`, `GodStoneShop` handler, and `PrestigeService`.
- Add manual production SQL seed under `docs/sql/` — intentionally **not** a knex migration, run directly against prod so hidden thresholds never enter git history.

## Test plan
- [x] `yarn test __tests__/service/AchievementEngine.test.js __tests__/service/GachaService.test.js __tests__/service/PrestigeService.test.js src/service/__tests__/RaceSimulation.test.js` — 105/105 passed
- [x] `yarn lint` — passed, no issues
- [ ] Run `docs/sql/2026-08-01-add-achievements-race-market-prestige.sql` manually against prod DB after merge/deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)