### PR TITLE
feat(chat-level): 新增「驚蟄」天氣，久違發言可獲得原始經驗爆發加成

### DIFF
--- a/app/__tests__/bin/EventDequeue.handleChatExp.test.js
+++ b/app/__tests__/bin/EventDequeue.handleChatExp.test.js
@@ -84,13 +84,15 @@ describe("EventDequeue.handleChatExp", () => {
     expect(payload.timeSinceLastMsg).toBe(3000);
   });
 
-  it("sets CHAT_TOUCH_TIMESTAMP_{userId} with 10s TTL", async () => {
+  // 48h: must exceed silence_burst's largest threshold (24h) so a long silence
+  // stays distinguishable from an expired marker — see handleChatExp.
+  it("sets CHAT_TOUCH_TIMESTAMP_{userId} with 48h TTL", async () => {
     redis.get.mockResolvedValue(null);
 
     await handleChatExp(groupTextEvent({ userId: "Uaaa", ts: 1700000000000 }));
 
     expect(redis.set).toHaveBeenCalledWith("CHAT_TOUCH_TIMESTAMP_Uaaa", "1700000000000", {
-      EX: 10,
+      EX: 172800,
     });
   });
 
@@ -103,7 +105,7 @@ describe("EventDequeue.handleChatExp", () => {
     await handleChatExp(groupTextEvent({ userId: "Uaaa", ts: 1700000000000 }));
 
     expect(redis.set).toHaveBeenCalledWith("CHAT_TOUCH_TIMESTAMP_Uaaa", "1700000000000", {
-      EX: 10,
+      EX: 172800,
     });
   });
 

--- a/app/bin/EventDequeue.js
+++ b/app/bin/EventDequeue.js
@@ -184,11 +184,9 @@ async function handleChatExp(botEvent) {
 
   const groupCount = await getGroupMemberCount(groupId);
 
-  // TTL 10s — must stay above the cooldown table's longest baseline tier
-  // (6s full-speed threshold) so the pipeline can always resolve the
-  // previous timestamp. The pre-M2 code used 5s which silently expired
-  // touch markers within the full-speed tier — spec line 88.
-  await redis.set(touchKey, String(currTS), { EX: 10 });
+  // TTL is determined by silence_burst's maximum threshold (24h), with 48h
+  // of headroom so long silences remain distinguishable from expired markers.
+  await redis.set(touchKey, String(currTS), { EX: 172800 });
 
   // Record the group this user was last active in. PrestigeService uses this
   // to route LIFF-originated broadcasts (trial_enter / prestige / awakening)

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -227,6 +227,18 @@
           "name": "熱鬧廣場",
           "flavorText": "人越多越熱鬧，話題被氣氛推著跑。",
           "effects": { "group_bonus_mult": 1.1 }
+        },
+        "dormant_thunder": {
+          "category": "buff",
+          "name": "驚蟄",
+          "flavorText": "雲層安靜地積蓄了很久，久到你以為不會響。",
+          "effects": {
+            "silence_burst": [
+              { "gapMs": 86400000, "mult": 10 },
+              { "gapMs": 21600000, "mult": 5 },
+              { "gapMs": 3600000, "mult": 2 }
+            ]
+          }
         }
       }
     }

--- a/app/src/service/chatXp/__tests__/computeEventXp.test.js
+++ b/app/src/service/chatXp/__tests__/computeEventXp.test.js
@@ -45,6 +45,28 @@ describe("computeEventXp", () => {
     expect(reduced.raw).toBeCloseTo(neutral.raw * 0.9, 5);
   });
 
+  it("silence_burst applies its highest raw multiplier after 24h", () => {
+    const neutral = computeEventXp(args());
+    const weather = computeEventXp(
+      args({
+        event: { timeSinceLastMsg: 86400000, groupCount: 1 },
+        effects: { silence_burst: [{ gapMs: 86400000, mult: 10 }] },
+      })
+    );
+    expect(weather.raw).toBeCloseTo(neutral.raw * 10, 5);
+  });
+
+  it("null silence uses the highest tier without NaN", () => {
+    const r = computeEventXp(
+      args({
+        event: { timeSinceLastMsg: null, groupCount: 1 },
+        effects: { silence_burst: [{ gapMs: 86400000, mult: 10 }] },
+      })
+    );
+    expect(r.raw).toBeCloseTo(computeEventXp(args()).raw * 10, 5);
+    expect(Number.isNaN(r.raw)).toBe(false);
+  });
+
   it("cooldown_required_mult>1 lengthens the window: a 5s gap drops below full rate", () => {
     // 5000ms < 6000 (t4_6) but >4000 (t2_4) → baseline rate 0.8 without weather.
     const neutral = computeEventXp(args({ event: { timeSinceLastMsg: 5000, groupCount: 1 } }));

--- a/app/src/service/chatXp/__tests__/weatherConfig.test.js
+++ b/app/src/service/chatXp/__tests__/weatherConfig.test.js
@@ -13,7 +13,7 @@ describe("chat_level.dailyWeather config", () => {
     const pool = cfg.pool;
     const entries = Object.values(pool);
     expect(entries.filter(w => w.category === "debuff")).toHaveLength(3);
-    expect(entries.filter(w => w.category === "buff")).toHaveLength(4);
+    expect(entries.filter(w => w.category === "buff")).toHaveLength(5);
     for (const w of entries) {
       expect(w.name && w.flavorText && w.effects).toBeTruthy();
       if (w.category === "debuff") expect(w.protectionType).toBeTruthy();

--- a/app/src/service/chatXp/__tests__/weatherEffects.test.js
+++ b/app/src/service/chatXp/__tests__/weatherEffects.test.js
@@ -1,6 +1,7 @@
 const {
   resolveEffectiveEffects,
   mult,
+  silenceMult,
   pickWeather,
   describeEffects,
 } = require("../weatherEffects");
@@ -61,6 +62,24 @@ describe("mult", () => {
   });
 });
 
+describe("silenceMult", () => {
+  const effects = {
+    silence_burst: [
+      { gapMs: 86400000, mult: 10 },
+      { gapMs: 21600000, mult: 5 },
+      { gapMs: 3600000, mult: 2 },
+    ],
+  };
+
+  it("null uses the highest tier", () => expect(silenceMult(effects, null)).toBe(10));
+  it("matches a tier at its exact boundary", () => expect(silenceMult(effects, 21600000)).toBe(5));
+  it("returns identity below the smallest tier", () =>
+    expect(silenceMult(effects, 3599999)).toBe(1));
+  it("returns identity without silence_burst", () => expect(silenceMult({}, 86400000)).toBe(1));
+  it("returns identity for an empty tier list", () =>
+    expect(silenceMult({ silence_burst: [] }, 86400000)).toBe(1));
+});
+
 describe("pickWeather", () => {
   // pool order: 3 debuff then 3 buff; weights buff:60 debuff:40 → categories ["debuff","buff"]
   const pool = {
@@ -104,6 +123,14 @@ describe("describeEffects", () => {
   it("renders exp_to_stone_rate as a conversion ratio, not a percentage", () => {
     // (value - 1) * 100 would have printed "+4900%" for a rate of 50.
     expect(describeEffects({ exp_to_stone_rate: 50 })).toEqual(["經驗轉女神石 50:1"]);
+  });
+  it("renders silence_burst as its highest multiplier without NaN", () => {
+    expect(describeEffects({ silence_burst: [{ gapMs: 86400000, mult: 10 }] })).toEqual([
+      "久違發言 最高 ×10",
+    ]);
+    expect(describeEffects({ silence_burst: [{ gapMs: 86400000, mult: 10 }] })[0]).not.toContain(
+      "NaN"
+    );
   });
   it("does not render the alchemy daily cap as an effect", () => {
     expect(describeEffects({ exp_to_stone_rate: 1, exp_to_stone_daily_cap: 100000 })).toEqual([

--- a/app/src/service/chatXp/computeEventXp.js
+++ b/app/src/service/chatXp/computeEventXp.js
@@ -5,7 +5,7 @@ const { computeGroupBonus } = require("./groupBonus");
 const { computePerMsgXp } = require("./perMsgXp");
 const { applyDiminish } = require("./diminishTier");
 const { applyTrialAndPermanent } = require("./trialAndPermanent");
-const { mult } = require("./weatherEffects");
+const { mult, silenceMult } = require("./weatherEffects");
 
 /**
  * Pure per-message XP computation. `effects` is the effective weather effect map
@@ -34,7 +34,7 @@ function computeEventXp({
     groupBonus,
     status: state,
   });
-  const raw = rawBase * mult(effects, "raw_xp_mult");
+  const raw = rawBase * mult(effects, "raw_xp_mult") * silenceMult(effects, event.timeSinceLastMsg);
 
   const honeymoonMult = state.prestige_count === 0 ? 1.2 : 1.0;
   const scaledIncoming = raw * honeymoonMult;

--- a/app/src/service/chatXp/weatherEffects.js
+++ b/app/src/service/chatXp/weatherEffects.js
@@ -8,6 +8,7 @@ const EFFECT_LABELS = {
   effective_xp_mult: "最終經驗",
   group_bonus_mult: "群組加成",
   exp_to_stone_rate: "經驗轉女神石",
+  silence_burst: "久違發言",
 };
 
 /**
@@ -30,6 +31,18 @@ function resolveEffectiveEffects(weather, protection, eventTs) {
 function mult(effects, field) {
   const v = effects && effects[field];
   return typeof v === "number" && v > 0 ? v : EFFECT_IDENTITY;
+}
+
+function silenceMult(effects, timeSinceLastMsg) {
+  const tiers = effects && effects.silence_burst;
+  if (!Array.isArray(tiers) || tiers.length === 0) return EFFECT_IDENTITY;
+  // null = 沉默超過 touch key 的 TTL（見 EventDequeue handleChatExp）→ 視為最高階。
+  const gap = timeSinceLastMsg == null ? Infinity : timeSinceLastMsg;
+  // ponytail: 依賴 config 中 tiers 由大到小排序，不在每則訊息重複排序。
+  for (const t of tiers) {
+    if (gap >= t.gapMs) return t.mult > 0 ? t.mult : EFFECT_IDENTITY;
+  }
+  return EFFECT_IDENTITY;
 }
 
 /**
@@ -83,9 +96,20 @@ function describeEffects(effects) {
       // Not a multiplier: it's a conversion ratio (N exp → 1 stone), so the
       // ×-1-as-percentage formatting below would render nonsense (+4900%).
       if (field === "exp_to_stone_rate") return `${label} ${value}:1`;
+      if (field === "silence_burst") {
+        const top = Math.max(...value.map(t => t.mult));
+        return `${label} 最高 ×${top}`;
+      }
       const pct = Math.round((value - 1) * 100);
       return `${label} ${pct >= 0 ? `+${pct}` : pct}%`;
     });
 }
 
-module.exports = { resolveEffectiveEffects, mult, pickWeather, describeEffects, EFFECT_IDENTITY };
+module.exports = {
+  resolveEffectiveEffects,
+  mult,
+  silenceMult,
+  pickWeather,
+  describeEffects,
+  EFFECT_IDENTITY,
+};

--- a/app/src/templates/application/Weather.js
+++ b/app/src/templates/application/Weather.js
@@ -68,7 +68,11 @@ function generateWeatherBubble({
       body.push(textNode("今日為減益天氣。", MUTED_NOTE));
     }
   } else {
-    body.push(textNode("今日為增益天氣，無需防護。", MUTED_NOTE));
+    if (weather.effects?.silence_burst) {
+      body.push(textNode("越久沒發言，下一句的經驗越重。", MUTED_NOTE));
+    } else {
+      body.push(textNode("今日為增益天氣，無需防護。", MUTED_NOTE));
+    }
   }
 
   const needsProtection = isDebuff && !isProtected && purchaseEnabled;

--- a/frontend/src/pages/XpHistory/About.jsx
+++ b/frontend/src/pages/XpHistory/About.jsx
@@ -130,6 +130,21 @@ export default function XpHistoryAbout() {
         </Typography>
       </Section>
 
+      <Section title="天氣「驚蟄」">
+        <Term name="說明">距離上次發言越久，下一則訊息的原始 XP 倍率越高。</Term>
+        <Stack gap={0.5}>
+          <Row k="超過 24 小時" v="×10" />
+          <Row k="超過 6 小時" v="×5" />
+          <Row k="超過 1 小時" v="×2" />
+        </Stack>
+        <Typography variant="caption" color="text.secondary">
+          倍率只作用在觸發的那一則訊息。
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          爆發拿到的原始 XP 一樣會推進今日遞減進度，因此爆發之後的發言收益會明顯下降。
+        </Typography>
+      </Section>
+
       <Section title="實得 XP 後續加成">
         <Term name="蜜月">
           轉生次數 = 0 時自動 ×1.2。轉生一次後解除（讓老玩家不會永遠領蜜月）。

--- a/frontend/src/pages/XpHistory/weatherLabels.js
+++ b/frontend/src/pages/XpHistory/weatherLabels.js
@@ -4,6 +4,7 @@ const SHORT = {
   effective_xp_mult: "最終",
   group_bonus_mult: "群組",
   exp_to_stone_rate: "經驗轉女神石",
+  silence_burst: "久違發言",
 };
 const FULL = {
   cooldown_required_mult: "冷卻時間需求",
@@ -11,6 +12,7 @@ const FULL = {
   effective_xp_mult: "最終經驗",
   group_bonus_mult: "群組加成",
   exp_to_stone_rate: "經驗轉女神石",
+  silence_burst: "久違發言",
 };
 
 // Internal safety rail, never a player-facing effect. Mirrors the same filter in
@@ -31,6 +33,9 @@ export function weatherEffectLabels(effects, { full = false } = {}) {
       // would render nonsense (1 → +0%, 50 → +4900%).
       if (k === "exp_to_stone_rate") {
         return Number(v) === 1 ? `${map[k]} 1:1` : `${map[k]} ${v}:1`;
+      }
+      if (k === "silence_burst") {
+        return `${map[k]} 最高 ×${Math.max(...v.map(({ mult }) => mult))}`;
       }
       return `${map[k] || k} ${effectPct(v)}`;
     });


### PR DESCRIPTION
## Summary

新增 buff 天氣 `dormant_thunder`（驚蟄）。距離上次發言越久，該則訊息的**原始經驗**倍率越高：

| 沉默時間 | 倍率 |
|---|---|
| 超過 24 小時 | ×10 |
| 超過 6 小時 | ×5 |
| 超過 1 小時 | ×2 |

### 設計取捨

**倍率套在 raw 階段而非 effective。** `diminishTier` 的每日分段遞減（0~400 ×1.0、400~1000 ×0.3、之後 ×0.03）會自然封頂，不需要額外的次數上限或 DB 欄位。

實際數字：沉默 24h 的第一句 raw = 900 → 分段遞減後 effective ≈ 550。對照整天狂聊 200 句約 1090。單句拿到約半天份，但不會失控。

**機制天生只獎勵潛水玩家。** 爆發的 raw 一樣會把當日遞減 cursor 推到 900，後續發言直接掉進 tier3（×0.03）。所以活躍玩家觸發爆發幾乎沒有淨收益，不需要另做防濫用機制。

**`CHAT_TOUCH_TIMESTAMP` TTL 由 10s 延長至 48h。** 原本超過 10 秒的間隔一律變成 `null`，無法分辨「隔 11 秒」與「隔 3 天」。此改動對既有計算為中性——`selectCooldownRate` 對 `null` 與任何 > 6000 的值都回傳 1.0。`null`（沉默超過 TTL，或 redis 重啟）視為最高階。

### 改動

- `app/config/default.json` — 新增 `dormant_thunder` 天氣定義
- `app/src/service/chatXp/weatherEffects.js` — `silenceMult()` + `describeEffects` 陣列分支
- `app/src/service/chatXp/computeEventXp.js` — 於 raw 階段套用
- `app/bin/EventDequeue.js` — touch key TTL 10s → 48h
- `app/src/templates/application/Weather.js` — Flex bubble 機制提示
- `frontend/src/pages/XpHistory/weatherLabels.js` — 陣列型 effects 分支（避免被當倍率算成 NaN）
- `frontend/src/pages/XpHistory/About.jsx` — 說明頁公開三階門檻

## Test plan

- [x] `cd app && yarn test` — 930 passed / 119 suites
- [x] `cd app && yarn lint`
- [x] `cd frontend && yarn lint`
- [x] `silenceMult` 邊界：null、剛好等於門檻、低於最小門檻、無 effects、空陣列
- [x] `describeEffects` 產出 `久違發言 最高 ×10` 且非 NaN
- [ ] 手動：LIFF 說明頁排版
- [ ] 手動：`#今天天氣` Flex bubble（需等抽到驚蟄，或本地改權重）

## Notes

- **無需 migration、無新環境變數、無新套件。** `app/config/default.json` 有改動，部署時隨 image 帶上即可。
- `#今天天氣` 指令本身也是一則計分訊息（`handleChatExp` 不過濾指令，與 `handleTopicAnalysis` 不同），所以潛水後查天氣會由該指令觸發爆發。總量不變，屬風味錯位而非平衡問題，此 PR 不處理。
- 經驗歷程的事件 chip 顯示的是天氣最高階（×10），非該則訊息實際吃到的倍率——`chat_exp_events` 未存 `timeSinceLastMsg`。行為與其他天氣一致，但可能誤導，後續可考慮加欄位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)