### PR TITLE
feat(achievement): 新增每月簽到成就支援

### DIFF
--- a/app/__tests__/api/achievements.test.js
+++ b/app/__tests__/api/achievements.test.js
@@ -1,0 +1,118 @@
+// Achievement API 洩漏防線：condition / notify_* 是機密（玩家會挖 API 與 codebase），
+// 只要從 HTTP 出去的 payload 帶到就算破功。
+const request = require("supertest");
+const createApp = require("../helpers/createApp");
+
+jest.mock("../../src/model/application/Achievement", () => ({
+  allWithCategories: jest.fn(),
+}));
+jest.mock("../../src/service/AchievementEngine", () => ({
+  getUserSummary: jest.fn(),
+  getStats: jest.fn(),
+}));
+
+const AchievementModel = require("../../src/model/application/Achievement");
+const AchievementEngine = require("../../src/service/AchievementEngine");
+
+const SECRET_ROW = {
+  id: 1,
+  key: "secret_key",
+  name: "秘密成就",
+  description: "描述",
+  icon: "🗝",
+  type: "hidden",
+  rarity: 3,
+  target_value: 30,
+  reward_stones: 500,
+  order: 1,
+  category_key: "signin",
+  category_name: "簽到",
+  category_icon: "🗓",
+  category_id: 9,
+  condition: { event: "signin", metric: "streak", month: "2026-08", minValue: 30 },
+  notify_on_unlock: true,
+  notify_message: "解鎖秘密成就 {name}",
+  created_at: "2026-01-01",
+  updated_at: "2026-01-02",
+};
+
+const PRIVATE_KEYS = [
+  "condition",
+  "notify_message",
+  "notify_on_unlock",
+  "category_id",
+  "created_at",
+  "updated_at",
+];
+
+let app;
+beforeAll(() => {
+  app = createApp();
+});
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/achievements", () => {
+  it("returns only public fields", async () => {
+    AchievementModel.allWithCategories.mockResolvedValue([SECRET_ROW]);
+
+    const res = await request(app).get("/api/achievements");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    PRIVATE_KEYS.forEach(k => expect(res.body[0]).not.toHaveProperty(k));
+    expect(res.body[0]).toMatchObject({
+      id: 1,
+      key: "secret_key",
+      name: "秘密成就",
+      description: "描述",
+      icon: "🗝",
+      type: "hidden",
+      rarity: 3,
+      target_value: 30,
+      reward_stones: 500,
+      order: 1,
+      category_key: "signin",
+      category_name: "簽到",
+      category_icon: "🗓",
+    });
+  });
+
+  it("leaks no secret substring in the raw response body", async () => {
+    AchievementModel.allWithCategories.mockResolvedValue([SECRET_ROW]);
+
+    const res = await request(app).get("/api/achievements");
+
+    expect(res.text).not.toContain("condition");
+    expect(res.text).not.toContain("notify_message");
+    expect(res.text).not.toContain("minValue");
+    expect(res.text).not.toContain("解鎖秘密成就");
+  });
+});
+
+describe("GET /api/achievements/user/:userId", () => {
+  it("passes through the already-projected summary without private fields", async () => {
+    // getUserSummary 自己就會投影（見 AchievementEngine 測試），
+    // 這裡確認 controller 沒有在外面又把原始 row 塞回去。
+    AchievementEngine.getUserSummary.mockResolvedValue({
+      total: 1,
+      unlocked: 0,
+      percentage: 0,
+      categories: [
+        {
+          key: "signin",
+          achievements: [{ id: 1, key: "secret_key", name: "秘密成就", isUnlocked: false }],
+        },
+      ],
+      recentUnlocks: [],
+      nearCompletion: [],
+      profile: null,
+    });
+
+    const res = await request(app).get("/api/achievements/user/Uabc");
+
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain("condition");
+    expect(res.text).not.toContain("notify_message");
+    expect(res.body.categories[0].achievements[0].key).toBe("secret_key");
+  });
+});

--- a/app/__tests__/api/signins.test.js
+++ b/app/__tests__/api/signins.test.js
@@ -59,7 +59,12 @@ describe("GET /api/me/signins", () => {
 
 describe("POST /api/me/signins/makeup", () => {
   it("returns the refreshed payload plus ok/created on success", async () => {
-    SigninService.makeup.mockResolvedValue({ ok: true, date: "2026-08-05", cost: 20000 });
+    SigninService.makeup.mockResolvedValue({
+      ok: true,
+      date: "2026-08-05",
+      cost: 20000,
+      unlocked: [],
+    });
     SigninService.getCalendar.mockResolvedValue(PAYLOAD);
 
     const res = await request(app)
@@ -74,6 +79,70 @@ describe("POST /api/me/signins/makeup", () => {
       created: { date: "2026-08-05", cost: 20000 },
     });
     expect(SigninService.makeup).toHaveBeenCalledWith(USER_ID, "2026-08-05");
+  });
+
+  it("surfaces newly unlocked achievements on the success response", async () => {
+    const rows = [
+      {
+        id: 900,
+        key: "secret",
+        name: "全勤達人",
+        icon: "🗓",
+        rarity: 3,
+        reward_stones: 500,
+        category_key: "signin",
+      },
+    ];
+    SigninService.makeup.mockResolvedValue({
+      ok: true,
+      date: "2026-08-05",
+      cost: 20000,
+      unlocked: rows,
+    });
+    SigninService.getCalendar.mockResolvedValue(PAYLOAD);
+
+    const res = await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({ date: "2026-08-05" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.unlocked).toEqual(rows);
+    // 既有欄位仍在，前端舊版不會壞
+    expect(res.body.entries).toEqual(PAYLOAD.entries);
+    expect(res.body.stats).toEqual(PAYLOAD.stats);
+    expect(res.body.created).toEqual({ date: "2026-08-05", cost: 20000 });
+  });
+
+  it("does not leak achievement internals even if the service hands back a full row", async () => {
+    // 縱深防禦：service 已投影，但 controller 不該把任何私密欄位轉出去。
+    SigninService.makeup.mockResolvedValue({
+      ok: true,
+      date: "2026-08-05",
+      cost: 20000,
+      unlocked: [{ id: 900, key: "secret", name: "全勤達人", icon: "🗓" }],
+    });
+    SigninService.getCalendar.mockResolvedValue(PAYLOAD);
+
+    const res = await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({ date: "2026-08-05" });
+
+    expect(res.text).not.toContain("condition");
+    expect(res.text).not.toContain("notify_message");
+  });
+
+  it("always sends an unlocked array even when the service omits it", async () => {
+    SigninService.makeup.mockResolvedValue({ ok: true, date: "2026-08-05", cost: 20000 });
+    SigninService.getCalendar.mockResolvedValue(PAYLOAD);
+
+    const res = await request(app)
+      .post("/api/me/signins/makeup")
+      .set("Authorization", "Bearer t")
+      .send({ date: "2026-08-05" });
+
+    expect(res.body.unlocked).toEqual([]);
   });
 
   it("never trusts a userId supplied in the body", async () => {
@@ -107,6 +176,7 @@ describe("POST /api/me/signins/makeup", () => {
     expect(typeof res.body.message).toBe("string");
     // 失敗時不得回傳月曆 payload（前端才不會誤以為補簽成功）
     expect(res.body.entries).toBeUndefined();
+    expect(res.body.unlocked).toBeUndefined();
     expect(SigninService.getCalendar).not.toHaveBeenCalled();
   });
 

--- a/app/__tests__/model/UserAchievement.unlock.test.js
+++ b/app/__tests__/model/UserAchievement.unlock.test.js
@@ -1,0 +1,56 @@
+// UserAchievement.unlock 的契約：回傳「這次是否真的 INSERT」。
+// knex.raw 對 INSERT IGNORE 會 resolve 成 [ResultSetHeader, fields]，
+// affectedRows 命中為 1、被唯一鍵忽略為 0（已對真實 MySQL 驗證過）。
+jest.mock("../../src/util/mysql", () => {
+  const knex = jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    first: jest.fn().mockResolvedValue(null),
+  }));
+  knex.raw = jest.fn();
+  return knex;
+});
+
+const mysql = require("../../src/util/mysql");
+const UserAchievement = require("../../src/model/application/UserAchievement");
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("UserAchievement.unlock", () => {
+  it("returns true when the INSERT IGNORE created a row", async () => {
+    mysql.raw.mockResolvedValue([{ affectedRows: 1, insertId: 12 }, undefined]);
+
+    await expect(UserAchievement.unlock("Uabc", 7)).resolves.toBe(true);
+  });
+
+  it("returns false when the unique key made MySQL ignore the insert", async () => {
+    mysql.raw.mockResolvedValue([{ affectedRows: 0, insertId: 0 }, undefined]);
+
+    await expect(UserAchievement.unlock("Uabc", 7)).resolves.toBe(false);
+  });
+
+  it("issues INSERT IGNORE with bound params (no interpolation)", async () => {
+    mysql.raw.mockResolvedValue([{ affectedRows: 1 }, undefined]);
+
+    await UserAchievement.unlock("Uabc", 7);
+
+    const [sql, bindings] = mysql.raw.mock.calls[0];
+    expect(sql).toContain("INSERT IGNORE INTO user_achievements");
+    expect(bindings).toEqual(["Uabc", 7]);
+  });
+
+  it("tolerates a bare header object instead of the [header, fields] tuple", async () => {
+    // 某些 driver/mock 會直接回 header；不該因此把成功誤判成失敗。
+    mysql.raw.mockResolvedValue({ affectedRows: 1 });
+
+    await expect(UserAchievement.unlock("Uabc", 7)).resolves.toBe(true);
+  });
+
+  it("treats a missing/!unknown affectedRows as 'not created' (fail closed)", async () => {
+    // 寧可漏發獎也不要重複發獎。
+    mysql.raw.mockResolvedValue([{}, undefined]);
+    await expect(UserAchievement.unlock("Uabc", 7)).resolves.toBe(false);
+
+    mysql.raw.mockResolvedValue(undefined);
+    await expect(UserAchievement.unlock("Uabc", 7)).resolves.toBe(false);
+  });
+});

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -8,7 +8,8 @@ jest.mock("../../src/model/application/Achievement", () => ({
 jest.mock("../../src/model/application/UserAchievement", () => ({
   findByUser: jest.fn(),
   isUnlocked: jest.fn(),
-  unlock: jest.fn(),
+  // unlock 回傳「這次是否真的 INSERT」；預設為 true（贏得 race）
+  unlock: jest.fn().mockResolvedValue(true),
   countByUser: jest.fn(),
   getRecentByUser: jest.fn(),
   getUnlockedIds: jest.fn().mockResolvedValue(new Set()),
@@ -32,6 +33,13 @@ jest.mock("../../src/util/Logger", () => ({
 jest.mock("../../src/util/redis", () => ({
   get: jest.fn().mockResolvedValue(null),
   set: jest.fn().mockResolvedValue("OK"),
+}));
+// availableFrom 以台灣日期比對；固定「今天」才能穩定測到期前/後兩側。
+jest.mock("../../src/util/date", () => ({
+  todayUtc8: jest.fn(() => "2026-08-07"),
+  yesterdayUtc8: jest.fn(),
+  toUtc8Date: jest.fn(),
+  daysAgoUtc8: jest.fn(),
 }));
 jest.mock("../../src/util/mysql", () => {
   const mockChain = () => ({
@@ -64,6 +72,9 @@ const CACHE_DATA = [
 describe("AchievementEngine", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks 會清掉 mock 的預設回傳值；unlock 現在的契約是
+    // 「回傳這次是否真的 INSERT」，預設要是 true，否則所有解鎖都會被當成 race 輸家。
+    UserAchievementModel.unlock.mockResolvedValue(true);
     // Force cache refresh by mocking allWithCategories — getCache() will call it
     AchievementEngine._setCache(null);
     AchievementModel.allWithCategories.mockResolvedValue(CACHE_DATA);
@@ -115,7 +126,7 @@ describe("AchievementEngine", () => {
         ])
       );
       UserProgressModel.upsert.mockResolvedValue();
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
 
       await AchievementEngine.evaluate("user1", "chat_message", {});
@@ -179,7 +190,7 @@ describe("AchievementEngine", () => {
         ])
       );
       UserProgressModel.upsertMany.mockRejectedValueOnce(new Error("deadlock"));
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
 
       const result = await AchievementEngine.evaluate("user1", "chat_message", {});
@@ -208,7 +219,7 @@ describe("AchievementEngine", () => {
       );
       // First unlock (id1) blows up inside unlockAchievement; second must survive.
       UserAchievementModel.unlock.mockRejectedValueOnce(new Error("write conflict"));
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
 
       const result = await AchievementEngine.evaluate("user1", "chat_message", {});
@@ -258,7 +269,7 @@ describe("AchievementEngine", () => {
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
       UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[2, 99]]));
       UserProgressModel.upsert.mockResolvedValue();
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
       mysql.mockImplementationOnce(() => ({
         where: jest.fn().mockReturnThis(),
@@ -286,7 +297,7 @@ describe("AchievementEngine", () => {
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
       UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[2, 99]]));
       UserProgressModel.upsert.mockResolvedValue();
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
       const insert = jest.fn().mockResolvedValue();
       const update = jest.fn().mockResolvedValue(99);
@@ -330,6 +341,107 @@ describe("AchievementEngine", () => {
     });
   });
 
+  describe("concurrent unlock (INSERT IGNORE race)", () => {
+    const achievement = {
+      id: 7,
+      key: "chat_100",
+      target_value: 100,
+      reward_stones: 50,
+      notify_on_unlock: true,
+      notify_message: null,
+      condition: null,
+    };
+
+    let insert;
+    beforeEach(() => {
+      AchievementEngine._setCache([achievement]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map([[7, 99]]));
+      UserProgressModel.delete.mockResolvedValue();
+      insert = jest.fn().mockResolvedValue();
+      mysql.mockImplementation(() => ({
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+        insert,
+      }));
+    });
+
+    afterEach(() => {
+      mysql.mockImplementation(() => ({
+        insert: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        whereIn: jest.fn().mockReturnThis(),
+        update: jest.fn().mockResolvedValue(1),
+        first: jest.fn().mockResolvedValue(undefined),
+        select: jest.fn().mockReturnThis(),
+      }));
+    });
+
+    it("credits stones and reports the unlock when the INSERT won (affectedRows=1)", async () => {
+      UserAchievementModel.unlock.mockResolvedValue(true);
+
+      const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      expect(result.unlocked.map(a => a.id)).toEqual([7]);
+      expect(insert).toHaveBeenCalledTimes(1);
+      expect(insert).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "user1", itemId: 999, itemAmount: 50 })
+      );
+    });
+
+    it("pays nothing and reports no unlock when another pass won (affectedRows=0)", async () => {
+      UserAchievementModel.unlock.mockResolvedValue(false);
+
+      const result = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      // 併發下的輸家：不得重複發獎，也不得再送一次解鎖通知
+      expect(result.unlocked).toEqual([]);
+      expect(insert).not.toHaveBeenCalled();
+      expect(DefaultLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("still clears the progress row for the losing pass", async () => {
+      UserAchievementModel.unlock.mockResolvedValue(false);
+
+      await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      // progress 已無意義，不論誰贏都該清掉
+      expect(UserProgressModel.delete).toHaveBeenCalledWith("user1", 7);
+    });
+
+    it("unlockByKey reports already_unlocked and pays nothing when it loses the race", async () => {
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserAchievementModel.unlock.mockResolvedValue(false);
+
+      const result = await AchievementEngine.unlockByKey("user1", "chat_100");
+
+      expect(result).toEqual({ unlocked: false, reason: "already_unlocked" });
+      expect(insert).not.toHaveBeenCalled();
+    });
+
+    it("unlockByKey pays exactly once when it wins the race", async () => {
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserAchievementModel.unlock.mockResolvedValue(true);
+
+      const result = await AchievementEngine.unlockByKey("user1", "chat_100");
+
+      expect(result.unlocked).toBe(true);
+      expect(insert).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not credit stones twice across two sequential evaluate passes", async () => {
+      // 第一次贏、第二次輸（真實 INSERT IGNORE 的行為）
+      UserAchievementModel.unlock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+      const first = await AchievementEngine.evaluate("user1", "chat_message", {});
+      const second = await AchievementEngine.evaluate("user1", "chat_message", {});
+
+      expect(first.unlocked).toHaveLength(1);
+      expect(second.unlocked).toHaveLength(0);
+      expect(insert).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("mention_keyword event", () => {
     const baseAchievement = {
       id: 99,
@@ -348,7 +460,7 @@ describe("AchievementEngine", () => {
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
       UserProgressModel.getProgress.mockResolvedValue(null);
       UserProgressModel.upsert.mockResolvedValue();
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
       mysql.mockReturnValue({
         where: jest.fn().mockReturnThis(),
@@ -474,7 +586,7 @@ describe("AchievementEngine", () => {
     beforeEach(() => {
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
       UserProgressModel.getProgressByIds.mockResolvedValue(new Map());
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
       mysql.mockImplementation(() => ({
         where: jest.fn().mockReturnThis(),
@@ -651,6 +763,132 @@ describe("AchievementEngine", () => {
 
       expect(result.unlocked.map(a => a.id)).toEqual([900]);
     });
+
+    describe("condition.month", () => {
+      const fullMonthCtx = (month, fullMonth = true) => ({
+        source: "normal",
+        month,
+        fullMonth,
+        monthCount: 31,
+        daysInMonth: 31,
+        streak: 31,
+        total: 31,
+      });
+
+      it("completes full_month when context.month matches", async () => {
+        AchievementEngine._setCache([makeDef("full_month", 1, { month: "2026-08" })]);
+
+        const result = await AchievementEngine.evaluate(
+          "Ualice",
+          "signin",
+          fullMonthCtx("2026-08")
+        );
+
+        expect(result.unlocked.map(a => a.id)).toEqual([900]);
+      });
+
+      it("does not complete full_month when context.month differs", async () => {
+        AchievementEngine._setCache([makeDef("full_month", 1, { month: "2026-08" })]);
+
+        const result = await AchievementEngine.evaluate(
+          "Ualice",
+          "signin",
+          fullMonthCtx("2026-09")
+        );
+
+        expect(result.unlocked).toEqual([]);
+        expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
+        expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
+      });
+
+      it("does not complete a month-pinned full_month when the month is not yet full", async () => {
+        AchievementEngine._setCache([makeDef("full_month", 1, { month: "2026-08" })]);
+
+        const result = await AchievementEngine.evaluate(
+          "Ualice",
+          "signin",
+          fullMonthCtx("2026-08", false)
+        );
+
+        expect(result.unlocked).toEqual([]);
+      });
+
+      it("accepts any month when condition.month is absent", async () => {
+        AchievementEngine._setCache([makeDef("full_month", 1)]);
+
+        const result = await AchievementEngine.evaluate(
+          "Ualice",
+          "signin",
+          fullMonthCtx("2029-12")
+        );
+
+        expect(result.unlocked.map(a => a.id)).toEqual([900]);
+      });
+
+      it("does not gate streak on condition.month", async () => {
+        // streak 是累積型，綁月份沒有意義；即使 row 上帶了 month 也不該擋。
+        AchievementEngine._setCache([makeDef("streak", 5, { month: "2026-01" })]);
+
+        const result = await AchievementEngine.evaluate("Ualice", "signin", {
+          month: "2026-08",
+          streak: 5,
+        });
+
+        expect(result.unlocked.map(a => a.id)).toEqual([900]);
+      });
+
+      it("does not gate total on condition.month", async () => {
+        AchievementEngine._setCache([makeDef("total", 10, { month: "2026-01" })]);
+
+        const result = await AchievementEngine.evaluate("Ualice", "signin", {
+          month: "2026-08",
+          total: 10,
+        });
+
+        expect(result.unlocked.map(a => a.id)).toEqual([900]);
+      });
+    });
+
+    describe("condition.availableFrom", () => {
+      it("excludes a row whose availableFrom is still in the future", async () => {
+        AchievementEngine._setCache([makeDef("streak", 1, { availableFrom: "2026-08-08" })]);
+
+        const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 99 });
+
+        expect(result.unlocked).toEqual([]);
+        expect(UserProgressModel.upsertMany).not.toHaveBeenCalled();
+        expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
+      });
+
+      it("includes a row on its availableFrom day (boundary is inclusive)", async () => {
+        AchievementEngine._setCache([makeDef("streak", 1, { availableFrom: "2026-08-07" })]);
+
+        const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 1 });
+
+        expect(result.unlocked.map(a => a.id)).toEqual([900]);
+      });
+
+      it("includes a row whose availableFrom has passed", async () => {
+        AchievementEngine._setCache([makeDef("streak", 1, { availableFrom: "2026-01-01" })]);
+
+        const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 1 });
+
+        expect(result.unlocked.map(a => a.id)).toEqual([900]);
+      });
+
+      it("still applies the eligibility gate alongside availableFrom", async () => {
+        AchievementEngine._setCache([
+          makeDef("streak", 1, {
+            availableFrom: "2026-01-01",
+            eligibility: { excludeUserIds: ["Ualice"] },
+          }),
+        ]);
+
+        const result = await AchievementEngine.evaluate("Ualice", "signin", { streak: 9 });
+
+        expect(result.unlocked).toEqual([]);
+      });
+    });
   });
 
   describe("getUserSummary", () => {
@@ -711,6 +949,151 @@ describe("AchievementEngine", () => {
       expect(plebSummary.total).toBe(2);
       expect(plebSummary.categories[0].achievements.map(a => a.key)).toEqual(["a1", "a2"]);
     });
+
+    it("keeps unreleased (availableFrom) rows out of the completion denominator", async () => {
+      // 今天固定為 2026-08-07。未上線的成就若算進分母，所有人的完成率會先被稀釋。
+      AchievementModel.allWithCategories.mockResolvedValue([
+        { id: 1, key: "live1", name: "L1", category_key: "social", condition: null },
+        {
+          id: 2,
+          key: "live2",
+          name: "L2",
+          category_key: "social",
+          condition: { availableFrom: "2026-08-07" },
+        },
+        {
+          id: 3,
+          key: "unreleased",
+          name: "U",
+          category_key: "social",
+          condition: { availableFrom: "2026-09-01" },
+        },
+      ]);
+      CategoryModel.all.mockResolvedValue([{ id: 1, key: "social", name: "社交" }]);
+      UserAchievementModel.findByUser.mockResolvedValue([
+        { id: 1, key: "live1", name: "L1", unlocked_at: new Date() },
+      ]);
+      UserProgressModel.findByUser.mockResolvedValue([]);
+      UserAchievementModel.getRecentByUser.mockResolvedValue([]);
+      UserProgressModel.getNearCompletion.mockResolvedValue([]);
+
+      const summary = await AchievementEngine.getUserSummary("Ualice");
+
+      expect(summary.total).toBe(2);
+      expect(summary.percentage).toBe(50);
+      expect(summary.categories[0].achievements.map(a => a.key)).toEqual(["live1", "live2"]);
+    });
+
+    describe("public projection", () => {
+      const SECRET_ROW = {
+        id: 1,
+        key: "secret_key",
+        name: "秘密成就",
+        description: "描述",
+        icon: "🗝",
+        type: "hidden",
+        rarity: 3,
+        target_value: 30,
+        reward_stones: 500,
+        order: 1,
+        category_key: "signin",
+        category_name: "簽到",
+        category_icon: "🗓",
+        // 以下皆為內部欄位，絕不可外流
+        category_id: 9,
+        condition: { event: "signin", metric: "streak", month: "2026-08" },
+        notify_on_unlock: true,
+        notify_message: "解鎖秘密成就 {name}",
+        created_at: "2026-01-01",
+        updated_at: "2026-01-02",
+      };
+
+      const PRIVATE_KEYS = [
+        "condition",
+        "notify_message",
+        "notify_on_unlock",
+        "category_id",
+        "created_at",
+        "updated_at",
+      ];
+
+      beforeEach(() => {
+        AchievementModel.allWithCategories.mockResolvedValue([SECRET_ROW]);
+        CategoryModel.all.mockResolvedValue([{ id: 1, key: "signin", name: "簽到" }]);
+        UserAchievementModel.findByUser.mockResolvedValue([]);
+        UserProgressModel.findByUser.mockResolvedValue([]);
+        UserAchievementModel.getRecentByUser.mockResolvedValue([{ ...SECRET_ROW, unlocked_at: 1 }]);
+        UserProgressModel.getNearCompletion.mockResolvedValue([
+          { ...SECRET_ROW, current_value: 5, percentage: 17 },
+        ]);
+      });
+
+      it("strips internal fields from category achievements", async () => {
+        const summary = await AchievementEngine.getUserSummary("Ualice");
+        const row = summary.categories[0].achievements[0];
+
+        PRIVATE_KEYS.forEach(k => expect(row).not.toHaveProperty(k));
+      });
+
+      it("strips internal fields from recentUnlocks and nearCompletion", async () => {
+        const summary = await AchievementEngine.getUserSummary("Ualice");
+
+        PRIVATE_KEYS.forEach(k => {
+          expect(summary.recentUnlocks[0]).not.toHaveProperty(k);
+          expect(summary.nearCompletion[0]).not.toHaveProperty(k);
+        });
+      });
+
+      it("keeps every field the achievement UI renders", async () => {
+        const summary = await AchievementEngine.getUserSummary("Ualice");
+        const row = summary.categories[0].achievements[0];
+
+        expect(row).toMatchObject({
+          id: 1,
+          key: "secret_key",
+          name: "秘密成就",
+          description: "描述",
+          icon: "🗝",
+          type: "hidden",
+          rarity: 3,
+          target_value: 30,
+          reward_stones: 500,
+          order: 1,
+          category_key: "signin",
+          category_name: "簽到",
+          category_icon: "🗓",
+          isUnlocked: false,
+          currentValue: 0,
+          unlockedAt: null,
+        });
+      });
+
+      it("keeps the fields the LINE flex card reads on recent/near rows", async () => {
+        const summary = await AchievementEngine.getUserSummary("Ualice");
+
+        expect(summary.recentUnlocks[0]).toMatchObject({
+          icon: "🗝",
+          name: "秘密成就",
+          rarity: 3,
+          unlocked_at: 1,
+        });
+        expect(summary.nearCompletion[0]).toMatchObject({
+          current_value: 5,
+          target_value: 30,
+          percentage: 17,
+        });
+      });
+
+      it("serialises to JSON with no trace of the secret condition", async () => {
+        const summary = await AchievementEngine.getUserSummary("Ualice");
+        const json = JSON.stringify(summary);
+
+        expect(json).not.toContain("condition");
+        expect(json).not.toContain("notify_message");
+        expect(json).not.toContain("解鎖秘密成就");
+        expect(json).not.toContain("2026-08");
+      });
+    });
   });
 
   describe("isEligible", () => {
@@ -736,6 +1119,23 @@ describe("AchievementEngine", () => {
     it("exclude wins when user is in both", () => {
       const a = {
         condition: { eligibility: { includeUserIds: ["Uvip"], excludeUserIds: ["Uvip"] } },
+      };
+      expect(_isEligible("Uvip", a)).toBe(false);
+    });
+
+    it("hides a row before its availableFrom date and keeps it after", () => {
+      // 今天固定為 2026-08-07（見檔頭 util/date mock）
+      expect(_isEligible("Uany", { condition: { availableFrom: "2026-08-08" } })).toBe(false);
+      expect(_isEligible("Uany", { condition: { availableFrom: "2026-08-07" } })).toBe(true);
+      expect(_isEligible("Uany", { condition: { availableFrom: "2026-07-01" } })).toBe(true);
+    });
+
+    it("availableFrom rejects regardless of an otherwise passing eligibility block", () => {
+      const a = {
+        condition: {
+          availableFrom: "2026-12-01",
+          eligibility: { includeUserIds: ["Uvip"] },
+        },
       };
       expect(_isEligible("Uvip", a)).toBe(false);
     });
@@ -792,7 +1192,7 @@ describe("AchievementEngine", () => {
       AchievementEngine._setCache([sister]);
       UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
       UserProgressModel.upsert.mockResolvedValue();
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.delete.mockResolvedValue();
       mysql.mockImplementation(() => ({
         where: jest.fn().mockReturnThis(),
@@ -887,7 +1287,7 @@ describe("AchievementEngine", () => {
 
     it("unlocks and inserts stone ledger row on first call", async () => {
       UserAchievementModel.getUnlockedIds.mockResolvedValueOnce(new Set());
-      UserAchievementModel.unlock.mockResolvedValueOnce();
+      UserAchievementModel.unlock.mockResolvedValueOnce(true);
 
       const result = await AchievementEngine.unlockByKey("Uabc", "prestige_departure");
 
@@ -980,7 +1380,7 @@ describe("AchievementEngine", () => {
 
     beforeEach(() => {
       AchievementEngine._setCache(CHAT_CACHE);
-      UserAchievementModel.unlock.mockResolvedValue();
+      UserAchievementModel.unlock.mockResolvedValue(true);
       UserProgressModel.upsert.mockResolvedValue();
     });
 

--- a/app/__tests__/service/SigninService.test.js
+++ b/app/__tests__/service/SigninService.test.js
@@ -345,12 +345,23 @@ describe("achievement evaluation", () => {
     expect(AchievementEngine.evaluate).toHaveBeenCalledWith("Ualice", "signin", {
       source: "normal",
       date: TODAY,
+      month: "2026-08",
       streak: 2,
       total: 2,
       monthCount: 2,
       daysInMonth: 31,
       fullMonth: false,
     });
+  });
+
+  it("carries the current month, not the month of the back-filled date", async () => {
+    // 補簽的是過去某天，但 fullMonth 講的一律是「現在這個月」。
+    seedStones("Ualice", 50000);
+    await SigninService.makeup("Ualice", "2026-08-01");
+
+    const [, , ctx] = AchievementEngine.evaluate.mock.calls[0];
+    expect(ctx.month).toBe("2026-08");
+    expect(ctx.date).toBe("2026-08-01");
   });
 
   it("fires with source=makeup after a successful makeup", async () => {
@@ -374,5 +385,97 @@ describe("achievement evaluation", () => {
     seedStones("Ualice", 50000);
     const res = await SigninService.makeup("Ualice", "2026-08-05");
     expect(res.ok).toBe(true);
+    expect(res.unlocked).toEqual([]);
+  });
+});
+
+describe("makeup returns newly unlocked achievements", () => {
+  // 完整 DB row：makeup 回傳時必須被投影，內部欄位不得外流給前端
+  const FULL_ROW = {
+    id: 900,
+    key: "secret",
+    name: "全勤",
+    icon: "🗓",
+    rarity: 3,
+    reward_stones: 500,
+    category_key: "signin",
+    description: "秘密條件",
+    target_value: 31,
+    category_id: 4,
+    condition: { event: "signin", metric: "full_month", month: "2026-08" },
+    notify_on_unlock: true,
+    notify_message: "解鎖 {name}",
+    created_at: "2026-01-01",
+  };
+
+  it("surfaces the unlocked achievements projected to the notice shape", async () => {
+    AchievementEngine.evaluate.mockResolvedValueOnce({ unlocked: [FULL_ROW] });
+    seedStones("Ualice", 50000);
+
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+
+    expect(res.ok).toBe(true);
+    expect(res.unlocked).toEqual([
+      {
+        id: 900,
+        key: "secret",
+        name: "全勤",
+        icon: "🗓",
+        rarity: 3,
+        reward_stones: 500,
+        category_key: "signin",
+      },
+    ]);
+    // 既有欄位不得被破壞
+    expect(res.date).toBe("2026-08-05");
+    expect(res.cost).toBe(20000);
+  });
+
+  it("never leaks condition / notify_message through the makeup result", async () => {
+    AchievementEngine.evaluate.mockResolvedValueOnce({ unlocked: [FULL_ROW] });
+    seedStones("Ualice", 50000);
+
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+    const json = JSON.stringify(res);
+
+    ["condition", "notify_message", "notify_on_unlock", "category_id", "created_at"].forEach(k =>
+      expect(res.unlocked[0]).not.toHaveProperty(k)
+    );
+    expect(json).not.toContain("full_month");
+    expect(json).not.toContain("解鎖 {name}");
+    expect(json).not.toContain("秘密條件");
+  });
+
+  it("returns an empty array when nothing unlocked", async () => {
+    seedStones("Ualice", 50000);
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+    expect(res.unlocked).toEqual([]);
+  });
+
+  it("returns an empty array when the engine yields no unlocked key", async () => {
+    AchievementEngine.evaluate.mockResolvedValueOnce({});
+    seedStones("Ualice", 50000);
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+    expect(res.unlocked).toEqual([]);
+  });
+
+  it("does not attach unlocked to a rejected makeup", async () => {
+    seedStones("Ualice", 1);
+    const res = await SigninService.makeup("Ualice", "2026-08-05");
+    expect(res.ok).toBe(false);
+    expect(res.unlocked).toBeUndefined();
+  });
+
+  it("still hands raw rows to internal callers via evaluateAchievements", async () => {
+    // notifyUnlocks 需要 notify_message / notify_on_unlock，內部路徑不可被投影破壞
+    AchievementEngine.evaluate.mockResolvedValueOnce({ unlocked: [FULL_ROW] });
+
+    const res = await SigninService.evaluateAchievements("Ualice", {
+      source: "normal",
+      date: TODAY,
+    });
+
+    expect(res.unlocked[0]).toHaveProperty("notify_message", "解鎖 {name}");
+    expect(res.unlocked[0]).toHaveProperty("notify_on_unlock", true);
   });
 });

--- a/app/src/controller/application/AchievementController.js
+++ b/app/src/controller/application/AchievementController.js
@@ -7,6 +7,7 @@ const AchievementEngine = require("../../service/AchievementEngine");
 const UserTitleModel = require("../../model/application/UserTitle");
 const UserAchievementModel = require("../../model/application/UserAchievement");
 const AchievementTemplate = require("../../templates/application/Achievement");
+const { toPublicList } = require("../../service/achievementPublicView");
 
 const lineClient = getClient("line");
 const RANKING_CACHE_KEY = "AchievementRanking_v1";
@@ -47,7 +48,8 @@ exports.api = {
     try {
       const AchievementModel = require("../../model/application/Achievement");
       const achievements = await AchievementModel.allWithCategories();
-      res.json(achievements);
+      // 公開列表：condition / notify_* 等內部欄位不得外流（玩家會挖 API）
+      res.json(toPublicList(achievements));
     } catch (err) {
       res.status(500).json({ message: err.message });
     }

--- a/app/src/controller/application/SigninController.js
+++ b/app/src/controller/application/SigninController.js
@@ -35,8 +35,14 @@ exports.apiMakeup = async (req, res) => {
     }
 
     // 成功回傳最新月曆，前端不必再打一次 GET。
+    // unlocked 為本次補簽新解鎖的成就（可能為空陣列），讓前端直接跳慶祝動畫。
     const payload = await SigninService.getCalendar(userId);
-    res.json({ ...payload, ok: true, created: { date: result.date, cost: result.cost } });
+    res.json({
+      ...payload,
+      ok: true,
+      created: { date: result.date, cost: result.cost },
+      unlocked: result.unlocked || [],
+    });
   } catch (e) {
     DefaultLogger.error("[me/signins/makeup]", e);
     res.status(500).json({ error: "internal_error" });

--- a/app/src/model/application/UserAchievement.js
+++ b/app/src/model/application/UserAchievement.js
@@ -29,11 +29,23 @@ exports.isUnlocked = async (userId, achievementId) => {
   return !!row;
 };
 
+/**
+ * Idempotent unlock. Returns whether this call is the one that actually
+ * inserted the row — two concurrent evaluate() passes both reach here, but
+ * INSERT IGNORE only lets one through, and only that one may pay the reward.
+ *
+ * knex.raw resolves to [ResultSetHeader, fields]; affectedRows is 1 on insert
+ * and 0 when the unique key made MySQL ignore it.
+ *
+ * @returns {Promise<Boolean>} true when a new row was created
+ */
 exports.unlock = async (userId, achievementId) => {
-  return mysql.raw(`INSERT IGNORE INTO ${TABLE} (user_id, achievement_id) VALUES (?, ?)`, [
-    userId,
-    achievementId,
-  ]);
+  const result = await mysql.raw(
+    `INSERT IGNORE INTO ${TABLE} (user_id, achievement_id) VALUES (?, ?)`,
+    [userId, achievementId]
+  );
+  const header = Array.isArray(result) ? result[0] : result;
+  return Number(header && header.affectedRows) > 0;
 };
 
 exports.getUnlockedIds = async (userId, achievementIds) => {

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -5,6 +5,8 @@ const CategoryModel = require("../model/application/AchievementCategory");
 const { DefaultLogger } = require("../util/Logger");
 const mysql = require("../util/mysql");
 const redis = require("../util/redis");
+const { todayUtc8 } = require("../util/date");
+const { toPublic, toPublicList } = require("./achievementPublicView");
 const { LV_MAX_TOTAL_EXP } = require("../../seeds/ChatExpUnitSeeder");
 
 // --- In-memory cache for achievement definitions (24 rows, rarely changes) ---
@@ -28,8 +30,17 @@ exports._setCache = data => {
 // Shared by evaluate() and getUserSummary() so ineligible rows are filtered
 // from both the unlock path and the collection-rate denominator.
 function isEligible(userId, achievement) {
-  const eligibility =
-    (achievement && achievement.condition && achievement.condition.eligibility) || null;
+  const condition = (achievement && achievement.condition) || null;
+
+  // `availableFrom` (YYYY-MM-DD, Asia/Taipei) hides a not-yet-released row from
+  // both the unlock path and the completion-rate denominator — otherwise a
+  // future achievement would drag everyone's percentage down before it exists.
+  // There is deliberately no `availableUntil`: once live, a row stays live, so
+  // an already-unlocked achievement can never vanish from a user's collection.
+  const availableFrom = condition && condition.availableFrom;
+  if (availableFrom && todayUtc8() < availableFrom) return false;
+
+  const eligibility = (condition && condition.eligibility) || null;
   if (!eligibility) return true;
   const include = Array.isArray(eligibility.includeUserIds) ? eligibility.includeUserIds : null;
   const exclude = Array.isArray(eligibility.excludeUserIds) ? eligibility.excludeUserIds : [];
@@ -134,13 +145,19 @@ const STRATEGIES = {
   // event and the metric, so a new achievement needs no code change here (and
   // its key never has to appear in this file — secret keys stay out of git).
   conditionMetric(currentValue, achievement, context) {
-    const metric = (achievement.condition || {}).metric;
+    const condition = achievement.condition || {};
+    const metric = condition.metric;
     switch (metric) {
       case "streak":
         return STRATEGIES.contextValue(currentValue, achievement, context, "streak");
       case "total":
         return STRATEGIES.contextValue(currentValue, achievement, context, "total");
       case "full_month":
+        // `condition.month` (YYYY-MM) pins a full-month achievement to one
+        // specific month. streak/total are cumulative and deliberately NOT
+        // gated: only the month-shaped metric can be month-specific.
+        // No `month` set = any month counts.
+        if (condition.month && context.month !== condition.month) return currentValue;
         return context.fullMonth ? achievement.target_value : currentValue;
       default:
         DefaultLogger.warn(
@@ -347,8 +364,10 @@ exports.evaluate = async (userId, eventType, context = {}) => {
     // deletes the progress row, and is order-sensitive, so it is not batched.
     for (const achievement of toUnlock) {
       try {
-        await unlockAchievement(userId, achievement);
-        unlocked.push(achievement);
+        // Only push when this pass actually won the INSERT IGNORE race —
+        // otherwise a concurrent evaluate would re-notify an old unlock.
+        const created = await unlockAchievement(userId, achievement);
+        if (created) unlocked.push(achievement);
       } catch (innerErr) {
         DefaultLogger.error(
           `AchievementEngine.evaluate unlock error for key ${achievement.key}:`,
@@ -373,9 +392,28 @@ async function handleTrackedSet(userId, achievementId, newItem, currentValue) {
   return currentValue + 1;
 }
 
+/**
+ * Award one achievement. Returns false when another concurrent pass already
+ * inserted the row — the caller must then NOT treat it as newly unlocked.
+ *
+ * The INSERT IGNORE is the concurrency gate: only the writer that actually
+ * created the row credits stones. Without this, two evaluate() passes racing
+ * on the same achievement each saw "not unlocked yet" during phase 1 and both
+ * paid the reward.
+ *
+ * @returns {Promise<Boolean>} true when this call performed the unlock
+ */
 async function unlockAchievement(userId, achievement) {
-  await UserAchievementModel.unlock(userId, achievement.id);
+  const created = await UserAchievementModel.unlock(userId, achievement.id);
+  // Progress row is dead weight once unlocked, regardless of who won the race.
   await UserProgressModel.delete(userId, achievement.id);
+
+  if (!created) {
+    DefaultLogger.info(
+      `Achievement ${achievement.key} for user ${userId} already unlocked by a concurrent pass; skipping reward`
+    );
+    return false;
+  }
 
   if (achievement.reward_stones > 0) {
     // Append a new ledger row — balance is SUM(itemAmount) across rows.
@@ -392,6 +430,7 @@ async function unlockAchievement(userId, achievement) {
   DefaultLogger.info(
     `Achievement unlocked: ${achievement.key} for user ${userId} (+${achievement.reward_stones} stones)`
   );
+  return true;
 }
 
 exports.getUserSummary = async userId => {
@@ -430,22 +469,29 @@ exports.getUserSummary = async userId => {
       ...cat,
       total: catAchievements.length,
       unlocked: catUnlocked.length,
-      achievements: catAchievements.map(a => ({
-        ...a,
-        isUnlocked: unlockedIds.has(a.id),
-        currentValue: progressMap[a.id] || 0,
-        unlockedAt: (unlocked.find(u => u.id === a.id) || {}).unlocked_at || null,
-      })),
+      achievements: catAchievements.map(a =>
+        toPublic({
+          ...a,
+          isUnlocked: unlockedIds.has(a.id),
+          currentValue: progressMap[a.id] || 0,
+          unlockedAt: (unlocked.find(u => u.id === a.id) || {}).unlocked_at || null,
+        })
+      ),
     };
   });
 
+  // getUserSummary is the shared exit for the LIFF achievement page, the
+  // `/api/achievements/user/:userId` endpoint and the LINE flex card, so the
+  // projection lives here rather than in each caller. The flex template only
+  // reads allowlisted fields (icon/name/rarity/unlocked_at/current_value/
+  // target_value/percentage), so it is unaffected.
   return {
     total,
     unlocked: unlockedCount,
     percentage: total > 0 ? Math.round((unlockedCount / total) * 100) : 0,
     categories: categorySummary,
-    recentUnlocks,
-    nearCompletion,
+    recentUnlocks: toPublicList(recentUnlocks),
+    nearCompletion: toPublicList(nearCompletion),
     profile: userProfile
       ? { displayName: userProfile.display_name, pictureUrl: userProfile.picture_url }
       : null,
@@ -481,7 +527,11 @@ exports.unlockByKey = async (userId, key) => {
     if (unlockedIds.has(achievement.id)) {
       return { unlocked: false, reason: "already_unlocked" };
     }
-    await unlockAchievement(userId, achievement);
+    // The pre-check above is only a fast path; the INSERT IGNORE result is the
+    // authority, so a racing caller reports already_unlocked instead of a
+    // second unlock (and never gets a duplicate reward).
+    const created = await unlockAchievement(userId, achievement);
+    if (!created) return { unlocked: false, reason: "already_unlocked" };
     return { unlocked: true, achievement };
   } catch (err) {
     DefaultLogger.error(`AchievementEngine.unlockByKey error for ${key}:`, err);

--- a/app/src/service/SigninService.js
+++ b/app/src/service/SigninService.js
@@ -3,6 +3,7 @@ const mysql = require("../util/mysql");
 const { todayUtc8 } = require("../util/date");
 const gacha = require("../model/princess/gacha");
 const AchievementEngine = require("./AchievementEngine");
+const { toUnlockNoticeList } = require("./achievementPublicView");
 const { DefaultLogger } = require("../util/Logger");
 
 const TABLE = "signin_ledger";
@@ -106,7 +107,8 @@ async function recordNormal(userId, options = {}) {
  *
  * @param {String} userId
  * @param {String} date YYYY-MM-DD
- * @returns {Promise<{ok: Boolean, code?: String, date?: String, cost?: Number, balance?: Number}>}
+ * @returns {Promise<{ok: Boolean, code?: String, date?: String, cost?: Number,
+ *   balance?: Number, unlocked?: Array}>}
  */
 async function makeup(userId, date) {
   if (!isValidDate(date)) return { ok: false, code: "INVALID_DATE" };
@@ -161,9 +163,12 @@ async function makeup(userId, date) {
     throw e;
   }
 
-  await evaluateAchievements(userId, { source: "makeup", date });
+  // evaluateAchievements 自己吞例外並回 { unlocked: [] }，補簽本身已經 commit，
+  // 成就掛掉不該讓呼叫端以為補簽失敗。
+  // 這裡是給前端的出口，投影成 unlock notice —— 不得帶出 condition / notify_message。
+  const { unlocked } = await evaluateAchievements(userId, { source: "makeup", date });
 
-  return { ok: true, date, cost: MAKEUP_COST };
+  return { ok: true, date, cost: MAKEUP_COST, unlocked: toUnlockNoticeList(unlocked) };
 }
 
 /**
@@ -250,6 +255,10 @@ async function evaluateAchievements(userId, meta) {
     return await AchievementEngine.evaluate(userId, "signin", {
       source: meta.source,
       date: meta.date,
+      // 當前月份（UTC+8 的 YYYY-MM）—— 讓 definition 能用 condition.month 綁定
+      // 特定月份的全勤成就。不從 meta.date 推導：補簽的是過去某天，
+      // 但 fullMonth 講的一律是「現在這個月」，兩者混用會在跨月時給錯月份。
+      month: summary.month,
       streak: summary.streak,
       total: summary.total,
       monthCount: summary.monthCount,

--- a/app/src/service/achievementPublicView.js
+++ b/app/src/service/achievementPublicView.js
@@ -1,0 +1,80 @@
+const { pick } = require("lodash");
+
+/**
+ * Public projections for achievement rows.
+ *
+ * `achievements` rows carry fields that must never reach a client:
+ *   - `condition`       unlock rules, secret thresholds, eligibility user lists
+ *   - `notify_message`  wording that can reveal how an achievement is earned
+ *   - `notify_on_unlock` internal delivery flag
+ *   - `category_id`, `created_at`, `updated_at` internal bookkeeping
+ *
+ * Players datamine this codebase, so anything shipped to the browser is public.
+ * These projections are allowlists, not blocklists: a column added to the table
+ * later stays private by default instead of silently leaking on the next deploy.
+ *
+ * Internal consumers (achievementNotifier needs `notify_message` /
+ * `notify_on_unlock`) keep using the raw rows and must NOT go through here.
+ */
+
+// Everything the achievement browser legitimately renders.
+const PUBLIC_FIELDS = [
+  "id",
+  "key",
+  "name",
+  "description",
+  "icon",
+  "type",
+  "rarity",
+  "target_value",
+  "reward_stones",
+  "order",
+  "category_key",
+  "category_name",
+  "category_icon",
+];
+
+// Composite/joined fields assembled by the callers on top of a base row.
+const DERIVED_FIELDS = [
+  "isUnlocked",
+  "currentValue",
+  "unlockedAt",
+  "unlocked_at",
+  "current_value",
+  "percentage",
+];
+
+// A freshly unlocked achievement only needs enough to render a toast.
+const UNLOCK_NOTICE_FIELDS = [
+  "id",
+  "key",
+  "name",
+  "icon",
+  "rarity",
+  "reward_stones",
+  "category_key",
+];
+
+const toPublic = achievement =>
+  achievement ? pick(achievement, [...PUBLIC_FIELDS, ...DERIVED_FIELDS]) : achievement;
+
+const toPublicList = rows => (Array.isArray(rows) ? rows.map(toPublic) : []);
+
+/**
+ * Shape used when telling a client "you just unlocked this".
+ * Deliberately narrower than toPublic — no description/target_value, since the
+ * unlock toast does not need the criteria and they may be secret.
+ */
+const toUnlockNotice = achievement =>
+  achievement ? pick(achievement, UNLOCK_NOTICE_FIELDS) : achievement;
+
+const toUnlockNoticeList = rows => (Array.isArray(rows) ? rows.map(toUnlockNotice) : []);
+
+module.exports = {
+  PUBLIC_FIELDS,
+  UNLOCK_NOTICE_FIELDS,
+  toPublic,
+  toPublicList,
+  toUnlockNotice,
+  toUnlockNoticeList,
+};

--- a/frontend/src/pages/Achievement/constants.js
+++ b/frontend/src/pages/Achievement/constants.js
@@ -1,0 +1,30 @@
+// Shared achievement display maps. Kept out of index.jsx because a page file
+// may only export components (react-refresh/only-export-components) — pages
+// other than Achievement (e.g. Signin's unlock toast) render the same icons.
+import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutlined";
+import CatchingPokemonIcon from "@mui/icons-material/CatchingPokemon";
+import GavelIcon from "@mui/icons-material/Gavel";
+import ShieldIcon from "@mui/icons-material/Shield";
+import PeopleIcon from "@mui/icons-material/People";
+import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+
+export const RARITY_CONFIG = {
+  0: { label: "普通", color: "#757575", bg: "#f5f5f5" },
+  1: { label: "稀有", color: "#6c5ce7", bg: "#ede7f6" },
+  2: { label: "史詩", color: "#b8860b", bg: "#fff8e1" },
+  3: { label: "傳說", color: "#d63384", bg: "#fce4ec" },
+};
+
+// Category-level fallback, keyed by `category_key`. Signin achievement keys are
+// deliberately absent from ACHIEVEMENT_ICONS (they are not committed), so they
+// resolve here — a new signin achievement needs no frontend change.
+export const CATEGORY_ICONS = {
+  chat: ChatBubbleOutlineIcon,
+  gacha: CatchingPokemonIcon,
+  janken: GavelIcon,
+  world_boss: ShieldIcon,
+  social: PeopleIcon,
+  subscribe: CardGiftcardIcon,
+  signin: CalendarMonthIcon,
+};

--- a/frontend/src/pages/Achievement/index.jsx
+++ b/frontend/src/pages/Achievement/index.jsx
@@ -39,13 +39,7 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutlined";
 import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
 import DiamondIcon from "@mui/icons-material/Diamond";
 import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
-
-const RARITY_CONFIG = {
-  0: { label: "普通", color: "#757575", bg: "#f5f5f5" },
-  1: { label: "稀有", color: "#6c5ce7", bg: "#ede7f6" },
-  2: { label: "史詩", color: "#b8860b", bg: "#fff8e1" },
-  3: { label: "傳說", color: "#d63384", bg: "#fce4ec" },
-};
+import { RARITY_CONFIG, CATEGORY_ICONS } from "./constants";
 
 const ACHIEVEMENT_ICONS = {
   chat_100: ChatBubbleOutlineIcon,
@@ -77,15 +71,6 @@ const ACHIEVEMENT_ICONS = {
   subscribe_6: DiamondIcon,
   subscribe_12: AccountBalanceIcon,
   legacy_pioneer: AccountBalanceIcon,
-};
-
-const CATEGORY_ICONS = {
-  chat: ChatBubbleOutlineIcon,
-  gacha: CatchingPokemonIcon,
-  janken: GavelIcon,
-  world_boss: ShieldIcon,
-  social: PeopleIcon,
-  subscribe: CardGiftcardIcon,
 };
 
 const CARD_HEIGHT = 180;

--- a/frontend/src/pages/Signin/index.jsx
+++ b/frontend/src/pages/Signin/index.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
+  Avatar,
   Box,
   Button,
   ButtonBase,
@@ -12,15 +13,18 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  IconButton,
   LinearProgress,
   Paper,
   Skeleton,
+  Snackbar,
   Stack,
   Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
 import DiamondIcon from "@mui/icons-material/Diamond";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import EventAvailableIcon from "@mui/icons-material/EventAvailable";
@@ -31,6 +35,7 @@ import useLiff from "../../context/useLiff";
 import AlertLogin from "../../components/AlertLogin";
 import HintSnackBar from "../../components/HintSnackBar";
 import useHintBar from "../../hooks/useHintBar";
+import { CATEGORY_ICONS, RARITY_CONFIG } from "../Achievement/constants";
 
 // Backend day boundary is Asia/Taipei (UTC+8) — same convention as
 // pages/XpHistory/dateTpe.js. Parse the API's ISO date at +08:00 and read the
@@ -261,6 +266,102 @@ function Legend() {
   );
 }
 
+/* ---------- achievement unlock toast ---------- */
+
+// POST /api/me/signins/makeup returns the calendar payload with `ok` /
+// `created` as siblings (see the API contract) — `unlocked` arrives the same
+// way, a top-level array of achievement rows, not nested in a wrapper.
+function readUnlocked(payload) {
+  const list = payload && payload.unlocked;
+  return Array.isArray(list) ? list.filter(Boolean) : [];
+}
+
+function UnlockRow({ achievement }) {
+  const rarity = RARITY_CONFIG[achievement.rarity] || RARITY_CONFIG[0];
+  // Keys of signin achievements are intentionally not in the frontend, so the
+  // icon resolves from the row's own emoji first, then the category fallback.
+  const FallbackIcon = CATEGORY_ICONS[achievement.category_key] || EmojiEventsIcon;
+  const reward = Number(achievement.reward_stones) || 0;
+
+  return (
+    <Stack direction="row" spacing={1.25} sx={{ alignItems: "center" }}>
+      <Avatar
+        variant="rounded"
+        sx={{
+          width: 36,
+          height: 36,
+          flexShrink: 0,
+          bgcolor: rarity.bg,
+          color: rarity.color,
+          fontSize: 18,
+        }}
+      >
+        {achievement.icon || <FallbackIcon sx={{ fontSize: 20 }} />}
+      </Avatar>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography variant="body2" noWrap sx={{ fontWeight: 700 }}>
+          {achievement.name}
+        </Typography>
+        <Typography variant="caption" sx={{ color: rarity.color, fontWeight: 600 }}>
+          {rarity.label}
+        </Typography>
+      </Box>
+      {reward > 0 && (
+        <Chip
+          size="small"
+          icon={<DiamondIcon sx={{ fontSize: "0.85rem !important" }} />}
+          label={`+${num(reward)}`}
+          sx={{ flexShrink: 0, fontWeight: 700, height: 22, fontSize: "0.72rem" }}
+        />
+      )}
+    </Stack>
+  );
+}
+
+function UnlockToast({ items, onClose }) {
+  const count = items.length;
+  // Long enough to read every row, short enough not to camp on the calendar.
+  const duration = Math.min(4500 + count * 1800, 10000);
+
+  return (
+    <Snackbar
+      open={count > 0}
+      autoHideDuration={duration}
+      onClose={(_, reason) => reason !== "clickaway" && onClose()}
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      sx={{ maxWidth: "min(420px, calc(100vw - 32px))" }}
+    >
+      <Paper
+        elevation={8}
+        role="status"
+        aria-live="polite"
+        sx={{
+          width: "100%",
+          p: 1.75,
+          borderRadius: 3,
+          borderTop: 4,
+          borderTopColor: "secondary.main",
+        }}
+      >
+        <Stack direction="row" spacing={1} sx={{ alignItems: "center", mb: 1.25 }}>
+          <EmojiEventsIcon sx={{ fontSize: 20, color: "secondary.main" }} />
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, flex: 1 }}>
+            {count > 1 ? `補簽成功，解鎖 ${count} 項成就！` : "補簽成功，還解鎖了新成就！"}
+          </Typography>
+          <IconButton size="small" onClick={onClose} aria-label="關閉成就通知">
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+        <Stack spacing={1.25} sx={{ maxHeight: 200, overflowY: "auto" }}>
+          {items.map(a => (
+            <UnlockRow key={a.id ?? a.key ?? a.name} achievement={a} />
+          ))}
+        </Stack>
+      </Paper>
+    </Snackbar>
+  );
+}
+
 /* ---------- page ---------- */
 
 export default function Signin() {
@@ -271,6 +372,7 @@ export default function Signin() {
   const [target, setTarget] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const [dialogError, setDialogError] = useState("");
+  const [unlocked, setUnlocked] = useState([]);
   const [hint, { handleOpen: showHint, handleClose: closeHint }] = useHintBar();
 
   useEffect(() => {
@@ -332,13 +434,22 @@ export default function Signin() {
       .then(res => {
         setData(res.data);
         setTarget(null);
-        showHint(`已補簽 ${fullDateLabel(target)}`, "success");
+        const unlocks = readUnlocked(res.data);
+        // One toast at a time: the unlock card already says 補簽成功, so the
+        // plain hint would just fight it for the same corner.
+        if (unlocks.length) {
+          closeHint();
+          setUnlocked(unlocks);
+        } else {
+          showHint(`已補簽 ${fullDateLabel(target)}`, "success");
+        }
       })
       .catch(err => {
         const code = err?.response?.data?.code;
         const message = ERROR_MSG[code] || err?.response?.data?.message || "補簽失敗，請稍後再試。";
         if (code === "ALREADY_SIGNED") {
           setTarget(null);
+          setUnlocked([]);
           showHint(message, "warning");
           load();
           return;
@@ -626,6 +737,8 @@ export default function Signin() {
         severity={hint.severity}
         onClose={closeHint}
       />
+
+      <UnlockToast items={unlocked} onClose={() => setUnlocked([])} />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- 讓 DB-driven 簽到成就支援指定月份與台灣日期 `availableFrom`，未到月份不顯示、不納入完成率
- 補簽成功時回傳新解鎖成就，LIFF 顯示支援多項成就的解鎖提示
- 新增簽到分類 icon fallback，私人 achievement key 不需進 frontend
- achievement API 改用 allowlist public view，避免洩漏 `condition`、eligibility 與通知模板
- 以 `INSERT IGNORE affectedRows` 防止併發 evaluate 重複發放女神石

## Test plan
- [x] Backend focused：175 passed / 7 suites
- [x] Backend full suite：1041 passed / 123 suites
- [x] App lint
- [x] Frontend lint：0 errors（58 existing warnings）
- [x] Frontend production build
- [x] Production unique index `(user_id, achievement_id)` verified

## Deployment notes
- PR 不包含實際簽到 achievement definitions 或門檻；待新 code 部署後，才以私人 SQL 建立 definitions。
- 線上 `signin_ledger` 歷史資料已另行完成 add-only 補償並保留 `signin_ledger_bak_20260807` 備份，不依賴此 PR migration。
- 本次沒有新增 dependency、schema migration 或環境變數。

🤖 Generated with [Claude Code](https://claude.com/claude-code)