### PR TITLE
fix(achievement): 補齊賽跑與市集分類圖示

### DIFF
--- a/frontend/src/pages/Achievement/constants.js
+++ b/frontend/src/pages/Achievement/constants.js
@@ -8,6 +8,8 @@ import ShieldIcon from "@mui/icons-material/Shield";
 import PeopleIcon from "@mui/icons-material/People";
 import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import SportsScoreIcon from "@mui/icons-material/SportsScore";
+import StorefrontIcon from "@mui/icons-material/Storefront";
 
 export const RARITY_CONFIG = {
   0: { label: "普通", color: "#757575", bg: "#f5f5f5" },
@@ -27,4 +29,6 @@ export const CATEGORY_ICONS = {
   social: PeopleIcon,
   subscribe: CardGiftcardIcon,
   signin: CalendarMonthIcon,
+  race: SportsScoreIcon,
+  market: StorefrontIcon,
 };


### PR DESCRIPTION
## Summary
- 為賽跑成就分類加入終點旗 icon
- 為市集成就分類加入店面 icon
- 沿用既有 MUI category fallback，不新增 dependency

## Test plan
- [x] `yarn lint:frontend`（0 errors；58 個既有 warnings）
- [x] `yarn build:frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)