### PR TITLE
hotfix(gacha): 修正每日一抽訂閱查詢丟 ERR_ASSERTION

### DIFF
--- a/app/src/controller/princess/gacha.js
+++ b/app/src/controller/princess/gacha.js
@@ -282,17 +282,19 @@ async function detectCanDaily(userId) {
   // 注意：這裡必須傳 Date 而非 Moment。mysql2 不認得 Moment 物件，
   // 會序列化成 "Mon Aug 03 2026 ..." 而讓 MySQL 丟 ER_WRONG_VALUE。
   const nowDate = now.toDate();
-  const subscribeUser = await SubscribeUser.all({
-    filter: {
-      [SubscribeUser.getColumnName("user_id")]: userId,
-      [SubscribeUser.getColumnName("start_at")]: { operator: "<=", value: nowDate },
-      [SubscribeUser.getColumnName("end_at")]: { operator: ">", value: nowDate },
-    },
-  }).join(
-    SubscribeCard.table,
-    SubscribeCard.getColumnName("key"),
-    SubscribeUser.getColumnName("subscribe_card_key")
-  );
+  // 直接用 query builder，不走 base.all() 的 filter：後者以 lodash get(filter, `${key}.operator`)
+  // 取運算子，key 帶了 "table.column" 的點號時會被當成路徑解析而找不到 operator，
+  // 於是整個 {operator, value} 物件被當成值丟給 knex（ERR_ASSERTION）。
+  // 這裡有 join，欄位必須帶表名，所以改用明確的 where 三參數形式。
+  const subscribeUser = await SubscribeUser.knex
+    .where(SubscribeUser.getColumnName("user_id"), userId)
+    .andWhere(SubscribeUser.getColumnName("start_at"), "<=", nowDate)
+    .andWhere(SubscribeUser.getColumnName("end_at"), ">", nowDate)
+    .join(
+      SubscribeCard.table,
+      SubscribeCard.getColumnName("key"),
+      SubscribeUser.getColumnName("subscribe_card_key")
+    );
 
   const activeSubs = subscribeUser;
   const bonusCount = activeSubs.reduce((acc, data) => {


### PR DESCRIPTION
## 這是 #773 的 regression,線上目前每次每日一抽都會壞

#773 上線後(`stack-deploy.timer` 於 `17:18:10` 自動部署),線上每次 `#抽` 都噴:

```
AssertionError [ERR_ASSERTION]: The values in where clause must not be object or array.
    at Runner.ensureConnection (/usr/src/app/node_modules/knex/lib/execution/runner.js:324:20)
```

**影響比原本的 bug 更嚴重** —— 原本只是凌晨 0-8 點限制失效,現在是每日一抽整個功能不可用(會走進 `runDailyDraw` 的 catch,回覆錯誤訊息)。

## 根因

`base.all()` 用 lodash 取運算子:

```js
get(filter, `${key}.operator`, "=")
```

key 帶了 `subscribe_user.start_at` 這種點號時,lodash 會把它當成**路徑**解析(`filter → subscribe_user → start_at → operator`),找不到就回退成 `"="`,並把整個 `{operator, value}` 物件當成值丟給 knex,於是 assertion 失敗。

本機重現:

```
subscribe_user.user_id  | op= "="  | val= U123
subscribe_user.start_at | op= "="  | val= !!!OBJECT!!! {"operator":"<=","value":...}
```

`SubscriptionService.js` 用同樣的 filter 寫法沒事,是因為它的 key **不帶表名前綴**。這裡因為要 join `subscribe_card`,欄位必須帶表名才不會 ambiguous —— 兩者剛好衝突。

## 修法

改用 query builder 的三參數 `where`,直接繞過 filter 的路徑解析:

```js
SubscribeUser.knex
  .where(SubscribeUser.getColumnName("user_id"), userId)
  .andWhere(SubscribeUser.getColumnName("start_at"), "<=", nowDate)
  .andWhere(SubscribeUser.getColumnName("end_at"), ">", nowDate)
  .join(...)
```

行為與 `GachaService.getRemainingDailyQuota` 一致:只計入 `start_at <= now < end_at` 的訂閱。#773 修的三件事(時區、TTL、競態鎖)都不受影響。

## Test plan

- [x] `yarn lint` 通過
- [x] `yarn test` 920/920 通過(數字比 #773 的 935 少,是因為 Market 相關測試檔還在本機 stash,與本 PR 無關)
- [x] **實際對 DB 執行過**產生的 query,確認 SQL 合法且能跑:
      `select * from subscribe_user inner join subscribe_card on ... where subscribe_user.user_id = ? and subscribe_user.start_at <= ? and subscribe_user.end_at > ?`
- [x] grep 過整個 `app/` 確認沒有其他地方把帶表名的 key 當 filter 用
- [ ] 部署後確認 `#抽` 不再噴 ERR_ASSERTION

## 我的疏失

#773 review 時我抓到了 Moment binding 的問題(`ER_WRONG_VALUE`),卻沒有實際執行這個 query 形狀就放行。單元測試沒有涵蓋到 `detectCanDaily` 的訂閱分支(它沒有被 export),所以 CI 也綠燈通過。教訓是:改到 query 建構方式時,光看 diff 和跑既有測試不夠,要實際把 query 打到 DB 上跑一次 —— 這正是我在本 PR 做的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)