### PR TITLE
feat(signin): 新增補簽月曆與簽到成就支援

### DIFF
--- a/app/__tests__/api/signins.test.js
+++ b/app/__tests__/api/signins.test.js
@@ -1,0 +1,137 @@
+const request = require("supertest");
+const createApp = require("../helpers/createApp");
+
+jest.mock("../../src/service/SigninService", () => ({
+  getCalendar: jest.fn(),
+  makeup: jest.fn(),
+}));
+
+const SigninService = require("../../src/service/SigninService");
+
+const USER_ID = "U" + "a".repeat(32);
+
+const PAYLOAD = {
+  month: "2026-08",
+  today: "2026-08-07",
+  daysInMonth: 31,
+  makeupCost: 20000,
+  godStoneBalance: 51000,
+  entries: [{ date: "2026-08-06", source: "normal", costStones: 0 }],
+  stats: { streak: 1, total: 12, monthCount: 1, fullMonth: false },
+};
+
+let app;
+beforeAll(() => {
+  app = createApp();
+});
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/me/signins", () => {
+  it("returns the calendar payload for the token's own userId", async () => {
+    SigninService.getCalendar.mockResolvedValue(PAYLOAD);
+
+    const res = await request(app).get("/api/me/signins").set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(PAYLOAD);
+    expect(SigninService.getCalendar).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it("carries every documented top-level key", async () => {
+    SigninService.getCalendar.mockResolvedValue(PAYLOAD);
+
+    const res = await request(app).get("/api/me/signins").set("Authorization", "Bearer t");
+
+    expect(Object.keys(res.body).sort()).toEqual(
+      ["month", "today", "daysInMonth", "makeupCost", "godStoneBalance", "entries", "stats"].sort()
+    );
+  });
+
+  it("500s on an unexpected service failure", async () => {
+    SigninService.getCalendar.mockRejectedValue(new Error("db down"));
+
+    const res = await request(app).get("/api/me/signins").set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error" });
+  });
+});
+
+describe("POST /api/me/signins/makeup", () => {
+  it("returns the refreshed payload plus ok/created on success", async () => {
+    SigninService.makeup.mockResolvedValue({ ok: true, date: "2026-08-05", cost: 20000 });
+    SigninService.getCalendar.mockResolvedValue(PAYLOAD);
+
+    const res = await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({ date: "2026-08-05" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ...PAYLOAD,
+      ok: true,
+      created: { date: "2026-08-05", cost: 20000 },
+    });
+    expect(SigninService.makeup).toHaveBeenCalledWith(USER_ID, "2026-08-05");
+  });
+
+  it("never trusts a userId supplied in the body", async () => {
+    SigninService.makeup.mockResolvedValue({ ok: true, date: "2026-08-05", cost: 20000 });
+    SigninService.getCalendar.mockResolvedValue(PAYLOAD);
+
+    await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({ date: "2026-08-05", userId: "Uvictim", user_id: "Uvictim" });
+
+    expect(SigninService.makeup).toHaveBeenCalledWith(USER_ID, "2026-08-05");
+  });
+
+  it.each([
+    ["INVALID_DATE", 400],
+    ["NOT_CURRENT_MONTH", 400],
+    ["DATE_NOT_PAST", 400],
+    ["INSUFFICIENT_STONES", 400],
+    ["ALREADY_SIGNED", 409],
+  ])("maps %s to HTTP %i with the code in the body", async (code, status) => {
+    SigninService.makeup.mockResolvedValue({ ok: false, code });
+
+    const res = await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({ date: "2026-08-05" });
+
+    expect(res.status).toBe(status);
+    expect(res.body.code).toBe(code);
+    expect(typeof res.body.message).toBe("string");
+    // 失敗時不得回傳月曆 payload（前端才不會誤以為補簽成功）
+    expect(res.body.entries).toBeUndefined();
+    expect(SigninService.getCalendar).not.toHaveBeenCalled();
+  });
+
+  it("400s with the code when the body has no date at all", async () => {
+    SigninService.makeup.mockResolvedValue({ ok: false, code: "INVALID_DATE" });
+
+    const res = await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_DATE");
+    expect(SigninService.makeup).toHaveBeenCalledWith(USER_ID, undefined);
+  });
+
+  it("500s on an unexpected service failure", async () => {
+    SigninService.makeup.mockRejectedValue(new Error("boom"));
+
+    const res = await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({ date: "2026-08-05" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error" });
+  });
+});

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -460,6 +460,199 @@ describe("AchievementEngine", () => {
     });
   });
 
+  describe("dynamic signin definitions", () => {
+    // 這些成就完全由 DB row 驅動：key 不出現在 EVENT_ACHIEVEMENT_MAP、也沒有
+    // 專屬 strategy。條件與門檻只存在資料庫，程式碼不洩漏。
+    const makeDef = (metric, target, extra = {}) => ({
+      id: 900,
+      key: "a_secret_key_not_in_code",
+      target_value: target,
+      reward_stones: 0,
+      condition: { event: "signin", metric, ...extra },
+    });
+
+    beforeEach(() => {
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map());
+      UserAchievementModel.unlock.mockResolvedValue();
+      UserProgressModel.delete.mockResolvedValue();
+      mysql.mockImplementation(() => ({
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+        insert: jest.fn().mockResolvedValue(),
+      }));
+    });
+
+    afterEach(() => {
+      // 還原預設 chain，否則後面的 getUserSummary 會繼承這裡的 mysql override
+      mysql.mockImplementation(() => ({
+        insert: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        whereIn: jest.fn().mockReturnThis(),
+        update: jest.fn().mockResolvedValue(1),
+        first: jest.fn().mockResolvedValue(undefined),
+        select: jest.fn().mockReturnThis(),
+      }));
+    });
+
+    it("tracks streak from context and unlocks at target", async () => {
+      AchievementEngine._setCache([makeDef("streak", 7)]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", {
+        source: "normal",
+        date: "2026-08-07",
+        streak: 7,
+        total: 20,
+        monthCount: 7,
+        daysInMonth: 31,
+        fullMonth: false,
+      });
+
+      expect(result.unlocked.map(a => a.id)).toEqual([900]);
+    });
+
+    it("records streak progress without unlocking below target", async () => {
+      AchievementEngine._setCache([makeDef("streak", 30)]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 5 });
+
+      expect(result.unlocked).toEqual([]);
+      expect(UserProgressModel.upsertMany).toHaveBeenCalledWith([
+        { userId: "Ualice", achievementId: 900, currentValue: 5 },
+      ]);
+    });
+
+    it("tracks total independently of streak", async () => {
+      AchievementEngine._setCache([makeDef("total", 100)]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", {
+        streak: 1,
+        total: 100,
+      });
+
+      expect(result.unlocked.map(a => a.id)).toEqual([900]);
+    });
+
+    it("full_month unlocks only when fullMonth is true", async () => {
+      AchievementEngine._setCache([makeDef("full_month", 1)]);
+
+      const miss = await AchievementEngine.evaluate("Ualice", "signin", {
+        fullMonth: false,
+        monthCount: 30,
+        daysInMonth: 31,
+      });
+      expect(miss.unlocked).toEqual([]);
+
+      const hit = await AchievementEngine.evaluate("Ualice", "signin", {
+        fullMonth: true,
+        monthCount: 31,
+        daysInMonth: 31,
+      });
+      expect(hit.unlocked.map(a => a.id)).toEqual([900]);
+    });
+
+    it("treats makeup signins the same as normal ones", async () => {
+      AchievementEngine._setCache([makeDef("streak", 3)]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", {
+        source: "makeup",
+        streak: 3,
+      });
+
+      expect(result.unlocked.map(a => a.id)).toEqual([900]);
+    });
+
+    it("skips and warns on an unknown metric instead of throwing", async () => {
+      AchievementEngine._setCache([makeDef("phase_of_the_moon", 1)]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 99 });
+
+      expect(result.unlocked).toEqual([]);
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
+      expect(DefaultLogger.warn).toHaveBeenCalledWith(expect.stringContaining("phase_of_the_moon"));
+    });
+
+    it("still honours the eligibility gate for condition-driven rows", async () => {
+      AchievementEngine._setCache([
+        makeDef("streak", 1, { eligibility: { excludeUserIds: ["Ualice"] } }),
+      ]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 10 });
+
+      expect(result.unlocked).toEqual([]);
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
+    });
+
+    it("ignores definitions whose condition.event names a different event", async () => {
+      AchievementEngine._setCache([
+        { ...makeDef("streak", 1), condition: { event: "janken_win", metric: "streak" } },
+      ]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 10 });
+
+      expect(result.unlocked).toEqual([]);
+    });
+
+    it("does not let a condition-driven row hijack a key that has its own strategy", async () => {
+      // gacha_first 有專屬 strategy（instant，永遠回 target_value）。
+      // 即使 DB row 把 condition.event 設成 signin，它也只能由 gacha_pull 觸發：
+      // 否則 instant 會在簽到時無條件解鎖一個轉蛋成就。
+      const hijacked = {
+        id: 901,
+        key: "gacha_first",
+        target_value: 1,
+        reward_stones: 0,
+        condition: { event: "signin", metric: "streak" },
+      };
+      AchievementEngine._setCache([hijacked]);
+
+      const viaSignin = await AchievementEngine.evaluate("Ualice", "signin", {
+        source: "normal",
+        streak: 1,
+      });
+      expect(viaSignin.unlocked).toEqual([]);
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
+      expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
+
+      // 原本的 gacha 路徑不受影響。
+      const viaGacha = await AchievementEngine.evaluate("Ualice", "gacha_pull", {});
+      expect(viaGacha.unlocked.map(a => a.id)).toEqual([901]);
+    });
+
+    it("keeps a hardcoded key off a foreign event that happens to share a context field", async () => {
+      // janken_streak_5 的 strategy 讀 context.streak —— 簽到 context 剛好也有 streak。
+      // 這是最危險的重疊：若被誤選中，簽到連續天數會直接灌進猜拳連勝進度。
+      AchievementEngine._setCache([
+        {
+          id: 902,
+          key: "janken_streak_5",
+          target_value: 5,
+          reward_stones: 0,
+          condition: { event: "signin", metric: "streak" },
+        },
+      ]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", {
+        source: "normal",
+        streak: 9,
+        total: 9,
+      });
+
+      expect(result.unlocked).toEqual([]);
+      expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
+      expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
+    });
+
+    it("still evaluates condition-driven rows whose key has no hardcoded strategy", async () => {
+      // 排除規則只針對「已有 strategy 的 key」，不能誤傷正常的 DB 驅動成就。
+      AchievementEngine._setCache([makeDef("streak", 3)]);
+
+      const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 3 });
+
+      expect(result.unlocked.map(a => a.id)).toEqual([900]);
+    });
+  });
+
   describe("getUserSummary", () => {
     it("should return structured summary", async () => {
       AchievementModel.allWithCategories.mockResolvedValue([

--- a/app/__tests__/service/GachaService.test.js
+++ b/app/__tests__/service/GachaService.test.js
@@ -56,10 +56,9 @@ jest.mock("../../src/model/princess/GachaRecord", () => ({
 jest.mock("../../src/model/princess/GachaRecordDetail", () => ({
   table: "gacha_record_detail",
 }));
-jest.mock("../../src/model/application/SigninDays", () => ({
-  first: jest.fn().mockResolvedValue(null),
-  create: jest.fn().mockResolvedValue(undefined),
-  update: jest.fn().mockResolvedValue(undefined),
+jest.mock("../../src/service/SigninService", () => ({
+  recordNormal: jest.fn(),
+  evaluateAchievements: jest.fn().mockResolvedValue({ unlocked: [] }),
 }));
 
 jest.mock("../../src/service/EventCenterService", () => ({
@@ -90,7 +89,7 @@ const GachaService = require("../../src/service/GachaService");
 const mysql = require("../../src/util/mysql");
 const EventCenterService = require("../../src/service/EventCenterService");
 const AchievementEngine = require("../../src/service/AchievementEngine");
-const signModel = require("../../src/model/application/SigninDays");
+const signinService = require("../../src/service/SigninService");
 
 function makePool() {
   return [
@@ -112,6 +111,8 @@ describe("GachaService.runDailyDraw", () => {
     );
     GachaModel.getDatabasePool.mockResolvedValue(makePool());
     GachaBanner.getActiveBannersWithCharacters.mockResolvedValue([]);
+    signinService.recordNormal.mockResolvedValue({ created: true, date: "2026-08-07" });
+    signinService.evaluateAchievements.mockResolvedValue({ unlocked: [] });
   });
 
   it("returns plain-data shape with exactly the seven documented keys", async () => {
@@ -147,10 +148,11 @@ describe("GachaService.runDailyDraw", () => {
     expect(result).not.toHaveProperty("message");
   });
 
-  it("invokes handleSignin, EventCenterService.add, AchievementEngine.evaluate with the contract args", async () => {
+  it("invokes recordNormal, EventCenterService.add, AchievementEngine.evaluate with the contract args", async () => {
     await GachaService.runDailyDraw("Uabc");
 
-    expect(signModel.first).toHaveBeenCalledWith({ filter: { user_id: "Uabc" } });
+    expect(signinService.recordNormal).toHaveBeenCalledTimes(1);
+    expect(signinService.recordNormal).toHaveBeenCalledWith("Uabc", { trx: currentTrx });
 
     expect(EventCenterService.add).toHaveBeenCalledTimes(1);
     expect(EventCenterService.add).toHaveBeenCalledWith("event_center:daily_quest", {
@@ -164,6 +166,53 @@ describe("GachaService.runDailyDraw", () => {
     expect(metaArg).toHaveProperty("threeStarCount");
     expect(metaArg).toHaveProperty("uniqueCount");
     expect(metaArg).toHaveProperty("pullType");
+  });
+
+  describe("signin integration", () => {
+    it("records the signin inside the same transaction as the gacha writes", async () => {
+      await GachaService.runDailyDraw("Utx");
+
+      // 同一個 trx 物件 = 同一筆交易；轉蛋回滾時簽到跟著消失。
+      const [, opts] = signinService.recordNormal.mock.calls[0];
+      expect(opts.trx).toBe(currentTrx);
+      expect(txInserts.some(t => t.table === "gacha_record")).toBe(true);
+    });
+
+    it("evaluates the signin achievement only when a new ledger row was created", async () => {
+      await GachaService.runDailyDraw("Ufirst");
+      expect(signinService.evaluateAchievements).toHaveBeenCalledWith("Ufirst", {
+        source: "normal",
+        date: "2026-08-07",
+      });
+    });
+
+    it("skips signin achievement evaluation when the day was already signed", async () => {
+      signinService.recordNormal.mockResolvedValue({ created: false, date: "2026-08-07" });
+
+      await GachaService.runDailyDraw("Usecond");
+
+      expect(signinService.evaluateAchievements).not.toHaveBeenCalled();
+      // 轉蛋成就仍照跑 —— 每日額度內的第二抽不該被簽到狀態影響。
+      expect(AchievementEngine.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it("merges signin unlocks with gacha unlocks in the returned unlocks array", async () => {
+      AchievementEngine.evaluate.mockResolvedValue({ unlocked: [{ key: "gacha_first" }] });
+      signinService.evaluateAchievements.mockResolvedValue({
+        unlocked: [{ key: "signin_secret" }],
+      });
+
+      const result = await GachaService.runDailyDraw("Umerge");
+
+      expect(result.unlocks.map(u => u.key)).toEqual(["gacha_first", "signin_secret"]);
+    });
+
+    it("still returns a result when signin achievement evaluation yields nothing", async () => {
+      AchievementEngine.evaluate.mockResolvedValue({ unlocked: [] });
+      signinService.evaluateAchievements.mockResolvedValue({ unlocked: undefined });
+      const result = await GachaService.runDailyDraw("Uempty");
+      expect(result.unlocks).toEqual([]);
+    });
   });
 
   it("writes one GachaRecord row and one GachaRecordDetail row per pulled character", async () => {

--- a/app/__tests__/service/SigninService.test.js
+++ b/app/__tests__/service/SigninService.test.js
@@ -1,0 +1,378 @@
+// SigninService — 日期規則 / streak / 扣款 / 重複簽到。
+// 只 mock 到 knex 邊界（util/mysql 由全域 setup 提供 mock builder 的形狀概念），
+// 這裡用一個小型 in-memory 假資料庫，讓交易語意（回滾 = 不留任何列）可被驗證。
+
+const TODAY = "2026-08-07"; // 星期五，8 月有 31 天
+
+jest.mock("../../src/util/date", () => ({
+  todayUtc8: () => "2026-08-07",
+  yesterdayUtc8: () => "2026-08-06",
+  toUtc8Date: d => d,
+  daysAgoUtc8: jest.fn(),
+}));
+
+jest.mock("../../src/model/princess/gacha", () => ({
+  getUserGodStoneCount: jest.fn().mockResolvedValue(0),
+}));
+
+jest.mock("../../src/service/AchievementEngine", () => ({
+  evaluate: jest.fn().mockResolvedValue({ unlocked: [] }),
+}));
+
+// --- 極簡 in-memory knex 替身 ------------------------------------------------
+// 只支援本 service 用到的呼叫形狀。不是通用 knex 模擬器，壞掉會直接噴錯而不是
+// 靜默回錯答案，這正是我們要的。
+const db = { signin_ledger: [], inventory: [] };
+let nextId = 1;
+let failNextLedgerInsert = null;
+
+function makeBuilder(table, staged) {
+  const state = { table, wheres: [], raws: [] };
+  const rows = () => staged[table];
+
+  const matches = row =>
+    state.wheres.every(w => {
+      if (w.op === "=") return String(row[w.col]) === String(w.value);
+      if (w.op === ">=") return String(row[w.col]) >= String(w.value);
+      if (w.op === "<=") return String(row[w.col]) <= String(w.value);
+      return false;
+    });
+
+  const builder = {
+    where(arg, op, value) {
+      if (typeof arg === "object") {
+        Object.entries(arg).forEach(([col, v]) => state.wheres.push({ col, op: "=", value: v }));
+      } else if (value === undefined) {
+        state.wheres.push({ col: arg, op: "=", value: op });
+      } else {
+        state.wheres.push({ col: arg, op, value });
+      }
+      return builder;
+    },
+    andWhere(...args) {
+      return builder.where(...args);
+    },
+    orderBy() {
+      return builder;
+    },
+    forUpdate() {
+      return builder;
+    },
+    select() {
+      // 回傳 builder 本身（thenable），才能接 .forUpdate()；await 時才真的求值。
+      return builder;
+    },
+    first() {
+      const found = rows().find(matches);
+      return Promise.resolve(found ? { ...found } : undefined);
+    },
+    insert(payload) {
+      const list = Array.isArray(payload) ? payload : [payload];
+      if (table === "signin_ledger") {
+        if (failNextLedgerInsert) {
+          const err = failNextLedgerInsert;
+          failNextLedgerInsert = null;
+          return Promise.reject(err);
+        }
+        for (const row of list) {
+          const dup = rows().some(
+            r => r.user_id === row.user_id && r.signin_date === row.signin_date
+          );
+          if (dup) {
+            const err = new Error("Duplicate entry");
+            err.code = "ER_DUP_ENTRY";
+            return Promise.reject(err);
+          }
+        }
+      }
+      list.forEach(row => rows().push({ id: nextId++, ...row }));
+      return Promise.resolve([nextId - 1]);
+    },
+    then(resolve, reject) {
+      // service 用 DATE_FORMAT alias 取回字串日期；假資料本來就存字串。
+      const found = rows()
+        .filter(matches)
+        .map(r => ({ ...r }));
+      return Promise.resolve(found).then(resolve, reject);
+    },
+  };
+  return builder;
+}
+
+jest.mock("../../src/util/mysql", () => {
+  const knex = jest.fn(table => makeBuilder(table, knex._staged || db));
+  knex.raw = jest.fn(sql => sql);
+  knex.transaction = jest.fn(async cb => {
+    // 交易 = 對快照操作，成功才 merge 回主資料；失敗整批丟棄。
+    const staged = {
+      signin_ledger: db.signin_ledger.map(r => ({ ...r })),
+      inventory: db.inventory.map(r => ({ ...r })),
+    };
+    const trx = jest.fn(table => makeBuilder(table, staged));
+    // 成功才 merge 回主資料；失敗時 staged 直接丟棄 = 回滾。
+    const result = await cb(trx);
+    db.signin_ledger = staged.signin_ledger;
+    db.inventory = staged.inventory;
+    return result;
+  });
+  return knex;
+});
+
+const SigninService = require("../../src/service/SigninService");
+const AchievementEngine = require("../../src/service/AchievementEngine");
+
+function seedSignins(userId, dates, source = "normal") {
+  dates.forEach(date =>
+    db.signin_ledger.push({
+      id: nextId++,
+      user_id: userId,
+      signin_date: date,
+      source,
+      cost_stones: 0,
+    })
+  );
+}
+
+function seedStones(userId, amount) {
+  db.inventory.push({ id: nextId++, userId, itemId: 999, itemAmount: amount });
+}
+
+const stoneRows = userId => db.inventory.filter(r => r.userId === userId && r.itemId === 999);
+const balanceOf = userId => stoneRows(userId).reduce((a, r) => a + r.itemAmount, 0);
+
+beforeEach(() => {
+  db.signin_ledger = [];
+  db.inventory = [];
+  nextId = 1;
+  failNextLedgerInsert = null;
+  jest.clearAllMocks();
+});
+
+describe("computeStreak", () => {
+  const streak = dates => SigninService._computeStreak(dates, TODAY);
+
+  it("counts back from today when today is signed", () => {
+    expect(streak(["2026-08-07", "2026-08-06", "2026-08-05"])).toBe(3);
+  });
+
+  it("counts back from yesterday when today is not signed yet", () => {
+    expect(streak(["2026-08-06", "2026-08-05"])).toBe(2);
+  });
+
+  it("is 0 when neither today nor yesterday is signed", () => {
+    expect(streak(["2026-08-05", "2026-08-04"])).toBe(0);
+  });
+
+  it("is 0 on an empty ledger", () => {
+    expect(streak([])).toBe(0);
+  });
+
+  it("stops at the first gap", () => {
+    expect(streak(["2026-08-07", "2026-08-06", "2026-08-04", "2026-08-03"])).toBe(2);
+  });
+
+  it("crosses a month boundary", () => {
+    expect(streak(["2026-08-02", "2026-08-01", "2026-07-31"])).toBe(0);
+    expect(
+      SigninService._computeStreak(["2026-08-02", "2026-08-01", "2026-07-31"], "2026-08-02")
+    ).toBe(3);
+  });
+});
+
+describe("recordNormal", () => {
+  it("inserts a normal row and reports created", async () => {
+    const res = await SigninService.recordNormal("Ualice");
+    expect(res).toEqual({ created: true, date: TODAY });
+    expect(db.signin_ledger).toHaveLength(1);
+    expect(db.signin_ledger[0]).toMatchObject({ source: "normal", cost_stones: 0 });
+  });
+
+  it("is idempotent for the same day (no duplicate row, created=false)", async () => {
+    await SigninService.recordNormal("Ualice");
+    const res = await SigninService.recordNormal("Ualice");
+    expect(res.created).toBe(false);
+    expect(db.signin_ledger).toHaveLength(1);
+  });
+
+  it("swallows a unique-key collision from a racing writer", async () => {
+    const err = new Error("dup");
+    err.code = "ER_DUP_ENTRY";
+    failNextLedgerInsert = err;
+    const res = await SigninService.recordNormal("Urace");
+    expect(res.created).toBe(false);
+  });
+
+  it("accepts an explicit date", async () => {
+    await SigninService.recordNormal("Ualice", { date: "2026-08-03" });
+    expect(db.signin_ledger[0].signin_date).toBe("2026-08-03");
+  });
+});
+
+describe("makeup date rules", () => {
+  it.each([
+    ["", "INVALID_DATE"],
+    [undefined, "INVALID_DATE"],
+    ["2026-8-3", "INVALID_DATE"],
+    ["2026/08/03", "INVALID_DATE"],
+    ["2026-02-31", "INVALID_DATE"],
+    ["20260803", "INVALID_DATE"],
+    ["2026-07-31", "NOT_CURRENT_MONTH"],
+    ["2026-09-01", "NOT_CURRENT_MONTH"],
+    ["2025-08-03", "NOT_CURRENT_MONTH"],
+    [TODAY, "DATE_NOT_PAST"],
+    ["2026-08-08", "DATE_NOT_PAST"],
+  ])("rejects %s with %s", async (date, code) => {
+    seedStones("Ualice", 999999);
+    const res = await SigninService.makeup("Ualice", date);
+    expect(res).toMatchObject({ ok: false, code });
+    expect(db.signin_ledger).toHaveLength(0);
+    expect(balanceOf("Ualice")).toBe(999999);
+  });
+
+  it("accepts yesterday", async () => {
+    seedStones("Ualice", 50000);
+    const res = await SigninService.makeup("Ualice", "2026-08-06");
+    expect(res).toMatchObject({ ok: true, date: "2026-08-06", cost: 20000 });
+  });
+});
+
+describe("makeup debit", () => {
+  it("inserts ledger + a negative stone row of exactly the cost", async () => {
+    seedStones("Ualice", 50000);
+    await SigninService.makeup("Ualice", "2026-08-05");
+
+    expect(db.signin_ledger).toHaveLength(1);
+    expect(db.signin_ledger[0]).toMatchObject({
+      signin_date: "2026-08-05",
+      source: "makeup",
+      cost_stones: 20000,
+    });
+    const debits = stoneRows("Ualice").filter(r => r.itemAmount < 0);
+    expect(debits).toHaveLength(1);
+    expect(debits[0].itemAmount).toBe(-20000);
+    expect(balanceOf("Ualice")).toBe(30000);
+  });
+
+  it("rejects when balance is below cost and debits nothing", async () => {
+    seedStones("Ualice", 19999);
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+    expect(res).toMatchObject({ ok: false, code: "INSUFFICIENT_STONES", cost: 20000 });
+    expect(db.signin_ledger).toHaveLength(0);
+    expect(balanceOf("Ualice")).toBe(19999);
+  });
+
+  it("rejects when the user has no stone rows at all", async () => {
+    const res = await SigninService.makeup("Unew", "2026-08-05");
+    expect(res.code).toBe("INSUFFICIENT_STONES");
+    expect(db.inventory).toHaveLength(0);
+  });
+
+  it("sums a multi-row ledger balance rather than reading one row", async () => {
+    seedStones("Ualice", 15000);
+    seedStones("Ualice", 6000);
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+    expect(res.ok).toBe(true);
+    expect(balanceOf("Ualice")).toBe(1000);
+  });
+});
+
+describe("makeup duplicates", () => {
+  it("returns ALREADY_SIGNED and does NOT debit when the date is already signed", async () => {
+    seedSignins("Ualice", ["2026-08-05"]);
+    seedStones("Ualice", 50000);
+
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_SIGNED" });
+    expect(db.signin_ledger).toHaveLength(1);
+    expect(balanceOf("Ualice")).toBe(50000);
+  });
+
+  it("does not double-debit when the unique key collides mid-transaction", async () => {
+    // 模擬另一條請求在餘額檢查之後、insert 之前先寫入：ledger insert 撞唯一鍵，
+    // 整筆交易回滾，扣款那列不得留下。
+    seedStones("Ualice", 50000);
+    const err = new Error("dup");
+    err.code = "ER_DUP_ENTRY";
+    failNextLedgerInsert = err;
+
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_SIGNED" });
+    expect(balanceOf("Ualice")).toBe(50000);
+    expect(db.inventory.filter(r => r.itemAmount < 0)).toHaveLength(0);
+  });
+
+  it("does not create a gacha record for a makeup signin", async () => {
+    seedStones("Ualice", 50000);
+    await SigninService.makeup("Ualice", "2026-08-05");
+    expect(Object.keys(db)).toEqual(["signin_ledger", "inventory"]);
+  });
+});
+
+describe("getSummary", () => {
+  it("counts total across all months but monthCount only for the current month", async () => {
+    seedSignins("Ualice", ["2026-07-30", "2026-08-01", "2026-08-07"]);
+    const s = await SigninService.getSummary("Ualice");
+    expect(s.total).toBe(3);
+    expect(s.monthCount).toBe(2);
+    expect(s.month).toBe("2026-08");
+    expect(s.daysInMonth).toBe(31);
+  });
+
+  it("treats makeup rows as equal to normal ones for streak", async () => {
+    seedSignins("Ualice", ["2026-08-07"], "normal");
+    seedSignins("Ualice", ["2026-08-06", "2026-08-05"], "makeup");
+    const s = await SigninService.getSummary("Ualice");
+    expect(s.streak).toBe(3);
+  });
+
+  it("fullMonth is false until every day of the month has a row", async () => {
+    const days = Array.from({ length: 30 }, (_, i) => `2026-08-${String(i + 1).padStart(2, "0")}`);
+    seedSignins("Ualice", days);
+    expect((await SigninService.getSummary("Ualice")).fullMonth).toBe(false);
+
+    seedSignins("Ualice", ["2026-08-31"]);
+    expect((await SigninService.getSummary("Ualice")).fullMonth).toBe(true);
+  });
+});
+
+describe("achievement evaluation", () => {
+  it("passes the documented signin context", async () => {
+    seedSignins("Ualice", ["2026-08-06", "2026-08-07"]);
+    await SigninService.evaluateAchievements("Ualice", { source: "normal", date: TODAY });
+
+    expect(AchievementEngine.evaluate).toHaveBeenCalledWith("Ualice", "signin", {
+      source: "normal",
+      date: TODAY,
+      streak: 2,
+      total: 2,
+      monthCount: 2,
+      daysInMonth: 31,
+      fullMonth: false,
+    });
+  });
+
+  it("fires with source=makeup after a successful makeup", async () => {
+    seedStones("Ualice", 50000);
+    await SigninService.makeup("Ualice", "2026-08-05");
+
+    expect(AchievementEngine.evaluate).toHaveBeenCalledTimes(1);
+    const [, event, ctx] = AchievementEngine.evaluate.mock.calls[0];
+    expect(event).toBe("signin");
+    expect(ctx).toMatchObject({ source: "makeup", date: "2026-08-05" });
+  });
+
+  it("does not fire when the makeup is rejected", async () => {
+    seedStones("Ualice", 1);
+    await SigninService.makeup("Ualice", "2026-08-05");
+    expect(AchievementEngine.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("swallows achievement failures so signin still succeeds", async () => {
+    AchievementEngine.evaluate.mockRejectedValueOnce(new Error("engine down"));
+    seedStones("Ualice", 50000);
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+    expect(res.ok).toBe(true);
+  });
+});

--- a/app/bin/DailyQuestProcess.js
+++ b/app/bin/DailyQuestProcess.js
@@ -3,6 +3,7 @@ const redis = require("../src/util/redis");
 const moment = require("moment");
 const config = require("config");
 const { DefaultLogger } = require("../src/util/Logger");
+const { todayUtc8 } = require("../src/util/date");
 
 module.exports = main;
 
@@ -101,11 +102,9 @@ async function getTodayRecord(userId) {
   const end = moment().endOf("day").toDate();
 
   const [gacha, janken] = await Promise.all([
-    mysql("signin_days")
-      .where("user_id", userId)
-      .where("last_signin_at", ">=", start)
-      .where("last_signin_at", "<=", end)
-      .first(),
+    // 每日一抽的簽到來源已從 signin_days 換成 signin_ledger（一天一列）。
+    // 舊表不再被寫入，繼續讀它會讓每日任務永遠判定未完成。
+    mysql("signin_ledger").where("user_id", userId).where("signin_date", todayUtc8()).first(),
     mysql("janken_result")
       .where("user_id", userId)
       .where("created_at", ">=", start)

--- a/app/migrations/20260807085854_create_signin_ledger.js
+++ b/app/migrations/20260807085854_create_signin_ledger.js
@@ -1,0 +1,46 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * signin_ledger：一天一列的簽到帳本，取代 signin_days 的「單列 + sum_days」設計。
+ * 舊表保留不動（不再讀寫、也不 drop），避免歷史查詢與回滾風險。
+ *
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  await knex.schema.createTable("signin_ledger", table => {
+    table.bigIncrements("id").primary();
+    table.string("user_id", 33).notNullable();
+    table.date("signin_date").notNullable().comment("UTC+8 date");
+    table.enu("source", ["normal", "makeup"]).notNullable().comment("normal:每日一抽, makeup:補簽");
+    table.integer("cost_stones").notNullable().defaultTo(0).comment("補簽花費女神石");
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.unique(["user_id", "signin_date"], "uq_signin_user_date");
+    table.index("signin_date", "idx_signin_date");
+  });
+
+  // 當月回填：以 DB 的 +08 session 時區把 gacha_record.created_at 折成日期，
+  // 一次 set-based INSERT ... SELECT，不逐列跑。只補當月，更早的月份不回填
+  // （補簽只允許當月，回填更早等於送出無法對應的歷史）。
+  await knex.raw(`
+    INSERT IGNORE INTO signin_ledger (user_id, signin_date, source, cost_stones, created_at)
+    SELECT
+      user_id,
+      DATE(created_at) AS signin_date,
+      'normal',
+      0,
+      MIN(created_at)
+    FROM gacha_record
+    WHERE created_at >= DATE_FORMAT(CURDATE(), '%Y-%m-01')
+      AND created_at < DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 1 MONTH)
+    GROUP BY user_id, DATE(created_at)
+  `);
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("signin_ledger");
+};

--- a/app/src/controller/application/ChatLevelController.js
+++ b/app/src/controller/application/ChatLevelController.js
@@ -19,7 +19,7 @@ const LineClient = getClient("line");
 const GachaModel = require("../../model/princess/gacha");
 const GachaRecord = require("../../model/princess/GachaRecord");
 const JankenResult = require("../../model/application/JankenResult");
-const SigninModel = require("../../model/application/SigninDays");
+const SigninService = require("../../service/SigninService");
 const DailyQuestModel = require("../../model/application/DailyQuest");
 const DonateModel = require("../../model/application/DonateList");
 const SubscribeUserModel = require("../../model/application/SubscribeUser");
@@ -65,6 +65,7 @@ const { resolveTierUppers } = require("../../service/chatXp/diminishTier");
 const { todayUtc8 } = require("../../util/date");
 
 const XP_HISTORY_LIFF_PATH = "/xp-history";
+const SIGNIN_LIFF_PATH = "/signin";
 
 /**
  * 顯示個人狀態，現複合了其他布丁系統的資訊
@@ -129,7 +130,7 @@ exports.showStatus = async (context, props) => {
       time("me.charTotal", () => GachaModel.getPrincessCharacterCount()),
       time("me.godStone", () => GachaModel.getUserGodStoneCount(userId)),
       time("me.janken", () => JankenResult.findUserGrade(userId)),
-      time("me.signin", () => SigninModel.first({ filter: { user_id: userId } })),
+      time("me.signin", () => SigninService.getSummary(userId)),
       getQuestInfo(userId),
       time("me.donate", () => DonateModel.getUserTotalAmount(userId)),
       time("me.subscribe", () => getSubscribeInfo(userId)),
@@ -179,7 +180,13 @@ exports.showStatus = async (context, props) => {
         janken: questInfo.janken,
         weeklyCompleted: questInfo.weeklyCompletedCount,
       },
-      signinDays: get(signinInfo, "sum_days", 0),
+      signin: {
+        streak: get(signinInfo, "streak", 0),
+        monthCount: get(signinInfo, "monthCount", 0),
+        daysInMonth: get(signinInfo, "daysInMonth", 0),
+        total: get(signinInfo, "total", 0),
+      },
+      signinUri: commonTemplate.getLiffUri("full", SIGNIN_LIFF_PATH),
       characterCurrent,
       characterTotal,
       starProgress: gachaProgress.progress,

--- a/app/src/controller/application/SigninController.js
+++ b/app/src/controller/application/SigninController.js
@@ -1,0 +1,44 @@
+const SigninService = require("../../service/SigninService");
+const { DefaultLogger } = require("../../util/Logger");
+
+// domain error code → HTTP status + 使用者訊息。
+// 這張表就是 API 契約本身，service 只回 code，不知道 HTTP。
+const ERRORS = {
+  INVALID_DATE: { status: 400, message: "日期格式錯誤" },
+  NOT_CURRENT_MONTH: { status: 400, message: "只能補簽當月的日期" },
+  DATE_NOT_PAST: { status: 400, message: "只能補簽今天以前的日期" },
+  INSUFFICIENT_STONES: { status: 400, message: "女神石不足" },
+  ALREADY_SIGNED: { status: 409, message: "這天已經簽到過了" },
+};
+
+// API: GET /api/me/signins
+exports.apiGetCalendar = async (req, res) => {
+  try {
+    const { userId } = req.profile;
+    res.json(await SigninService.getCalendar(userId));
+  } catch (e) {
+    DefaultLogger.error("[me/signins]", e);
+    res.status(500).json({ error: "internal_error" });
+  }
+};
+
+// API: POST /api/me/signins/makeup
+exports.apiMakeup = async (req, res) => {
+  try {
+    const { userId } = req.profile;
+    const date = (req.body || {}).date;
+
+    const result = await SigninService.makeup(userId, date);
+    if (!result.ok) {
+      const mapped = ERRORS[result.code] || { status: 400, message: "補簽失敗" };
+      return res.status(mapped.status).json({ code: result.code, message: mapped.message });
+    }
+
+    // 成功回傳最新月曆，前端不必再打一次 GET。
+    const payload = await SigninService.getCalendar(userId);
+    res.json({ ...payload, ok: true, created: { date: result.date, cost: result.cost } });
+  } catch (e) {
+    DefaultLogger.error("[me/signins/makeup]", e);
+    res.status(500).json({ error: "internal_error" });
+  }
+};

--- a/app/src/router/api.js
+++ b/app/src/router/api.js
@@ -23,6 +23,7 @@ const ChatLevelController = require("../controller/application/ChatLevelControll
 const AnnounceController = require("../controller/application/AnnounceController");
 const WorldBossController = require("../controller/application/WorldBossController");
 const WeatherController = require("../controller/application/WeatherController");
+const SigninController = require("../controller/application/SigninController");
 const { api: GodStoneShopRouter } = require("../controller/princess/GodStoneShop");
 const AdminModel = require("../model/application/Admin");
 const { admin: AdminWorldBossRouter } = require("./WorldBoss");
@@ -129,6 +130,9 @@ router.get("/me/xp-daily", verifyToken, async (req, res) => {
 
 router.get("/me/chat-weather/today", verifyToken, WeatherController.apiGetToday);
 router.post("/me/chat-weather/protection/purchase", verifyToken, WeatherController.apiPurchase);
+
+router.get("/me/signins", verifyToken, SigninController.apiGetCalendar);
+router.post("/me/signins/makeup", verifyToken, SigninController.apiMakeup);
 
 router.get("/liff-ids", (req, res) => {
   const { size } = req.query || "full";

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -130,6 +130,25 @@ const STRATEGIES = {
     if (!contextKey || minValue === undefined) return currentValue;
     return context[contextKey] >= minValue ? achievement.target_value : currentValue;
   },
+  // Fully definition-driven strategy: the DB row's `condition` names both the
+  // event and the metric, so a new achievement needs no code change here (and
+  // its key never has to appear in this file — secret keys stay out of git).
+  conditionMetric(currentValue, achievement, context) {
+    const metric = (achievement.condition || {}).metric;
+    switch (metric) {
+      case "streak":
+        return STRATEGIES.contextValue(currentValue, achievement, context, "streak");
+      case "total":
+        return STRATEGIES.contextValue(currentValue, achievement, context, "total");
+      case "full_month":
+        return context.fullMonth ? achievement.target_value : currentValue;
+      default:
+        DefaultLogger.warn(
+          `AchievementEngine: unknown condition.metric=${metric} for achievement id=${achievement.id}`
+        );
+        return currentValue;
+    }
+  },
   timeWindow(currentValue, achievement, startHour, endHour) {
     const hour = new Date(Date.now() + 8 * 60 * 60 * 1000).getUTCHours(); // Asia/Taipei
     return hour >= startHour && hour < endHour ? achievement.target_value : currentValue;
@@ -225,6 +244,49 @@ const GODDESS_STONE_ITEM_ID = 999;
 const REDIS_TTL = 90 * 24 * 60 * 60; // 90 days
 
 /**
+ * Candidate rows for an event = the hardcoded key list (legacy events) UNION
+ * every definition whose `condition.event` names this event. The second half is
+ * what lets a new achievement ship as a DB row alone: no key here, no strategy
+ * entry, therefore no secret key or threshold committed to git.
+ *
+ * Keys that already own a hardcoded strategy are excluded from the second half:
+ * their strategy is written for their own event's context, and `resolveStrategy`
+ * prefers it over the generic one. Without this guard a DB row setting
+ * `condition.event` on such a key would drag it into a foreign event and run
+ * that strategy against the wrong context — e.g. `gacha_first` (instant, always
+ * returns target_value) would unlock on a signin. The event map stays the only
+ * way a hardcoded key gets evaluated.
+ */
+function resolveAchievements(cache, eventType) {
+  const byKey = (EVENT_ACHIEVEMENT_MAP[eventType] || [])
+    .map(key => cache.find(a => a.key === key))
+    .filter(Boolean);
+
+  const seen = new Set(byKey.map(a => a.id));
+  const byCondition = cache.filter(
+    a =>
+      a.condition &&
+      a.condition.event === eventType &&
+      !seen.has(a.id) &&
+      !ACHIEVEMENT_STRATEGY[a.key]
+  );
+
+  return [...byKey, ...byCondition];
+}
+
+/**
+ * Pick the progress strategy for one achievement: an explicit per-key entry
+ * wins; otherwise a definition carrying `condition.event` falls back to the
+ * generic metric strategy.
+ */
+function resolveStrategy(achievement) {
+  const byKey = ACHIEVEMENT_STRATEGY[achievement.key];
+  if (byKey) return byKey;
+  if (achievement.condition && achievement.condition.event) return STRATEGIES.conditionMetric;
+  return null;
+}
+
+/**
  * Evaluate achievements for a user after an event.
  * Errors are logged and swallowed, never thrown.
  * @returns {Promise<{ unlocked: Array }>} newly unlocked achievement rows (empty if none).
@@ -232,14 +294,8 @@ const REDIS_TTL = 90 * 24 * 60 * 60; // 90 days
 exports.evaluate = async (userId, eventType, context = {}) => {
   const unlocked = [];
   try {
-    const achievementKeys = EVENT_ACHIEVEMENT_MAP[eventType];
-    if (!achievementKeys || achievementKeys.length === 0) return { unlocked };
-
     const cache = await getCache();
-    const achievements = achievementKeys
-      .map(key => cache.find(a => a.key === key))
-      .filter(Boolean)
-      .filter(a => isEligible(userId, a));
+    const achievements = resolveAchievements(cache, eventType).filter(a => isEligible(userId, a));
     if (achievements.length === 0) return { unlocked };
 
     const allIds = achievements.map(a => a.id);
@@ -260,7 +316,7 @@ exports.evaluate = async (userId, eventType, context = {}) => {
     for (const achievement of candidates) {
       try {
         const currentValue = progressMap.get(achievement.id) || 0;
-        const strategy = ACHIEVEMENT_STRATEGY[achievement.key];
+        const strategy = resolveStrategy(achievement);
         const newValue = strategy ? await strategy(currentValue, achievement, ctx) : currentValue;
         if (newValue === null || newValue === currentValue) continue;
 

--- a/app/src/service/GachaService.js
+++ b/app/src/service/GachaService.js
@@ -9,11 +9,11 @@ const { inventory } = InventoryModel;
 const GachaRecord = require("../model/princess/GachaRecord");
 const GachaRecordDetail = require("../model/princess/GachaRecordDetail");
 const GachaBanner = require("../model/princess/GachaBanner");
-const signModel = require("../model/application/SigninDays");
 const SubscribeUser = require("../model/application/SubscribeUser");
 const SubscribeCard = require("../model/application/SubscribeCard");
 
 const EventCenterService = require("./EventCenterService");
+const SigninService = require("./SigninService");
 const AchievementEngine = require("./AchievementEngine");
 const {
   play,
@@ -28,28 +28,6 @@ const {
 const i18n = require("../util/i18n");
 const { DefaultLogger } = require("../util/Logger");
 const { time } = require("../middleware/timing");
-
-async function handleSignin(userId) {
-  const userData = await signModel.first({ filter: { user_id: userId } });
-  const now = moment();
-
-  if (!userData) {
-    return await signModel.create({ user_id: userId, last_signin_at: now.toDate() });
-  }
-
-  const latsSigninAt = moment(userData.last_signin_at);
-  const updateData = { last_signin_at: now.toDate() };
-
-  if (now.isSame(latsSigninAt, "day")) {
-    return;
-  } else if (now.diff(latsSigninAt, "days") > 1) {
-    updateData.sum_days = 1;
-  } else {
-    updateData.sum_days = userData.sum_days + 1;
-  }
-
-  await signModel.update(userId, updateData, { pk: "user_id" });
-}
 
 function resolveCost(pickup, ensure, europe, activeEuropeBanner) {
   if (pickup) {
@@ -251,6 +229,8 @@ async function runDailyDraw(userId, opts = {}) {
   const repeatReward = computeRepeatReward(uniqRewards, duplicateItems);
   const newCharacters = uniqRewards.filter(r => newItemIds.includes(r.id));
 
+  let signinCreated = false;
+  let signinDate = null;
   await time("rd.tx", async () => {
     await mysql.transaction(async trx => {
       if (cost.amount > 0) {
@@ -304,15 +284,28 @@ async function runDailyDraw(userId, opts = {}) {
           }))
         );
       }
+
+      // 簽到與轉蛋紀錄同進同退：交易回滾時不會留下「有簽到、沒轉蛋」的孤兒列。
+      const signin = await SigninService.recordNormal(userId, { trx });
+      signinCreated = signin.created;
+      signinDate = signin.date;
     });
   });
 
   await time("rd.side", () =>
-    Promise.all([
-      handleSignin(userId),
-      EventCenterService.add(EventCenterService.getEventName("daily_quest"), { userId }),
-    ])
+    EventCenterService.add(EventCenterService.getEventName("daily_quest"), { userId })
   );
+
+  // 成就評估必須在 commit 之後 —— 交易內查 streak/total 會讀到未提交的狀態。
+  // 只有真的新增了 ledger 才評估，同一天重抽不重複觸發。
+  const signinUnlocks = signinCreated
+    ? await time("rd.signinAchievement", () =>
+        SigninService.evaluateAchievements(userId, {
+          source: "normal",
+          date: signinDate,
+        }).then(r => r.unlocked || [])
+      )
+    : [];
 
   const { unlocked } = await time("rd.achievement", () =>
     AchievementEngine.evaluate(userId, "gacha_pull", {
@@ -335,7 +328,7 @@ async function runDailyDraw(userId, opts = {}) {
     ownCharactersCount,
     repeatReward,
     godStoneCost: cost.amount,
-    unlocks: unlocked || [],
+    unlocks: [...(unlocked || []), ...signinUnlocks],
   };
 }
 

--- a/app/src/service/SigninService.js
+++ b/app/src/service/SigninService.js
@@ -1,0 +1,275 @@
+const moment = require("moment");
+const mysql = require("../util/mysql");
+const { todayUtc8 } = require("../util/date");
+const gacha = require("../model/princess/gacha");
+const AchievementEngine = require("./AchievementEngine");
+const { DefaultLogger } = require("../util/Logger");
+
+const TABLE = "signin_ledger";
+const GODDESS_STONE_ITEM_ID = 999;
+const MAKEUP_COST = 20000;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+// MySQL 的 DATE 欄位會被 driver 轉成 JS Date，再受連線時區影響。
+// 直接在 SQL 端格式化成字串，整條路徑就只有一種型別，不必在 JS 端再猜時區。
+const DATE_SELECT = "DATE_FORMAT(signin_date, '%Y-%m-%d') AS signin_date";
+
+class SigninError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = "SigninError";
+    this.code = code;
+  }
+}
+
+const qb = trx => (trx || mysql)(TABLE);
+
+const isDuplicate = e => e && e.code === "ER_DUP_ENTRY";
+
+function isValidDate(date) {
+  return (
+    typeof date === "string" &&
+    DATE_PATTERN.test(date) &&
+    moment(date, "YYYY-MM-DD", true).isValid()
+  );
+}
+
+/**
+ * 從 today（今天已簽）或 yesterday（今天未簽但昨天有簽）往回數連續天數。
+ * normal 與 makeup 等價 —— ledger 有列就算簽到。
+ *
+ * @param {Array<String>} dates 該使用者所有簽到日期（YYYY-MM-DD，順序不拘）
+ * @param {String} today
+ * @returns {Number}
+ */
+function computeStreak(dates, today) {
+  const set = new Set(dates);
+  const yesterday = moment(today, "YYYY-MM-DD").subtract(1, "day").format("YYYY-MM-DD");
+
+  let cursor;
+  if (set.has(today)) cursor = today;
+  else if (set.has(yesterday)) cursor = yesterday;
+  else return 0;
+
+  let streak = 0;
+  const walker = moment(cursor, "YYYY-MM-DD");
+  while (set.has(walker.format("YYYY-MM-DD"))) {
+    streak += 1;
+    walker.subtract(1, "day");
+  }
+  return streak;
+}
+
+function listDates(userId, trx) {
+  return qb(trx)
+    .where({ user_id: userId })
+    .orderBy("signin_date", "desc")
+    .select(mysql.raw(DATE_SELECT))
+    .then(rows => rows.map(row => row.signin_date));
+}
+
+/**
+ * 寫入一筆「正常」簽到（每日一抽觸發）。已存在則不重複寫、不報錯。
+ * 呼叫端若傳入 trx，寫入會落在該交易內（每日一抽就是這樣共用同一筆交易）。
+ *
+ * @param {String} userId
+ * @param {Object} [options]
+ * @param {import("knex").Knex.Transaction} [options.trx]
+ * @param {String} [options.date] YYYY-MM-DD，預設今天（UTC+8）
+ * @returns {Promise<{created: Boolean, date: String}>}
+ */
+async function recordNormal(userId, options = {}) {
+  const { trx } = options;
+  const date = options.date || todayUtc8();
+
+  const existing = await qb(trx).where({ user_id: userId, signin_date: date }).first("id");
+  if (existing) return { created: false, date };
+
+  try {
+    await qb(trx).insert({
+      user_id: userId,
+      signin_date: date,
+      source: "normal",
+      cost_stones: 0,
+    });
+  } catch (e) {
+    if (isDuplicate(e)) return { created: false, date };
+    throw e;
+  }
+
+  return { created: true, date };
+}
+
+/**
+ * 補簽：只允許當月、昨天（含）以前的日期，扣除女神石後補一筆 makeup ledger。
+ * 錯誤以 domain code 回傳（不 throw），意料外的例外才往上拋。
+ *
+ * @param {String} userId
+ * @param {String} date YYYY-MM-DD
+ * @returns {Promise<{ok: Boolean, code?: String, date?: String, cost?: Number, balance?: Number}>}
+ */
+async function makeup(userId, date) {
+  if (!isValidDate(date)) return { ok: false, code: "INVALID_DATE" };
+
+  const today = todayUtc8();
+  if (date.slice(0, 7) !== today.slice(0, 7)) return { ok: false, code: "NOT_CURRENT_MONTH" };
+  // 字串比較在同格式的 YYYY-MM-DD 上等價於日期比較；今天與未來都不可補。
+  if (date >= today) return { ok: false, code: "DATE_NOT_PAST" };
+
+  let balance = 0;
+  try {
+    await mysql.transaction(async trx => {
+      // per-user 鎖：SELECT ... FOR UPDATE 鎖住這位使用者的女神石帳列，
+      // 讓同一人的補簽序列化 —— 餘額讀取與扣款落在同一把鎖內，
+      // 兩筆併發不會各自通過餘額檢查後重複扣。
+      // 沒有任何帳列 = 餘額 0，必然被 INSUFFICIENT_STONES 擋下，不需另外鎖。
+      const rows = await trx("inventory")
+        .where({ userId, itemId: GODDESS_STONE_ITEM_ID })
+        .select("itemAmount")
+        .forUpdate();
+      balance = rows.reduce((acc, row) => acc + Number(row.itemAmount || 0), 0);
+
+      // 先看有沒有簽過：已簽的人該拿到 ALREADY_SIGNED，不該被餘額不足蓋掉。
+      const existing = await qb(trx).where({ user_id: userId, signin_date: date }).first("id");
+      if (existing) throw new SigninError("ALREADY_SIGNED");
+
+      if (balance < MAKEUP_COST) throw new SigninError("INSUFFICIENT_STONES");
+
+      // ledger 先寫：unique(user_id, signin_date) 撞車會讓整筆交易回滾，
+      // 扣款那列跟著不存在 —— 重複補簽絕不會重複扣女神石。
+      await qb(trx).insert({
+        user_id: userId,
+        signin_date: date,
+        source: "makeup",
+        cost_stones: MAKEUP_COST,
+      });
+
+      await trx("inventory").insert({
+        userId,
+        itemId: GODDESS_STONE_ITEM_ID,
+        itemAmount: -MAKEUP_COST,
+        note: `signin_makeup:${date}`,
+      });
+    });
+  } catch (e) {
+    if (isDuplicate(e)) return { ok: false, code: "ALREADY_SIGNED" };
+    if (e instanceof SigninError) {
+      return e.code === "INSUFFICIENT_STONES"
+        ? { ok: false, code: e.code, balance, cost: MAKEUP_COST }
+        : { ok: false, code: e.code };
+    }
+    throw e;
+  }
+
+  await evaluateAchievements(userId, { source: "makeup", date });
+
+  return { ok: true, date, cost: MAKEUP_COST };
+}
+
+/**
+ * 簽到統計。streak 跨月連續計算，total 為 ledger 全部筆數，
+ * fullMonth 僅在當月每一天都有 ledger 時為 true。
+ *
+ * @param {String} userId
+ * @param {Object} [options]
+ * @param {import("knex").Knex.Transaction} [options.trx]
+ * @returns {Promise<{month:String, today:String, daysInMonth:Number, streak:Number,
+ *   total:Number, monthCount:Number, fullMonth:Boolean}>}
+ */
+async function getSummary(userId, options = {}) {
+  const today = todayUtc8();
+  const month = today.slice(0, 7);
+  const daysInMonth = moment(today, "YYYY-MM-DD").daysInMonth();
+
+  const dates = await listDates(userId, options.trx);
+  const monthCount = dates.filter(d => d.startsWith(month)).length;
+
+  return {
+    month,
+    today,
+    daysInMonth,
+    streak: computeStreak(dates, today),
+    total: dates.length,
+    monthCount,
+    // unique(user_id, signin_date) 保證一天最多一列，所以列數就等於天數。
+    fullMonth: monthCount >= daysInMonth,
+  };
+}
+
+/**
+ * 當月月曆 payload（GET /api/me/signins 的回應本體）。
+ * @param {String} userId
+ */
+async function getCalendar(userId) {
+  const summary = await getSummary(userId);
+  const monthEnd = `${summary.month}-${String(summary.daysInMonth).padStart(2, "0")}`;
+
+  const [rows, godStoneBalance] = await Promise.all([
+    qb()
+      .where({ user_id: userId })
+      .andWhere("signin_date", ">=", `${summary.month}-01`)
+      .andWhere("signin_date", "<=", monthEnd)
+      .orderBy("signin_date", "asc")
+      .select(mysql.raw(DATE_SELECT), "source", "cost_stones"),
+    gacha.getUserGodStoneCount(userId),
+  ]);
+
+  return {
+    month: summary.month,
+    today: summary.today,
+    daysInMonth: summary.daysInMonth,
+    makeupCost: MAKEUP_COST,
+    godStoneBalance: Number(godStoneBalance) || 0,
+    entries: rows.map(row => ({
+      date: row.signin_date,
+      source: row.source,
+      costStones: Number(row.cost_stones) || 0,
+    })),
+    stats: {
+      streak: summary.streak,
+      total: summary.total,
+      monthCount: summary.monthCount,
+      fullMonth: summary.fullMonth,
+    },
+  };
+}
+
+/**
+ * 簽到成就評估。只在「真的新增了一筆 ledger」之後、交易 commit 完才呼叫，
+ * 否則 streak/total 會讀到未提交的狀態。失敗只記錄，不影響簽到本身。
+ *
+ * @param {String} userId
+ * @param {Object} meta
+ * @param {"normal"|"makeup"} meta.source
+ * @param {String} meta.date
+ * @returns {Promise<{unlocked: Array}>}
+ */
+async function evaluateAchievements(userId, meta) {
+  try {
+    const summary = await getSummary(userId);
+    return await AchievementEngine.evaluate(userId, "signin", {
+      source: meta.source,
+      date: meta.date,
+      streak: summary.streak,
+      total: summary.total,
+      monthCount: summary.monthCount,
+      daysInMonth: summary.daysInMonth,
+      fullMonth: summary.fullMonth,
+    });
+  } catch (err) {
+    DefaultLogger.warn(
+      `SigninService.evaluateAchievements failed user=${userId}: ${err && err.message}`
+    );
+    return { unlocked: [] };
+  }
+}
+
+module.exports = {
+  MAKEUP_COST,
+  recordNormal,
+  makeup,
+  getSummary,
+  getCalendar,
+  evaluateAchievements,
+  _computeStreak: computeStreak,
+};

--- a/app/src/templates/application/Me/Profile.js
+++ b/app/src/templates/application/Me/Profile.js
@@ -313,8 +313,10 @@ function buildStatsRow({ gacha, janken, weeklyCompleted }) {
   };
 }
 
-function buildStreak(signinDays) {
-  return {
+function buildStreak(signin) {
+  const { streak = 0, monthCount = 0, daysInMonth = 0, total = 0 } = signin || {};
+
+  const streakRow = {
     type: "box",
     layout: "horizontal",
     contents: [
@@ -331,7 +333,7 @@ function buildStreak(signinDays) {
         contents: [
           {
             type: "span",
-            text: `${signinDays || 0}`,
+            text: `${streak}`,
             weight: "bold",
             color: COLORS.amber500,
             size: "md",
@@ -342,6 +344,36 @@ function buildStreak(signinDays) {
         flex: 0,
       },
     ],
+    alignItems: "center",
+  };
+
+  const detailRow = {
+    type: "box",
+    layout: "horizontal",
+    contents: [
+      {
+        type: "text",
+        text: `本月 ${monthCount}/${daysInMonth} 天`,
+        size: "xxs",
+        color: COLORS.textMuted,
+        flex: 1,
+      },
+      {
+        type: "text",
+        text: `累積 ${total} 天`,
+        size: "xxs",
+        color: COLORS.textMuted,
+        align: "end",
+        flex: 0,
+      },
+    ],
+    margin: "xs",
+  };
+
+  return {
+    type: "box",
+    layout: "vertical",
+    contents: [streakRow, detailRow],
     backgroundColor: COLORS.amberBg,
     cornerRadius: "md",
     paddingStart: "md",
@@ -349,7 +381,6 @@ function buildStreak(signinDays) {
     paddingTop: "sm",
     paddingBottom: "sm",
     margin: "md",
-    alignItems: "center",
   };
 }
 
@@ -362,7 +393,8 @@ exports.build = ({
   expNext,
   flags,
   today,
-  signinDays,
+  signin,
+  signinUri,
   subscriptionPanel,
   subscriptionBadge,
   dailyRaw,
@@ -402,7 +434,7 @@ exports.build = ({
   bodyContents.push({
     type: "box",
     layout: "vertical",
-    contents: [buildStreak(signinDays)],
+    contents: [buildStreak(signin)],
     paddingStart: "lg",
     paddingEnd: "lg",
     paddingBottom: "md",
@@ -412,10 +444,18 @@ exports.build = ({
     layout: "vertical",
     contents: [
       buildLinkPill({
+        label: "🗓 查看簽到月曆",
+        size: "xs",
+        cornerRadius: "md",
+        alignItems: "center",
+        action: { type: "uri", label: "查看簽到月曆", uri: signinUri },
+      }),
+      buildLinkPill({
         label: "📈 查看經驗歷程",
         size: "xs",
         cornerRadius: "md",
         alignItems: "center",
+        margin: "sm",
         action: { type: "uri", label: "查看經驗歷程", uri: xpHistoryUri },
       }),
     ],

--- a/app/src/templates/application/Me/__tests__/Profile.test.js
+++ b/app/src/templates/application/Me/__tests__/Profile.test.js
@@ -8,7 +8,8 @@ const baseInput = {
   expCurrent: 1200,
   expNext: 2000,
   today: { gacha: false, janken: false, weeklyCompleted: 0 },
-  signinDays: 7,
+  signin: { streak: 7, monthCount: 5, daysInMonth: 31, total: 42 },
+  signinUri: "https://liff.line.me/test-liff-id/signin",
   subscriptionPanel: null,
   subscriptionBadge: null,
   xpHistoryUri: "https://liff.line.me/test-liff-id/xp-history",
@@ -93,6 +94,50 @@ describe("Me/Profile.build", () => {
       type: "uri",
       label: "查看經驗歷程",
       uri: baseInput.xpHistoryUri,
+    });
+  });
+
+  describe("signin panel", () => {
+    it("renders the streak from SigninService summary", () => {
+      const bubble = Profile.build(baseInput);
+      const spans = findNode(bubble, n =>
+        n.type === "text" && Array.isArray(n.contents) && n.contents.some(s => s.text === " 天")
+          ? n.contents
+          : null
+      );
+      expect(spans[0].text).toBe("7");
+    });
+
+    it("renders month progress and lifetime total", () => {
+      const bubble = Profile.build(baseInput);
+      expect(findText(bubble, t => t.startsWith("本月"))).toBe("本月 5/31 天");
+      expect(findText(bubble, t => t.startsWith("累積"))).toBe("累積 42 天");
+    });
+
+    it("falls back to zeros when the summary is missing", () => {
+      const bubble = Profile.build({ ...baseInput, signin: undefined });
+      expect(findText(bubble, t => t.startsWith("本月"))).toBe("本月 0/0 天");
+      expect(findText(bubble, t => t.startsWith("累積"))).toBe("累積 0 天");
+    });
+
+    it("renders 簽到月曆 CTA as a uri action pointing at the LIFF URL", () => {
+      const bubble = Profile.build(baseInput);
+      const action = findNode(bubble, n =>
+        n.action && n.action.label === "查看簽到月曆" ? n.action : null
+      );
+      expect(action).toEqual({
+        type: "uri",
+        label: "查看簽到月曆",
+        uri: baseInput.signinUri,
+      });
+    });
+
+    it("keeps the XP history CTA alongside the new signin CTA", () => {
+      const bubble = Profile.build(baseInput);
+      const xp = findNode(bubble, n =>
+        n.action && n.action.label === "查看經驗歷程" ? n.action : null
+      );
+      expect(xp.uri).toBe(baseInput.xpHistoryUri);
     });
   });
 

--- a/app/src/templates/application/Me/index.js
+++ b/app/src/templates/application/Me/index.js
@@ -19,7 +19,8 @@ const Subscription = require("./Subscription");
  * @param {Boolean} data.today.gacha
  * @param {Boolean} data.today.janken
  * @param {Number}  data.today.weeklyCompleted
- * @param {Number} data.signinDays
+ * @param {Object} data.signin           {streak, monthCount, daysInMonth, total}
+ * @param {String} data.signinUri        簽到月曆 LIFF 連結
  * @param {Number} data.characterCurrent
  * @param {Number} data.characterTotal
  * @param {Number} data.starProgress     0–100
@@ -46,7 +47,8 @@ exports.buildBubbles = data => {
         expNext: data.expNext,
         flags: data.flags,
         today: data.today,
-        signinDays: data.signinDays,
+        signin: data.signin,
+        signinUri: data.signinUri,
         subscriptionPanel: cards.length === 1 ? cards[0] : null,
         subscriptionBadge: null,
         dailyRaw: data.dailyRaw,
@@ -66,7 +68,8 @@ exports.buildBubbles = data => {
         expNext: data.expNext,
         flags: data.flags,
         today: data.today,
-        signinDays: data.signinDays,
+        signin: data.signin,
+        signinUri: data.signinUri,
         subscriptionPanel: null,
         subscriptionBadge: { text: cards.map(c => c.titleText).join(" + ") },
         dailyRaw: data.dailyRaw,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,7 @@ import XpHistoryAbout from "./pages/XpHistory/About";
 import AutoSettings from "./pages/AutoSettings";
 import AutoHistory from "./pages/AutoHistory";
 import Topics from "./pages/Topics";
+import Signin from "./pages/Signin";
 import AdminGachaPool from "./pages/Admin/GachaPool";
 import AdminGachaPoolForm from "./pages/Admin/GachaPool/GachaPoolForm";
 import AdminGachaBanner from "./pages/Admin/GachaBanner";
@@ -106,6 +107,9 @@ export default function App() {
 
           {/* Chat word-cloud (LIFF) — must match getLiffUri("full", "/topics") */}
           <Route path="topics" element={<Topics />} />
+
+          {/* Daily sign-in calendar (LIFF) — matches /liff/full/signin */}
+          <Route path="signin" element={<Signin />} />
 
           {/* Admin — requires admin privilege */}
           <Route element={<RequireAdmin />}>

--- a/frontend/src/pages/Signin/index.jsx
+++ b/frontend/src/pages/Signin/index.jsx
@@ -1,0 +1,631 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  ButtonBase,
+  Card,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  LinearProgress,
+  Paper,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import CheckIcon from "@mui/icons-material/Check";
+import DiamondIcon from "@mui/icons-material/Diamond";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import EventAvailableIcon from "@mui/icons-material/EventAvailable";
+import LocalFireDepartmentIcon from "@mui/icons-material/LocalFireDepartment";
+import TodayIcon from "@mui/icons-material/Today";
+import api from "../../services/api";
+import useLiff from "../../context/useLiff";
+import AlertLogin from "../../components/AlertLogin";
+import HintSnackBar from "../../components/HintSnackBar";
+import useHintBar from "../../hooks/useHintBar";
+
+// Backend day boundary is Asia/Taipei (UTC+8) — same convention as
+// pages/XpHistory/dateTpe.js. Parse the API's ISO date at +08:00 and read the
+// weekday back in that zone so the grid never drifts a day on other locales.
+const WEEKDAY_LABELS = ["日", "一", "二", "三", "四", "五", "六"];
+const WEEKDAY_INDEX = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+const WEEKDAY_FMT = new Intl.DateTimeFormat("en-US", {
+  timeZone: "Asia/Taipei",
+  weekday: "short",
+});
+const FULL_DATE_FMT = new Intl.DateTimeFormat("zh-TW", {
+  timeZone: "Asia/Taipei",
+  month: "long",
+  day: "numeric",
+  weekday: "long",
+});
+
+function tpeInstant(date) {
+  const d = new Date(`${date}T00:00:00+08:00`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function weekdayIndexTpe(date) {
+  const d = tpeInstant(date);
+  return d ? (WEEKDAY_INDEX[WEEKDAY_FMT.format(d)] ?? 0) : 0;
+}
+
+function fullDateLabel(date) {
+  const d = tpeInstant(date);
+  return d ? FULL_DATE_FMT.format(d) : date;
+}
+
+const pad = n => String(n).padStart(2, "0");
+const num = n => Number(n || 0).toLocaleString();
+
+// date strings are zero-padded ISO, so lexical compare == chronological compare
+const STATUS = {
+  signed: { label: "已簽到", icon: CheckIcon },
+  makeup: { label: "補簽", icon: AutoFixHighIcon },
+  missed: { label: "可補簽", icon: AddIcon },
+  today: { label: "今天", icon: TodayIcon },
+  future: { label: "未到", icon: null },
+};
+
+const ERROR_MSG = {
+  INVALID_DATE: "日期格式不正確。",
+  NOT_CURRENT_MONTH: "只能補簽本月的日期。",
+  DATE_NOT_PAST: "只能補簽已經過去的日期。",
+  INSUFFICIENT_STONES: "女神石不足，無法補簽。",
+  ALREADY_SIGNED: "這天已經簽到了，已為你重新整理。",
+};
+
+/* ---------- day cell ---------- */
+
+function dayCellSx(status, isToday) {
+  const base = {
+    width: "100%",
+    aspectRatio: "1 / 1",
+    borderRadius: 2,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 0.15,
+    border: "1px solid",
+    transition: "transform .18s ease-out, box-shadow .18s ease-out, border-color .18s ease-out",
+    ...(isToday && {
+      outline: "2px solid",
+      outlineColor: "primary.main",
+      outlineOffset: 2,
+    }),
+  };
+
+  if (status === "signed") {
+    return {
+      ...base,
+      bgcolor: "primary.main",
+      borderColor: "primary.main",
+      color: "primary.contrastText",
+    };
+  }
+  if (status === "makeup") {
+    return {
+      ...base,
+      bgcolor: "secondary.main",
+      borderStyle: "dashed",
+      borderWidth: 2,
+      borderColor: "secondary.dark",
+      color: "secondary.contrastText",
+    };
+  }
+  if (status === "missed") {
+    return {
+      ...base,
+      borderStyle: "dashed",
+      borderWidth: 2,
+      borderColor: "divider",
+      color: "text.secondary",
+      bgcolor: "action.hover",
+      "&:hover": {
+        borderColor: "secondary.main",
+        color: "secondary.main",
+        transform: "translateY(-2px)",
+        boxShadow: 3,
+      },
+      "&:active": { transform: "translateY(0)" },
+      "&.Mui-focusVisible": { borderColor: "secondary.main", color: "secondary.main" },
+    };
+  }
+  if (status === "today") {
+    return { ...base, borderColor: "primary.main", color: "primary.main", bgcolor: "transparent" };
+  }
+  return { ...base, borderColor: "transparent", color: "text.disabled", opacity: 0.55 };
+}
+
+function DayCell({ cell, isToday, onPick }) {
+  const { day, date, status } = cell;
+  const meta = STATUS[status];
+  const Icon = meta.icon;
+  const actionable = status === "missed";
+
+  const body = (
+    <>
+      <Typography
+        component="span"
+        sx={{ fontSize: { xs: 15, sm: 17 }, fontWeight: 700, lineHeight: 1 }}
+      >
+        {day}
+      </Typography>
+      {Icon ? (
+        <Icon sx={{ fontSize: 13 }} />
+      ) : (
+        <Box component="span" sx={{ fontSize: 13, lineHeight: 1 }}>
+          ·
+        </Box>
+      )}
+    </>
+  );
+
+  const label = `${fullDateLabel(date)}，${isToday && status !== "signed" && status !== "makeup" ? "今天，尚未簽到" : meta.label}`;
+
+  if (actionable) {
+    return (
+      <ButtonBase
+        onClick={() => onPick(date)}
+        aria-label={`${label}，點擊補簽`}
+        sx={dayCellSx(status, isToday)}
+      >
+        {body}
+      </ButtonBase>
+    );
+  }
+
+  return (
+    <Box role="listitem" aria-label={label} sx={dayCellSx(status, isToday)}>
+      {body}
+    </Box>
+  );
+}
+
+/* ---------- stat tile ---------- */
+
+function StatTile({ icon: Icon, label, value, unit, accent }) {
+  return (
+    <Card variant="outlined" sx={{ height: "100%" }}>
+      <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
+        <Stack direction="row" spacing={0.75} sx={{ alignItems: "center", mb: 0.75 }}>
+          <Icon sx={{ fontSize: 16, color: accent }} />
+          <Typography variant="caption" sx={{ color: "text.secondary", fontWeight: 600 }}>
+            {label}
+          </Typography>
+        </Stack>
+        <Typography component="p" sx={{ fontSize: 22, fontWeight: 700, lineHeight: 1.2 }}>
+          {value}
+          {unit && (
+            <Typography
+              component="span"
+              variant="caption"
+              sx={{ ml: 0.5, color: "text.secondary", fontWeight: 500 }}
+            >
+              {unit}
+            </Typography>
+          )}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* ---------- legend ---------- */
+
+const LEGEND = [
+  { status: "signed", text: "已簽到" },
+  { status: "makeup", text: "補簽" },
+  { status: "missed", text: "可補簽" },
+  { status: "today", text: "今天" },
+  { status: "future", text: "未到" },
+];
+
+function Legend() {
+  return (
+    <Stack direction="row" spacing={1.25} sx={{ flexWrap: "wrap", rowGap: 1 }}>
+      {LEGEND.map(({ status, text }) => {
+        const Icon = STATUS[status].icon;
+        return (
+          <Stack key={status} direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+            <Box
+              aria-hidden
+              sx={{
+                ...dayCellSx(status, false),
+                width: 20,
+                height: 20,
+                aspectRatio: "auto",
+                borderRadius: 1,
+                flexShrink: 0,
+                "&:hover": undefined,
+              }}
+            >
+              {Icon ? <Icon sx={{ fontSize: 11 }} /> : null}
+            </Box>
+            <Typography variant="caption" sx={{ color: "text.secondary" }}>
+              {text}
+            </Typography>
+          </Stack>
+        );
+      })}
+    </Stack>
+  );
+}
+
+/* ---------- page ---------- */
+
+export default function Signin() {
+  const { loggedIn } = useLiff();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [target, setTarget] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [dialogError, setDialogError] = useState("");
+  const [hint, { handleOpen: showHint, handleClose: closeHint }] = useHintBar();
+
+  useEffect(() => {
+    document.title = "每日簽到";
+  }, []);
+
+  // ponytail: `loading` only guards the first paint — refetches (retry /
+  // ALREADY_SIGNED) keep the calendar on screen instead of flashing skeletons.
+  const load = useCallback(() => {
+    return api
+      .get("/api/me/signins")
+      .then(res => {
+        setData(res.data);
+        setLoadError(false);
+      })
+      .catch(() => setLoadError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (loggedIn) load();
+  }, [loggedIn, load]);
+
+  const cells = useMemo(() => {
+    if (!data) return [];
+    const bySource = new Map((data.entries || []).map(e => [e.date, e.source]));
+    return Array.from({ length: data.daysInMonth }, (_, i) => {
+      const day = i + 1;
+      const date = `${data.month}-${pad(day)}`;
+      const source = bySource.get(date);
+      let status;
+      if (source) status = source === "makeup" ? "makeup" : "signed";
+      else if (date === data.today) status = "today";
+      else if (date < data.today) status = "missed";
+      else status = "future";
+      return { day, date, status };
+    });
+  }, [data]);
+
+  const cost = Number(data?.makeupCost || 0);
+  const balance = Number(data?.godStoneBalance || 0);
+  const affordable = balance >= cost;
+
+  const openConfirm = date => {
+    setDialogError("");
+    setTarget(date);
+  };
+
+  const closeConfirm = () => {
+    if (submitting) return;
+    setTarget(null);
+  };
+
+  const submit = () => {
+    setSubmitting(true);
+    setDialogError("");
+    api
+      .post("/api/me/signins/makeup", { date: target })
+      .then(res => {
+        setData(res.data);
+        setTarget(null);
+        showHint(`已補簽 ${fullDateLabel(target)}`, "success");
+      })
+      .catch(err => {
+        const code = err?.response?.data?.code;
+        const message = ERROR_MSG[code] || err?.response?.data?.message || "補簽失敗，請稍後再試。";
+        if (code === "ALREADY_SIGNED") {
+          setTarget(null);
+          showHint(message, "warning");
+          load();
+          return;
+        }
+        setDialogError(message);
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  if (!loggedIn) return <AlertLogin />;
+
+  const leadingBlanks = data ? weekdayIndexTpe(`${data.month}-01`) : 0;
+  const monthLabel = data ? Number(data.month.slice(5, 7)) : null;
+  const stats = data?.stats || {};
+  const progress = data?.daysInMonth ? ((stats.monthCount || 0) / data.daysInMonth) * 100 : 0;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5, maxWidth: 720, mx: "auto" }}>
+      {/* hero */}
+      <Paper sx={{ position: "relative", overflow: "hidden", borderRadius: 3 }}>
+        <Box
+          sx={{
+            position: "absolute",
+            inset: 0,
+            background: theme =>
+              `linear-gradient(135deg, ${theme.palette.primary.dark} 0%, ${theme.palette.primary.main} 100%)`,
+          }}
+        />
+        <Box
+          sx={{
+            position: "relative",
+            p: { xs: 2.5, sm: 3.5 },
+            display: "flex",
+            alignItems: "center",
+            gap: 2,
+            flexWrap: "wrap",
+            color: "#fff",
+          }}
+        >
+          <EventAvailableIcon sx={{ fontSize: 44, color: "rgba(255,255,255,0.85)" }} />
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography variant="h5" sx={{ fontWeight: 700 }}>
+              {monthLabel ? `${monthLabel} 月簽到` : "每日簽到"}
+            </Typography>
+            <Typography variant="body2" sx={{ opacity: 0.9, mt: 0.25 }}>
+              錯過的日子可以用女神石補簽，只看得到本月。
+            </Typography>
+          </Box>
+          {stats.fullMonth && (
+            <Chip
+              icon={<EmojiEventsIcon sx={{ color: "inherit !important" }} />}
+              label="本月全勤"
+              size="small"
+              sx={{ bgcolor: "rgba(255,255,255,0.22)", color: "#fff", fontWeight: 700 }}
+            />
+          )}
+        </Box>
+      </Paper>
+
+      {loadError && (
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={load}>
+              重試
+            </Button>
+          }
+        >
+          載入簽到資料失敗，請稍後再試。
+        </Alert>
+      )}
+
+      {loading && !data ? (
+        <>
+          <Box sx={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 1.5 }}>
+            {[0, 1, 2, 3].map(i => (
+              <Skeleton key={i} variant="rounded" height={86} animation="wave" />
+            ))}
+          </Box>
+          <Skeleton variant="rounded" height={360} animation="wave" />
+        </>
+      ) : (
+        data && (
+          <>
+            {/* stats */}
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(4, 1fr)" },
+                gap: 1.5,
+              }}
+            >
+              <StatTile
+                icon={LocalFireDepartmentIcon}
+                label="連續簽到"
+                value={num(stats.streak)}
+                unit="天"
+                accent="error.main"
+              />
+              <StatTile
+                icon={EventAvailableIcon}
+                label="累計簽到"
+                value={num(stats.total)}
+                unit="天"
+                accent="primary.main"
+              />
+              <StatTile
+                icon={TodayIcon}
+                label="本月簽到"
+                value={`${num(stats.monthCount)} / ${data.daysInMonth}`}
+                accent="info.main"
+              />
+              <StatTile
+                icon={DiamondIcon}
+                label="女神石"
+                value={num(balance)}
+                accent="secondary.main"
+              />
+            </Box>
+
+            {/* calendar */}
+            <Card>
+              <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
+                <Stack
+                  direction="row"
+                  sx={{ alignItems: "baseline", justifyContent: "space-between", mb: 1.5 }}
+                >
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                    {data.month}
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                    補簽一次 {num(cost)} 女神石
+                  </Typography>
+                </Stack>
+
+                <Box
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(7, 1fr)",
+                    gap: { xs: 0.75, sm: 1 },
+                    mb: 1,
+                  }}
+                >
+                  {WEEKDAY_LABELS.map(w => (
+                    <Typography
+                      key={w}
+                      variant="caption"
+                      aria-hidden
+                      sx={{
+                        textAlign: "center",
+                        color: "text.secondary",
+                        fontWeight: 700,
+                      }}
+                    >
+                      {w}
+                    </Typography>
+                  ))}
+                </Box>
+
+                <Box
+                  role="list"
+                  aria-label={`${data.month} 簽到月曆`}
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(7, 1fr)",
+                    gap: { xs: 0.75, sm: 1 },
+                  }}
+                >
+                  {Array.from({ length: leadingBlanks }, (_, i) => (
+                    <Box key={`blank-${i}`} aria-hidden />
+                  ))}
+                  {cells.map(cell => (
+                    <DayCell
+                      key={cell.date}
+                      cell={cell}
+                      isToday={cell.date === data.today}
+                      onPick={openConfirm}
+                    />
+                  ))}
+                </Box>
+
+                <Divider sx={{ my: 2 }} />
+                <Legend />
+
+                <Box sx={{ mt: 2 }}>
+                  <Stack
+                    direction="row"
+                    sx={{ justifyContent: "space-between", mb: 0.5 }}
+                    aria-hidden
+                  >
+                    <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                      本月進度
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                      {num(stats.monthCount)} / {data.daysInMonth} 天
+                    </Typography>
+                  </Stack>
+                  <LinearProgress
+                    variant="determinate"
+                    value={Math.min(progress, 100)}
+                    aria-label="本月簽到進度"
+                    sx={{
+                      height: 6,
+                      borderRadius: 3,
+                      "& .MuiLinearProgress-bar": { borderRadius: 3 },
+                    }}
+                  />
+                </Box>
+              </CardContent>
+            </Card>
+
+            {!affordable && (
+              <Alert severity="info">
+                女神石餘額 {num(balance)}，補簽一次需要 {num(cost)}，目前還無法補簽。
+              </Alert>
+            )}
+          </>
+        )
+      )}
+
+      {/* confirm — same shape as XpHistory/TodayWeather's purchase dialog */}
+      <Dialog open={Boolean(target)} onClose={closeConfirm} fullWidth maxWidth="xs">
+        <DialogTitle>補簽 {target ? fullDateLabel(target) : ""}？</DialogTitle>
+        <DialogContent>
+          <Stack spacing={1} sx={{ mb: 1.5 }}>
+            <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                花費
+              </Typography>
+              <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                {num(cost)} 女神石
+              </Typography>
+            </Stack>
+            <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                補簽後餘額
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{ fontWeight: 700, color: affordable ? "text.primary" : "error.main" }}
+              >
+                {num(Math.max(balance - cost, 0))}
+              </Typography>
+            </Stack>
+          </Stack>
+          <Box
+            sx={{
+              p: 1.5,
+              borderRadius: 2,
+              bgcolor: "action.hover",
+              border: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Typography variant="caption" component="ul" sx={{ pl: 2, m: 0, lineHeight: 1.9 }}>
+              <li>不會補發當天的每日轉蛋。</li>
+              <li>會採計簽到相關成就。</li>
+              <li>一次只能補一天。</li>
+            </Typography>
+          </Box>
+          {!affordable && (
+            <Alert severity="warning" sx={{ mt: 1.5 }}>
+              女神石不足，無法補簽。
+            </Alert>
+          )}
+          {dialogError && (
+            <Alert severity="error" sx={{ mt: 1.5 }}>
+              {dialogError}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeConfirm} disabled={submitting}>
+            取消
+          </Button>
+          <Button variant="contained" onClick={submit} disabled={submitting || !affordable}>
+            {submitting ? "補簽中…" : "確定補簽"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <HintSnackBar
+        open={hint.open}
+        message={hint.message}
+        severity={hint.severity}
+        onClose={closeHint}
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- 新增逐日 `signin_ledger`、當月每日轉蛋回填與原子補簽扣款
- 整合每日轉蛋、DailyQuest、`/me` LIFF 入口與通用簽到成就 context
- 新增沿用既有 MUI theme 的 LIFF 簽到月曆、補簽確認及錯誤狀態
- 補簽限台灣時區本月昨天以前，每日固定扣除 20,000 女神石

## Test plan
- [x] Backend focused tests：132 passed
- [x] Achievement regression tests：53 passed
- [x] Backend full suite：997 passed
- [x] Frontend lint：0 errors（既有 warnings）
- [x] Frontend production build
- [x] Knex rollback/migrate/status 驗證
- [x] `signin_ledger` schema、unique index 與 backfill 範圍驗證

## Deployment notes
- 必須在新 bot image 啟動前先執行 `yarn migrate`，否則每日轉蛋會因缺少 `signin_ledger` 而 rollback。
- 本次沒有新增 dependency 或環境變數。
- 本 PR 只提供通用簽到成就事件；具體成就定義與機密門檻不在 repo 內。

🤖 Generated with [Claude Code](https://claude.com/claude-code)