### PR TITLE
fix(gacha): 修正每日一抽限制失效 — DB 時區不一致 + 額度檢查競態

### DIFF
--- a/app/knexfile.js
+++ b/app/knexfile.js
@@ -5,6 +5,10 @@ if (process.env.NODE_ENV !== "production") {
   });
 }
 
+// 時區必須跟 src/util/mysql.js 一致 —— 見那支檔案開頭的完整說明。
+// migration 會寫入 timestamp/datetime 欄位，用錯時區等於寫進偏移 8 小時的資料。
+const TIMEZONE = "+08:00";
+
 module.exports = {
   client: "mysql2",
   connection: {
@@ -13,6 +17,13 @@ module.exports = {
     password: process.env.DB_USER_PASSWORD,
     port: process.env.DB_PORT,
     database: "Princess",
+    timezone: TIMEZONE,
   },
-  pool: { min: 0, max: 10 },
+  pool: {
+    min: 0,
+    max: 10,
+    afterCreate: (conn, done) => {
+      conn.query(`SET time_zone = '${TIMEZONE}'`, err => done(err, conn));
+    },
+  },
 };

--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -166,11 +166,6 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     return await normalGacha();
   }
 
-  const isAbleDailyGacha = await detectCanDaily(userId, groupId);
-  if (!isAbleDailyGacha) {
-    return await normalGacha();
-  }
-
   // 進行每日一抽
   // 需要檢查是否要花費女神石進行機率調升或是保證抽
   const userOwnStone = parseInt(await GachaModel.getUserGodStoneCount(userId));
@@ -190,12 +185,22 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
     return context.replyText(i18n.__("message.gacha.not_enough_stone"));
   }
 
+  const dailyClaimKey = await detectCanDaily(userId);
+  if (!dailyClaimKey) {
+    return await normalGacha();
+  }
+
   let result;
   try {
     result = await time("gacha.runDaily", () =>
       GachaService.runDailyDraw(userId, { tag, pickup, ensure, europe })
     );
   } catch (err) {
+    // 交易失敗時釋放 claim，讓回滾後的每日額度可以重試；程序崩潰則等 TTL 自動釋放。
+    if (dailyClaimKey !== true) {
+      await redis.del(dailyClaimKey);
+      await redis.del(`daily_gacha_${userId}_${moment().format("MMDD")}`);
+    }
     DefaultLogger.warn(`[gacha] runDailyDraw failed for ${userId}: ${err.message}`);
     console.log(err);
     return context.replyText(
@@ -242,9 +247,11 @@ async function gacha(context, { match, pickup, ensure = false, europe = false })
 }
 
 /**
- * 檢查是否可以進行每日轉蛋
+ * 檢查是否可以進行每日轉蛋。
+ * 成功時回傳搶佔到的 redis claim key（呼叫端在抽卡失敗時需釋放），
+ * 額度用盡時回傳 false；測試環境直接回傳 true。
  * @param {String} userId
- * @returns {Promise<Boolean>}
+ * @returns {Promise<String|Boolean>}
  */
 async function detectCanDaily(userId) {
   if (process.env.NODE_ENV !== "production") return true;
@@ -263,15 +270,23 @@ async function detectCanDaily(userId) {
   // 檢查是否有超過每日抽卡上限
   const record = await GachaRecord.knex
     .where({ user_id: userId })
-    .whereBetween("created_at", [now.startOf("day").toDate(), now.endOf("day").toDate()])
+    .whereBetween("created_at", [
+      now.clone().startOf("day").toDate(),
+      now.clone().endOf("day").toDate(),
+    ])
     .count({ count: "*" })
     .first();
 
   // 轉蛋次數
-  const usedCount = get(record, "count", 0);
+  const usedCount = Number(get(record, "count", 0));
+  // 注意：這裡必須傳 Date 而非 Moment。mysql2 不認得 Moment 物件，
+  // 會序列化成 "Mon Aug 03 2026 ..." 而讓 MySQL 丟 ER_WRONG_VALUE。
+  const nowDate = now.toDate();
   const subscribeUser = await SubscribeUser.all({
     filter: {
-      user_id: userId,
+      [SubscribeUser.getColumnName("user_id")]: userId,
+      [SubscribeUser.getColumnName("start_at")]: { operator: "<=", value: nowDate },
+      [SubscribeUser.getColumnName("end_at")]: { operator: ">", value: nowDate },
     },
   }).join(
     SubscribeCard.table,
@@ -279,36 +294,42 @@ async function detectCanDaily(userId) {
     SubscribeUser.getColumnName("subscribe_card_key")
   );
 
-  if (subscribeUser.length === 0) {
-    // 無訂閱用戶，不管有無超過，都幫其設定一個 cache
-    // 以免每次都要去資料庫檢查
-    // 此次的回傳便可以讓呼叫端知道是否超過
-    await redis.set(key, "1", {
-      EX: 60,
-    });
-
-    return usedCount < dailyLimit;
-  }
-
-  // 計算訂閱用戶的轉蛋次數
-  const bonusCount = subscribeUser.reduce((acc, data) => {
-    const { effects } = data;
-    const gachaEffect = effects.find(effect => effect.type === "gacha_times");
-    const effectCount = get(gachaEffect, "value", 0);
-    return acc + effectCount;
+  const activeSubs = subscribeUser;
+  const bonusCount = activeSubs.reduce((acc, data) => {
+    const effects = Array.isArray(data.effects)
+      ? data.effects
+      : typeof data.effects === "string"
+        ? JSON.parse(data.effects || "[]")
+        : [];
+    const gachaEffect = effects.find(effect => effect && effect.type === "gacha_times");
+    return acc + get(gachaEffect, "value", 0);
   }, dailyLimit);
 
   CustomLogger.debug(`detectCanDaily: ${userId} useCount: ${usedCount} bonusCount: ${bonusCount}`);
 
   if (usedCount >= bonusCount) {
-    // 超過每日限制，設定 cache 1 天
+    // 超過每日限制，cache 到今天結束；cache 只作負快取，DB count 仍是權威。
+    const ttl = Math.max(60, moment().endOf("day").diff(moment(), "seconds"));
     await redis.set(key, "1", {
-      EX: 60,
+      EX: ttl,
     });
     return false;
   }
 
-  return true;
+  // 每個 DB usedCount 對應一個 slot；Redis 遺失時仍會重新從 DB count 對齊，不會多發額度。
+  const claimKey = `daily_gacha_claim_${userId}_${now.format("MMDD")}_${usedCount}`;
+  const ttl = Math.max(60, moment().endOf("day").diff(moment(), "seconds"));
+  const claimed = await redis.set(claimKey, "1", {
+    EX: ttl,
+    NX: true,
+  });
+  if (isNull(claimed)) return false;
+
+  if (activeSubs.length === 0) {
+    // 無訂閱用戶只有一個每日額度，成功 claim 後以負快取避免重查資料庫。
+    await redis.set(key, "1", { EX: ttl });
+  }
+  return claimKey;
 }
 
 async function purgeDailyGachaCache(userId) {

--- a/app/src/util/mysql.js
+++ b/app/src/util/mysql.js
@@ -1,3 +1,19 @@
+const { DefaultLogger } = require("./Logger");
+
+// 時區約定：連線層明確宣告 +08:00，不依賴容器的 TZ 環境變數。
+//
+// 2026-07 搬到 EC2 時，prod 的 mysql container 少了 `TZ: Asia/Taipei`（bot 有、mysql 沒有），
+// 於是 MySQL 跑 UTC、Node 跑 Taipei。mysql2 預設 `timezone: "local"`，會把 JS Date 以
+// Node 本地時間序列化成字串，MySQL 再用自己的 session 時區解讀 —— 兩邊差 8 小時。
+// 結果所有「今天」的區間查詢（每日一抽、每日任務、世界boss 傷害上限…）在台北時間
+// 00:00-07:59 都查不到當天資料，等於限制整段時間失效。
+//
+// 這裡兩邊都釘住：
+//   - connection.timezone：mysql2 client 端序列化/解析 Date 用 +08:00
+//   - pool.afterCreate：每條連線的 MySQL session 也設成 +08:00
+// 用數字 offset 而非 "Asia/Taipei"，因為後者需要 MySQL 載入時區表，而台灣沒有日光節約。
+const TIMEZONE = "+08:00";
+
 const knex = require("knex")({
   client: "mysql2",
   connection: {
@@ -6,11 +22,33 @@ const knex = require("knex")({
     password: process.env.DB_USER_PASSWORD,
     port: process.env.DB_PORT,
     database: "Princess",
+    timezone: TIMEZONE,
   },
-  pool: { min: 0, max: 10 },
+  pool: {
+    min: 0,
+    max: 10,
+    afterCreate: (conn, done) => {
+      conn.query(`SET time_zone = '${TIMEZONE}'`, err => done(err, conn));
+    },
+  },
 });
 
 require("./queryProfiler").attach(knex);
+
+// 開機自檢：時區設錯是靜默的（查詢照跑、只是答案錯），所以在這裡吵一次。
+// 上一次就是因為沒人發現，過了幾天才從使用者回報追出來。
+knex
+  .raw("SELECT TIMEDIFF(NOW(), UTC_TIMESTAMP()) AS offset")
+  .then(([rows]) => {
+    const offset = String(rows[0].offset);
+    if (offset !== "08:00:00") {
+      DefaultLogger.error(
+        `db.timezone.mismatch expected=08:00:00 actual=${offset} — ` +
+          `每日/當天區間查詢會失準，請檢查 MySQL 時區設定`
+      );
+    }
+  })
+  .catch(err => DefaultLogger.warn(`db.timezone.check_failed ${err.message}`));
 
 /**
  * @returns { import("knex").Knex }


### PR DESCRIPTION
## 背景

使用者回報一天可以抽好幾次轉蛋。查線上資料**屬實**：近 7 天有 343 次超額抽卡，最嚴重的使用者單日抽了 162 次。

某位使用者的時間軸最能說明問題（台北時間）：

```
2026-08-03 00:03:28
2026-08-03 00:05:35
2026-08-03 00:14:33  ... 一路到 01:49:48（共 10 抽）
2026-08-03 10:26:22  ← 只有這一筆之後就停了
```

全部集中在凌晨 0～8 點，8 點之後就正常。

## 根因

7 月底搬到 EC2 後，prod 的 `mysql` container 少了 `TZ` 設定（bot 有、mysql 沒有），變成 **MySQL 跑 UTC、Node 跑 Asia/Taipei**。

```
prod mysql:  @@global.time_zone = SYSTEM,  NOW() == UTC_TIMESTAMP()
prod bot:    TZ: Asia/Taipei
```

mysql2 預設 `timezone: "local"`，會用 Node 本地時間把 JS `Date` 序列化成字串，MySQL 再用自己的 session 時區解讀 —— 兩邊差 8 小時。

於是 `detectCanDaily` 的 `whereBetween` 下界落後 8 小時，台北時間 00:00-07:59 之間查不到當天紀錄，`usedCount` 恆為 0，限制整段時間失效。

數據佐證（近 7 天超額抽卡按時段分）：

| 時段 | 超額次數 |
|---|---|
| 台北 00:00-07:59（防線失效） | **238** |
| 台北 08:00-23:59（防線正常） | 105 |

且確認是搬機後的 regression：該時段的超額數 7 月每天只有 1-5 筆，08-01 起跳到 10 / 3 / **186** / 39。

## 改動

**時區（主因）**

選擇讓 MySQL 講台北時間，而非讓 app 改講 UTC —— 因為 37 個 `datetime` 欄位存了 4 年的台北 wall-clock 字面值，`datetime` 不會隨 session 時區重新解讀，改走 UTC 得把 37 欄位 × 4 年全部 −8h 重寫。

- `connection.timezone: "+08:00"` + `pool.afterCreate` 的 `SET time_zone`，兩端都釘住
- **釘在程式碼而非 env var** —— 這次就是因為約定住在 repo 外的 compose 檔才出事
- 用數字 offset 而非 `Asia/Taipei`，免得依賴 MySQL 時區表（台灣無日光節約）
- 加開機自檢：`TIMEDIFF(NOW(), UTC_TIMESTAMP())` ≠ `08:00:00` 就 log ERROR。時區設錯是靜默的，這次拖了幾天才從使用者回報追出來

**`detectCanDaily` 三個既有缺陷**

- 過期訂閱不再給 bonus 額度（漏了 `start_at`/`end_at` 條件，月卡永久 +1、季卡永久 +2）
- 負向快取 TTL 從寫死的 60 秒改成算到當日結束（原註解寫「1 天」但程式是 `EX: 60`）
- 每日配額改用 Redis `NX` 搶佔 slot，擋掉 read-then-act 競態。DB count 仍是權威，Redis 被清空不會多發額度；抽卡失敗會釋放 claim

## 線上資料修復：不需要

`subscribe_user` / `coupon_code` / `gacha_banner` 在破窗期間（07-28 之後）**都是 0 筆**，沒有 entitlement 受影響。`subscribe_user` 全部 7 筆都是 4 月寫入，那時舊主機還是自洽的台北時區。

`timestamp` 欄位在部署後會「往前跳 8 小時」，但那是**修正**而非破壞 —— 會回到搬機前使用者看到的時間。

## Test plan

- [x] `yarn lint` 通過
- [x] `yarn test` 935/935 通過（與修改前 baseline 相同）
- [x] 時區行為實測：在 `TZ=Asia/Taipei` 下，台北午夜（`16:00Z`）現在 bind 成 `2026-08-04 00:00:00` 對上 `+08:00` session — 同一個瞬間
- [x] 驗證過 Moment 物件不能直接當 knex binding（會噴 `ER_WRONG_VALUE`），已確保傳入的是 `Date`
- [ ] 部署後確認 log 沒有 `db.timezone.mismatch`
- [ ] 部署後 24h 觀察：台北 00:00-07:59 的超額抽卡應回到 1-5 筆/天的 baseline

## 部署注意

CI 只 build image、沒有 CD，需要在 host 上手動 pull：

```bash
cd ~/stack && docker compose pull redive-bot redive-worker && \
  docker compose up -d redive-bot redive-worker
docker compose logs redive-bot | grep -i timezone   # 確認自檢沒噴 mismatch
```

建議（可選，belt-and-braces）：`~/stack/compose.yaml` 的 mysql service 補 `TZ: Asia/Taipei`。程式已不依賴它，但 phpMyAdmin 之類的 ad-hoc client 會受益。

另有一件商業決定待定：那 ~238 次超額抽卡的獎勵要不要回收。本 PR 未處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)