### PR TITLE
feat(auth): 改用 Redis session 延長 LIFF 登入

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ REDIS_PASSWORD=
 #LINE_LIFF_FULL_ID=
 
 ### LINE Login Channel（LIFF 管理用，make cf-tunnel 自動更新 LIFF endpoint）
+### LINE_LOGIN_CHANNEL_ID 同時是 runtime 必要設定：
+###   POST /api/auth/session 會拿它當 client_id 去 LINE 驗證 LIFF ID token，
+###   沒設定的話登入服務會回 503。必須是 LIFF app 所屬的那個 Login channel。
 #LINE_LOGIN_CHANNEL_ID=
 #LINE_LOGIN_CHANNEL_SECRET=
 
@@ -46,6 +49,9 @@ REDIS_PASSWORD=
 ##########################################################
 
 PROJECT_NAME=redive
+### 正式站的 canonical origin，也是 cookie session 的 same-origin 白名單來源。
+### 可寫 host（pudding.hanshino.dev）或含 scheme（https://pudding.hanshino.dev）。
+### make cf-tunnel 會就地覆寫成當下的 trycloudflare host。
 APP_DOMAIN=redivebot.local
 
 ### 使用資料庫名稱 #########################################

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# These two files are stored with CRLF endings (they predate any line-ending
+# policy). Without this, git counts each CR as trailing whitespace and
+# `git diff --check` fails on every line added to them. Scoped deliberately to
+# just these paths rather than `*`, so repo-wide whitespace policy is unchanged.
+# No `text`/`eol` attribute is set, so git performs no checkin/checkout
+# conversion and file contents are untouched.
+/.env.example whitespace=cr-at-eol
+/app/server.js whitespace=cr-at-eol

--- a/app/server.js
+++ b/app/server.js
@@ -9,9 +9,13 @@ const express = require("express");
 const { rateLimit, ipKeyGenerator } = require("express-rate-limit");
 const { bottender } = require("bottender");
 const apiRouter = require("./src/router/api");
-const cors = require("cors");
+const { checkOriginConfig } = require("./src/service/AuthSessionService");
 const { server, http } = require("./src/util/connection");
 require("./src/router/socket");
+
+// Surfaced at boot rather than on the first rejected request — a bad
+// APP_DOMAIN fails closed and would otherwise look like a random 403 storm.
+checkOriginConfig();
 
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -40,7 +44,8 @@ app.prepare().then(() => {
     req.rawBody = buf.toString();
   };
 
-  server.use(cors());
+  // No CORS middleware: auth is a same-origin HttpOnly cookie, and the old
+  // wildcard `cors()` would have handed any origin a credentialed read path.
   server.use(express.json({ verify, limit: "3mb" }));
   server.use(express.urlencoded({ extended: false, verify }));
 

--- a/app/src/middleware/__tests__/validation.auth.test.js
+++ b/app/src/middleware/__tests__/validation.auth.test.js
@@ -1,0 +1,268 @@
+// The global setup.js mocks this module to bypass auth everywhere else;
+// these tests are about the real thing.
+jest.unmock("../validation");
+jest.mock("../../service/AuthSessionService", () => {
+  const actual = jest.requireActual("../../service/AuthSessionService");
+  return {
+    ...actual,
+    getSession: jest.fn(),
+  };
+});
+jest.mock("../../model/application/Admin", () => ({
+  getList: jest.fn().mockResolvedValue([]),
+}));
+
+const AuthSessionService = require("../../service/AuthSessionService");
+const AdminModel = require("../../model/application/Admin");
+const { verifyToken, socketSetProfile, socketVerifyAdmin } = jest.requireActual("../validation");
+
+const USER_ID = "U" + "a".repeat(32);
+const PROFILE = { userId: USER_ID, displayName: "Alice", pictureUrl: null };
+const OLD_ENV = process.env;
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function makeReq({ method = "GET", cookie, origin } = {}) {
+  const headers = {};
+  if (cookie !== undefined) headers.cookie = cookie;
+  if (origin !== undefined) headers.origin = origin;
+  return {
+    method,
+    headers,
+    get(name) {
+      return headers[name.toLowerCase()];
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = { ...OLD_ENV, NODE_ENV: "production", APP_DOMAIN: "pudding.example" };
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  console.error.mockRestore();
+});
+
+afterAll(() => {
+  process.env = OLD_ENV;
+});
+
+describe("verifyToken (cookie session)", () => {
+  it("sets req.profile from the session and calls next", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const req = makeReq({ cookie: "redive_session=tok" });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(req, res, next);
+
+    expect(AuthSessionService.getSession).toHaveBeenCalledWith("tok");
+    expect(req.profile).toEqual(PROFILE);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBeNull();
+  });
+
+  it("401s when no cookie is present", async () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+    expect(AuthSessionService.getSession).not.toHaveBeenCalled();
+  });
+
+  it("401s when the session is missing or invalid in Redis", async () => {
+    AuthSessionService.getSession.mockResolvedValue(null);
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(makeReq({ cookie: "redive_session=stale" }), res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("503s (not 401) when Redis is unreachable, so the cookie survives", async () => {
+    AuthSessionService.getSession.mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(makeReq({ cookie: "redive_session=tok" }), res, next);
+
+    expect(res.statusCode).toBe(503);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("ignores an Authorization bearer header — no fallback path remains", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const req = makeReq();
+    req.headers.authorization = "Bearer liff-access-token";
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("403s an unsafe request from a foreign origin (CSRF guard)", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(
+      makeReq({ method: "POST", cookie: "redive_session=tok", origin: "https://evil.example" }),
+      res,
+      next
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+    expect(AuthSessionService.getSession).not.toHaveBeenCalled();
+  });
+
+  it("allows an unsafe request from the canonical origin", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(
+      makeReq({ method: "POST", cookie: "redive_session=tok", origin: "https://pudding.example" }),
+      res,
+      next
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not origin-check safe reads", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const res = makeRes();
+    const next = jest.fn();
+
+    await verifyToken(
+      makeReq({ cookie: "redive_session=tok", origin: "https://evil.example" }),
+      res,
+      next
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("socketSetProfile", () => {
+  function makeSocket({ cookie, origin } = {}) {
+    const headers = {};
+    if (cookie !== undefined) headers.cookie = cookie;
+    if (origin !== undefined) headers.origin = origin;
+    return { handshake: { headers }, data: {} };
+  }
+
+  it("puts the profile on socket.data and calls next once", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const socket = makeSocket({ cookie: "redive_session=tok", origin: "https://pudding.example" });
+    const next = jest.fn();
+
+    await socketSetProfile(socket, next);
+
+    expect(socket.data.profile).toEqual(PROFILE);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("rejects a handshake with no cookie", async () => {
+    const next = jest.fn();
+    await socketSetProfile(makeSocket(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it("rejects a cross-origin handshake", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const next = jest.fn();
+
+    await socketSetProfile(
+      makeSocket({ cookie: "redive_session=tok", origin: "https://evil.example" }),
+      next
+    );
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(AuthSessionService.getSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects a dead session", async () => {
+    AuthSessionService.getSession.mockResolvedValue(null);
+    const socket = makeSocket({ cookie: "redive_session=stale" });
+    const next = jest.fn();
+
+    await socketSetProfile(socket, next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(socket.data.profile).toBeUndefined();
+  });
+
+  it("does not ignore a token supplied via handshake.query", async () => {
+    AuthSessionService.getSession.mockResolvedValue(PROFILE);
+    const socket = makeSocket();
+    socket.handshake.query = { token: "liff-access-token" };
+    const next = jest.fn();
+
+    await socketSetProfile(socket, next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+});
+
+describe("socketVerifyAdmin", () => {
+  it("calls next exactly once when the user is not an admin", async () => {
+    AdminModel.getList.mockResolvedValue([]);
+    const next = jest.fn();
+
+    await socketVerifyAdmin({ data: { profile: PROFILE } }, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it("merges admin data and passes when the user is an admin", async () => {
+    AdminModel.getList.mockResolvedValue([{ userId: USER_ID, privilege: 9 }]);
+    const socket = { data: { profile: PROFILE } };
+    const next = jest.fn();
+
+    await socketVerifyAdmin(socket, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(socket.data.profile.privilege).toBe(9);
+  });
+
+  it("rejects when the admin lookup blows up", async () => {
+    AdminModel.getList.mockRejectedValue(new Error("db down"));
+    const next = jest.fn();
+
+    await socketVerifyAdmin({ data: { profile: PROFILE } }, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+});

--- a/app/src/middleware/validation.js
+++ b/app/src/middleware/validation.js
@@ -1,5 +1,10 @@
-const { default: axios } = require("axios");
 const AdminModel = require("../model/application/Admin");
+const {
+  SAFE_METHODS,
+  readSessionToken,
+  getSession,
+  isAllowedOrigin,
+} = require("../service/AuthSessionService");
 
 /**
  * 驗證Line來源id
@@ -38,33 +43,36 @@ exports.verifyLineUserId = (userId, res, next) => {
 };
 
 /**
- * 驗證line token
- * @param {String} token Liff的token
+ * Cookie session authentication. No Authorization bearer fallback exists —
+ * the only credential the browser holds is the HttpOnly `redive_session`
+ * cookie, so an attacker page cannot read or replay it.
+ *
+ * Contract kept from the old LIFF-token middleware: on success `req.profile`
+ * carries `{ userId, displayName, pictureUrl }`.
  */
-exports.verifyToken = (req, res, next) => {
-  const auth = req.get("Authorization");
-
-  if (auth === undefined) {
-    return Unauthorized(res);
+exports.verifyToken = async (req, res, next) => {
+  // Cookie auth is ambient, so unsafe verbs need a same-origin check (CSRF).
+  if (!SAFE_METHODS.has(req.method) && !isAllowedOrigin(req.get("Origin"))) {
+    return Forbidden(res);
   }
 
-  const token = auth.split(" ")[1] || "";
+  const token = readSessionToken(req.headers.cookie);
+  if (!token) return Unauthorized(res);
 
-  axios
-    .get("https://api.line.me/v2/profile", {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-    .then(resp => {
-      if (resp.status !== 200) return Promise.reject();
-      return resp.data;
-    })
-    .then(profile => {
-      req.profile = profile;
-      next();
-    })
-    .catch(() => Unauthorized(res));
+  let profile;
+  try {
+    profile = await getSession(token);
+  } catch (err) {
+    // Redis is down: the session may well be valid, so do NOT log the user
+    // out — 503 keeps the client's cookie and lets it retry.
+    console.error("[auth] session lookup failed", err && err.message);
+    return ServiceUnavailable(res);
+  }
+
+  if (!profile) return Unauthorized(res);
+
+  req.profile = profile;
+  next();
 };
 
 exports.verifyAdmin = async (req, res, next) => {
@@ -96,45 +104,44 @@ exports.verifyPrivilege = (allow = 9) => {
 };
 
 exports.socketSetProfile = async (socket, next) => {
-  const { token } = socket.handshake.query;
-
-  if (token === null || token === "null" || token === undefined) {
-    next(new Error("Authentication error"));
-    return;
+  if (!isAllowedOrigin(socket.handshake.headers.origin)) {
+    return next(new Error("Authentication error"));
   }
 
-  const profile = await axios
-    .get("https://api.line.me/v2/profile", {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-    .then(resp => {
-      if (resp.status !== 200) return Promise.reject();
-      return resp.data;
-    })
-    .catch(() => {
-      next(new Error("Authentication error"));
-      return;
-    });
+  const token = readSessionToken(socket.handshake.headers.cookie);
+  if (!token) return next(new Error("Authentication error"));
 
-  if (profile === false) return;
+  let profile;
+  try {
+    profile = await getSession(token);
+  } catch (err) {
+    console.error("[auth] socket session lookup failed", err && err.message);
+    return next(new Error("Service unavailable"));
+  }
 
-  socket.handshake.query = {
-    ...socket.handshake.query,
-    ...profile,
-  };
+  if (!profile) return next(new Error("Authentication error"));
 
+  socket.data.profile = profile;
   return next();
 };
 
 exports.socketVerifyAdmin = async (socket, next) => {
-  const { userId } = socket.handshake.query;
+  const { userId } = socket.data.profile || {};
 
-  const adminList = await AdminModel.getList();
-  var adminData = adminList.find(data => data.userId === userId);
-  if (adminData === undefined) next(new Error("Authentication error"));
+  let adminData;
+  try {
+    const adminList = await AdminModel.getList();
+    adminData = adminList.find(data => data.userId === userId);
+  } catch (err) {
+    console.error("[auth] socket admin lookup failed", err && err.message);
+    return next(new Error("Service unavailable"));
+  }
 
+  // Every branch must call next() exactly once — calling it twice lets an
+  // unauthorized socket through after the rejection.
+  if (adminData === undefined) return next(new Error("Authentication error"));
+
+  socket.data.profile = { ...socket.data.profile, ...adminData };
   return next();
 };
 
@@ -144,4 +151,8 @@ function Unauthorized(res) {
 
 function Forbidden(res) {
   res.status(403).json({ message: "forbidden" });
+}
+
+function ServiceUnavailable(res) {
+  res.status(503).json({ message: "session store unavailable." });
 }

--- a/app/src/router/__tests__/auth.test.js
+++ b/app/src/router/__tests__/auth.test.js
@@ -1,0 +1,267 @@
+const request = require("supertest");
+const express = require("express");
+
+jest.mock("../../service/AuthSessionService", () => {
+  const actual = jest.requireActual("../../service/AuthSessionService");
+  return {
+    ...actual,
+    verifyIdToken: jest.fn(),
+    createSession: jest.fn(),
+    destroySession: jest.fn(),
+  };
+});
+
+const AuthSessionService = require("../../service/AuthSessionService");
+
+const USER_ID = "U" + "a".repeat(32);
+const PROFILE = { userId: USER_ID, displayName: "Alice", pictureUrl: null };
+const OLD_ENV = process.env;
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", require("../auth"));
+  return app;
+}
+
+let app;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = { ...OLD_ENV, NODE_ENV: "production", APP_DOMAIN: "pudding.example" };
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  app = createApp();
+});
+
+afterEach(() => {
+  console.error.mockRestore();
+});
+
+afterAll(() => {
+  process.env = OLD_ENV;
+});
+
+describe("POST /api/auth/session", () => {
+  it("exchanges a verified ID token for an HttpOnly session cookie", async () => {
+    AuthSessionService.verifyIdToken.mockResolvedValue(PROFILE);
+    AuthSessionService.createSession.mockResolvedValue("session-token");
+
+    const res = await request(app)
+      .post("/api/auth/session")
+      .set("Origin", "https://pudding.example")
+      .send({ idToken: "id-token" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(PROFILE);
+    expect(AuthSessionService.verifyIdToken).toHaveBeenCalledWith("id-token");
+    expect(AuthSessionService.createSession).toHaveBeenCalledWith(PROFILE);
+
+    const cookie = res.headers["set-cookie"][0];
+    expect(cookie).toContain("redive_session=session-token");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("Secure");
+    expect(cookie).not.toContain("Domain=");
+    expect(cookie).toContain("Max-Age=2592000");
+    // the LIFF ID token must never come back to the browser
+    expect(res.headers["set-cookie"].join()).not.toContain("id-token");
+  });
+
+  it("omits Secure outside production so http://localhost works", async () => {
+    process.env.NODE_ENV = "development";
+    AuthSessionService.verifyIdToken.mockResolvedValue(PROFILE);
+    AuthSessionService.createSession.mockResolvedValue("session-token");
+
+    const res = await request(app)
+      .post("/api/auth/session")
+      .set("Origin", "http://localhost:3000")
+      .send({ idToken: "id-token" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["set-cookie"][0]).not.toContain("Secure");
+  });
+
+  it("rotates: new session is minted before the old one is dropped", async () => {
+    AuthSessionService.verifyIdToken.mockResolvedValue(PROFILE);
+    AuthSessionService.createSession.mockResolvedValue("new-token");
+    AuthSessionService.destroySession.mockResolvedValue(1);
+
+    const res = await request(app)
+      .post("/api/auth/session")
+      .set("Cookie", "redive_session=old-token")
+      .send({ idToken: "id-token" });
+
+    expect(res.status).toBe(200);
+    expect(AuthSessionService.destroySession).toHaveBeenCalledWith("old-token");
+    expect(AuthSessionService.createSession.mock.invocationCallOrder[0]).toBeLessThan(
+      AuthSessionService.destroySession.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("keeps the old session when minting the new one fails", async () => {
+    AuthSessionService.verifyIdToken.mockResolvedValue(PROFILE);
+    AuthSessionService.createSession.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await request(app)
+      .post("/api/auth/session")
+      .set("Cookie", "redive_session=old-token")
+      .send({ idToken: "id-token" });
+
+    expect(res.status).toBe(503);
+    expect(AuthSessionService.destroySession).not.toHaveBeenCalled();
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  // The exchange has four distinct failure modes and they must NOT collapse
+  // into one status. Only 401 tells the frontend "your session is invalid";
+  // reporting a LINE outage or a config gap that way would make it discard a
+  // working login and, in the outage case, hammer login on every retry.
+  describe("verify failure classification", () => {
+    const { AuthError } = jest.requireActual("../../service/AuthSessionService");
+
+    it("401s when LINE explicitly rejects the token", async () => {
+      AuthSessionService.verifyIdToken.mockRejectedValue(
+        new AuthError("INVALID_ID_TOKEN", "LINE rejected the id token (400)")
+      );
+
+      const res = await request(app).post("/api/auth/session").send({ idToken: "forged" });
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: "invalid id token." });
+      expect(AuthSessionService.createSession).not.toHaveBeenCalled();
+      expect(res.headers["set-cookie"]).toBeUndefined();
+    });
+
+    it("401s when the 200 payload fails aud/iss/sub checks", async () => {
+      AuthSessionService.verifyIdToken.mockRejectedValue(
+        new AuthError("INVALID_ID_TOKEN", "id token verify: audience mismatch")
+      );
+
+      const res = await request(app).post("/api/auth/session").send({ idToken: "forged" });
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: "invalid id token." });
+    });
+
+    it("502s — not 401 — when LINE is unreachable or times out", async () => {
+      AuthSessionService.verifyIdToken.mockRejectedValue(
+        new AuthError("LINE_UNAVAILABLE", "LINE verify endpoint unreachable (ECONNABORTED)")
+      );
+
+      const res = await request(app).post("/api/auth/session").send({ idToken: "id-token" });
+
+      expect(res.status).toBe(502);
+      expect(res.body).toEqual({ message: "line authentication unavailable." });
+      expect(AuthSessionService.createSession).not.toHaveBeenCalled();
+      // no cookie is cleared either — the caller's existing session survives
+      expect(res.headers["set-cookie"]).toBeUndefined();
+    });
+
+    it("503s when LINE_LOGIN_CHANNEL_ID is not configured", async () => {
+      AuthSessionService.verifyIdToken.mockRejectedValue(
+        new AuthError("AUTH_CONFIG", "LINE_LOGIN_CHANNEL_ID is not configured")
+      );
+
+      const res = await request(app).post("/api/auth/session").send({ idToken: "id-token" });
+
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({ message: "auth configuration unavailable." });
+    });
+
+    it("502s an unclassified error rather than claiming the token is invalid", async () => {
+      AuthSessionService.verifyIdToken.mockRejectedValue(new TypeError("undefined is not a fn"));
+
+      const res = await request(app).post("/api/auth/session").send({ idToken: "id-token" });
+
+      expect(res.status).toBe(502);
+      expect(res.body).toEqual({ message: "line authentication unavailable." });
+    });
+  });
+
+  it("400s a missing or non-string idToken", async () => {
+    expect((await request(app).post("/api/auth/session").send({})).status).toBe(400);
+    expect((await request(app).post("/api/auth/session").send({ idToken: 42 })).status).toBe(400);
+    expect((await request(app).post("/api/auth/session").send({ idToken: "" })).status).toBe(400);
+    expect(AuthSessionService.verifyIdToken).not.toHaveBeenCalled();
+  });
+
+  it("400s an oversized idToken without spending an outbound call on it", async () => {
+    const { MAX_ID_TOKEN_LENGTH } = jest.requireActual("../../service/AuthSessionService");
+
+    const res = await request(app)
+      .post("/api/auth/session")
+      .send({ idToken: "x".repeat(MAX_ID_TOKEN_LENGTH + 1) });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ message: "idToken is malformed." });
+    expect(AuthSessionService.verifyIdToken).not.toHaveBeenCalled();
+  });
+
+  it("still accepts a token right at the length limit", async () => {
+    const { MAX_ID_TOKEN_LENGTH } = jest.requireActual("../../service/AuthSessionService");
+    AuthSessionService.verifyIdToken.mockResolvedValue(PROFILE);
+    AuthSessionService.createSession.mockResolvedValue("session-token");
+
+    const res = await request(app)
+      .post("/api/auth/session")
+      .send({ idToken: "x".repeat(MAX_ID_TOKEN_LENGTH) });
+
+    expect(res.status).toBe(200);
+    expect(AuthSessionService.verifyIdToken).toHaveBeenCalled();
+  });
+
+  it("403s a cross-origin exchange attempt", async () => {
+    const res = await request(app)
+      .post("/api/auth/session")
+      .set("Origin", "https://evil.example")
+      .send({ idToken: "id-token" });
+
+    expect(res.status).toBe(403);
+    expect(AuthSessionService.verifyIdToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/auth/logout", () => {
+  it("deletes the session and clears the cookie", async () => {
+    AuthSessionService.destroySession.mockResolvedValue(1);
+
+    const res = await request(app)
+      .post("/api/auth/logout")
+      .set("Origin", "https://pudding.example")
+      .set("Cookie", "redive_session=tok");
+
+    expect(res.status).toBe(200);
+    expect(AuthSessionService.destroySession).toHaveBeenCalledWith("tok");
+    const cookie = res.headers["set-cookie"][0];
+    expect(cookie).toContain("redive_session=;");
+    expect(cookie).toContain("HttpOnly");
+  });
+
+  it("is idempotent when there is no session cookie", async () => {
+    const res = await request(app).post("/api/auth/logout");
+
+    expect(res.status).toBe(200);
+    expect(AuthSessionService.destroySession).not.toHaveBeenCalled();
+    expect(res.headers["set-cookie"][0]).toContain("redive_session=;");
+  });
+
+  it("503s and keeps the cookie when Redis cannot be reached", async () => {
+    AuthSessionService.destroySession.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await request(app).post("/api/auth/logout").set("Cookie", "redive_session=tok");
+
+    expect(res.status).toBe(503);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("403s a cross-origin logout", async () => {
+    const res = await request(app)
+      .post("/api/auth/logout")
+      .set("Origin", "https://evil.example")
+      .set("Cookie", "redive_session=tok");
+
+    expect(res.status).toBe(403);
+    expect(AuthSessionService.destroySession).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/router/api.js
+++ b/app/src/router/api.js
@@ -39,6 +39,7 @@ const moment = require("moment");
 const XpHistoryService = require("../service/XpHistoryService");
 const { todayUtc8 } = require("../util/date");
 
+router.use(require("./auth"));
 router.use(MarketRouter);
 router.use(InventoryRouter);
 router.use(TradeRouter);

--- a/app/src/router/auth.js
+++ b/app/src/router/auth.js
@@ -1,0 +1,103 @@
+const express = require("express");
+const router = express.Router();
+const {
+  MAX_ID_TOKEN_LENGTH,
+  readSessionToken,
+  setSessionCookie,
+  clearSessionCookie,
+  isAllowedOrigin,
+  verifyIdToken,
+  createSession,
+  destroySession,
+} = require("../service/AuthSessionService");
+
+// Maps AuthError.code -> wire response. Keyed on the code the service sets,
+// never on message text. An unrecognised code falls through to 502 rather
+// than 401: an unclassified failure must not be reported to the browser as
+// "your session is invalid", because that is the one answer that makes the
+// frontend throw away a working login.
+const VERIFY_FAILURES = {
+  INVALID_ID_TOKEN: { status: 401, message: "invalid id token." },
+  LINE_UNAVAILABLE: { status: 502, message: "line authentication unavailable." },
+  AUTH_CONFIG: { status: 503, message: "auth configuration unavailable." },
+};
+const VERIFY_FALLBACK = VERIFY_FAILURES.LINE_UNAVAILABLE;
+
+/**
+ * POST /api/auth/session
+ * Exchange a LIFF ID token for an opaque server session. The ID token is
+ * verified against LINE and then dropped — it is never stored anywhere.
+ */
+router.post("/auth/session", async (req, res) => {
+  if (!isAllowedOrigin(req.get("Origin"))) {
+    return res.status(403).json({ message: "forbidden" });
+  }
+
+  const idToken = req.body && req.body.idToken;
+  if (typeof idToken !== "string" || idToken === "") {
+    return res.status(400).json({ message: "idToken is required." });
+  }
+  if (idToken.length > MAX_ID_TOKEN_LENGTH) {
+    return res.status(400).json({ message: "idToken is malformed." });
+  }
+
+  let profile;
+  try {
+    profile = await verifyIdToken(idToken);
+  } catch (err) {
+    const failure = VERIFY_FAILURES[err && err.code] || VERIFY_FALLBACK;
+    console.error("[auth] id token verify failed", {
+      code: (err && err.code) || "UNCLASSIFIED",
+      status: failure.status,
+      message: err && err.message,
+    });
+    return res.status(failure.status).json({ message: failure.message });
+  }
+
+  // Rotate: mint the new session before dropping the old one, so a Redis
+  // failure halfway through never leaves the caller with no session at all.
+  const previousToken = readSessionToken(req.headers.cookie);
+  let token;
+  try {
+    token = await createSession(profile);
+  } catch (err) {
+    console.error("[auth] session create failed", err && err.message);
+    return res.status(503).json({ message: "session store unavailable." });
+  }
+
+  if (previousToken && previousToken !== token) {
+    destroySession(previousToken).catch(err =>
+      console.error("[auth] stale session cleanup failed", err && err.message)
+    );
+  }
+
+  setSessionCookie(res, token);
+  res.json(profile);
+});
+
+/**
+ * POST /api/auth/logout — idempotent; no session is still a 200.
+ */
+router.post("/auth/logout", async (req, res) => {
+  if (!isAllowedOrigin(req.get("Origin"))) {
+    return res.status(403).json({ message: "forbidden" });
+  }
+
+  const token = readSessionToken(req.headers.cookie);
+
+  if (token) {
+    try {
+      await destroySession(token);
+    } catch (err) {
+      // Leave the cookie in place: clearing it while the Redis record still
+      // lives would strand a session nobody can revoke.
+      console.error("[auth] session destroy failed", err && err.message);
+      return res.status(503).json({ message: "session store unavailable." });
+    }
+  }
+
+  clearSessionCookie(res);
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/app/src/service/AuthSessionService.js
+++ b/app/src/service/AuthSessionService.js
@@ -1,0 +1,316 @@
+const crypto = require("crypto");
+const { default: axios } = require("axios");
+const redis = require("../util/redis");
+
+const SESSION_COOKIE_NAME = "redive_session";
+const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // fixed absolute TTL, no sliding expiration
+const SESSION_KEY_PREFIX = "auth:session:";
+const VERIFY_URL = "https://api.line.me/oauth2/v2.1/verify";
+const VERIFY_TIMEOUT_MS = 5000;
+const LINE_ISSUER = "https://access.line.me";
+const LINE_USER_ID = /^U[a-f0-9]{32}$/;
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+// LINE ID tokens are JWTs, normally well under 2KB. The cap is a guard on the
+// outbound request body, not a validity check — anything longer cannot be a
+// token we would accept anyway, so reject it before spending a call on LINE.
+const MAX_ID_TOKEN_LENGTH = 4096;
+
+/**
+ * Failure classes for the ID-token exchange. The router maps `code` to a
+ * status; nothing matches on message text.
+ *
+ *  AUTH_CONFIG      the bot is misconfigured (no LINE_LOGIN_CHANNEL_ID)  -> 503
+ *  INVALID_ID_TOKEN LINE rejected it, or the payload did not check out   -> 401
+ *  LINE_UNAVAILABLE LINE could not be reached / answered 5xx             -> 502
+ *
+ * The INVALID vs UNAVAILABLE split matters: only INVALID means "your session
+ * is dead". Reporting a LINE outage as 401 would make the frontend discard a
+ * perfectly good login.
+ */
+class AuthError extends Error {
+  constructor(code, message, cause) {
+    super(message);
+    this.name = "AuthError";
+    this.code = code;
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+/**
+ * Cookie header parser. Express only exposes `req.cookies` with cookie-parser,
+ * and Socket.IO hands us the raw handshake header anyway, so one shared reader
+ * covers both. Writing is done through Express `res.cookie`.
+ */
+function parseCookies(header) {
+  const out = {};
+  if (typeof header !== "string" || header === "") return out;
+
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 1) continue;
+    const key = part.slice(0, eq).trim();
+    if (key === "" || Object.prototype.hasOwnProperty.call(out, key)) continue;
+
+    let value = part.slice(eq + 1).trim();
+    if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    }
+    try {
+      out[key] = decodeURIComponent(value);
+    } catch {
+      out[key] = value;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Opaque session token carried by the cookie. Never a LINE credential.
+ */
+function readSessionToken(cookieHeader) {
+  return parseCookies(cookieHeader)[SESSION_COOKIE_NAME] || null;
+}
+
+function sessionKey(token) {
+  return SESSION_KEY_PREFIX + crypto.createHash("sha256").update(token).digest("hex");
+}
+
+function isSecureCookie() {
+  return process.env.NODE_ENV === "production";
+}
+
+function cookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: isSecureCookie(),
+  };
+}
+
+function setSessionCookie(res, token) {
+  res.cookie(SESSION_COOKIE_NAME, token, {
+    ...cookieOptions(),
+    maxAge: SESSION_TTL_SECONDS * 1000,
+  });
+}
+
+function clearSessionCookie(res) {
+  res.clearCookie(SESSION_COOKIE_NAME, cookieOptions());
+}
+
+/**
+ * Canonical browser origin for this deployment. APP_DOMAIN is allowed to carry
+ * a scheme or not (`make cf-tunnel` writes a bare host).
+ */
+function canonicalOrigin() {
+  const raw = (process.env.APP_DOMAIN || "").trim();
+  if (raw === "") return null;
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  try {
+    return new URL(withScheme).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Boot-time sanity check, called from server.js.
+ *
+ * In production a missing/unparseable APP_DOMAIN leaves `canonicalOrigin()`
+ * null, and since the localhost escape hatch is production-disabled, every
+ * browser write and every Socket.IO handshake would then be rejected. That is
+ * fail-closed rather than fail-open, so it is loud but not fatal — a hard exit
+ * would take the LINE webhook down with it, which is strictly worse than a
+ * degraded LIFF frontend.
+ */
+function checkOriginConfig() {
+  if (process.env.NODE_ENV !== "production") return true;
+  if (canonicalOrigin()) return true;
+
+  console.error(
+    "[auth] FATAL-ish: APP_DOMAIN is missing or unparseable (%j). No canonical " +
+      "origin can be derived, so every cookie-authenticated write and every " +
+      "Socket.IO handshake carrying an Origin header will be rejected with 403. " +
+      "Set APP_DOMAIN to the public host, e.g. pudding.hanshino.dev",
+    process.env.APP_DOMAIN
+  );
+  return false;
+}
+
+/**
+ * Same-origin guard for cookie-authenticated requests.
+ *
+ * This is defence in depth, not the primary CSRF control — SameSite=Lax
+ * already stops the browser attaching `redive_session` to any cross-site
+ * unsafe request at all.
+ *
+ * A missing Origin is allowed: browsers send Origin on every non-GET/HEAD
+ * request and on every WebSocket handshake, so "no Origin" means a non-browser
+ * caller, which had to supply the session cookie by hand and therefore already
+ * holds the secret. Rejecting it would only break curl and the supertest suite
+ * without closing a hole.
+ */
+function isAllowedOrigin(origin) {
+  if (origin === undefined || origin === null || origin === "") return true;
+  if (typeof origin !== "string") return false;
+
+  let parsed;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return false;
+  }
+
+  const canonical = canonicalOrigin();
+  if (canonical && parsed.origin === canonical) return true;
+
+  // Dev runs the frontend on the Vite dev server, which proxies /api and
+  // /socket.io to the bot while keeping the browser Origin on :3000.
+  if (
+    process.env.NODE_ENV !== "production" &&
+    (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function normalizeProfile(profile) {
+  return {
+    userId: profile.userId,
+    displayName: typeof profile.displayName === "string" ? profile.displayName : "",
+    pictureUrl: typeof profile.pictureUrl === "string" ? profile.pictureUrl : null,
+  };
+}
+
+/**
+ * Verify a LIFF ID token against LINE and return the normalized profile.
+ * Only server-verified claims are trusted — nothing from the request body.
+ *
+ * @throws {AuthError} always an AuthError, so the caller can classify without
+ * inspecting message strings. See the AuthError docblock for the codes.
+ */
+async function verifyIdToken(idToken) {
+  const clientId = process.env.LINE_LOGIN_CHANNEL_ID;
+  if (!clientId) {
+    throw new AuthError("AUTH_CONFIG", "LINE_LOGIN_CHANNEL_ID is not configured");
+  }
+
+  const body = new URLSearchParams({ id_token: idToken, client_id: clientId });
+
+  let data;
+  try {
+    ({ data } = await axios.post(VERIFY_URL, body.toString(), {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      timeout: VERIFY_TIMEOUT_MS,
+    }));
+  } catch (err) {
+    const status = err.response && err.response.status;
+
+    // A 4xx is LINE telling us the token is bad (400 invalid_request /
+    // 401 invalid token). Anything else — timeout, DNS, socket reset, 5xx —
+    // is LINE being unreachable and says nothing about the token.
+    if (status >= 400 && status < 500) {
+      throw new AuthError("INVALID_ID_TOKEN", `LINE rejected the id token (${status})`, err);
+    }
+
+    throw new AuthError(
+      "LINE_UNAVAILABLE",
+      `LINE verify endpoint unreachable (${status || err.code || err.message})`,
+      err
+    );
+  }
+
+  // From here LINE answered 200; any mismatch is a token problem, not an outage.
+  if (!data || typeof data !== "object") {
+    throw new AuthError("INVALID_ID_TOKEN", "id token verify: empty response");
+  }
+
+  const aud = Array.isArray(data.aud) ? data.aud : [data.aud];
+  if (!aud.includes(clientId)) {
+    throw new AuthError("INVALID_ID_TOKEN", "id token verify: audience mismatch");
+  }
+  if (data.iss !== LINE_ISSUER) {
+    throw new AuthError("INVALID_ID_TOKEN", "id token verify: issuer mismatch");
+  }
+  if (!LINE_USER_ID.test(data.sub || "")) {
+    throw new AuthError("INVALID_ID_TOKEN", "id token verify: invalid subject");
+  }
+
+  return normalizeProfile({
+    userId: data.sub,
+    displayName: data.name,
+    pictureUrl: data.picture,
+  });
+}
+
+/**
+ * @returns {Promise<string>} the opaque session token (cookie value)
+ * @throws when Redis is unreachable — callers must surface 503, not 401
+ */
+async function createSession(profile) {
+  const token = crypto.randomBytes(32).toString("base64url");
+  const payload = JSON.stringify({
+    profile: normalizeProfile(profile),
+    createdAt: new Date().toISOString(),
+  });
+
+  const stored = await redis.set(sessionKey(token), payload, {
+    EX: SESSION_TTL_SECONDS,
+    NX: true,
+  });
+  if (stored !== "OK") throw new Error("failed to persist session");
+
+  return token;
+}
+
+/**
+ * @returns {Promise<object|null>} profile, or null when the session is gone or
+ * unreadable. Redis failures reject so callers can tell 401 from 503.
+ */
+async function getSession(token) {
+  if (typeof token !== "string" || token === "") return null;
+
+  const raw = await redis.get(sessionKey(token));
+  if (!raw) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const profile = parsed && parsed.profile;
+  if (!profile || !LINE_USER_ID.test(profile.userId || "")) return null;
+
+  return normalizeProfile(profile);
+}
+
+async function destroySession(token) {
+  if (typeof token !== "string" || token === "") return 0;
+  return redis.del(sessionKey(token));
+}
+
+module.exports = {
+  SESSION_COOKIE_NAME,
+  SESSION_TTL_SECONDS,
+  MAX_ID_TOKEN_LENGTH,
+  SAFE_METHODS,
+  AuthError,
+  parseCookies,
+  readSessionToken,
+  setSessionCookie,
+  clearSessionCookie,
+  canonicalOrigin,
+  checkOriginConfig,
+  isAllowedOrigin,
+  verifyIdToken,
+  createSession,
+  getSession,
+  destroySession,
+};

--- a/app/src/service/__tests__/AuthSessionService.test.js
+++ b/app/src/service/__tests__/AuthSessionService.test.js
@@ -1,0 +1,320 @@
+jest.mock("../../util/redis", () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+}));
+jest.mock("axios", () => ({ default: { post: jest.fn() }, post: jest.fn() }));
+
+const redis = require("../../util/redis");
+const { default: axios } = require("axios");
+const crypto = require("crypto");
+const AuthSessionService = require("../AuthSessionService");
+
+const USER_ID = "U" + "a".repeat(32);
+const OLD_ENV = process.env;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = { ...OLD_ENV, LINE_LOGIN_CHANNEL_ID: "1234567890", APP_DOMAIN: "pudding.example" };
+});
+
+afterAll(() => {
+  process.env = OLD_ENV;
+});
+
+describe("parseCookies / readSessionToken", () => {
+  it("parses a multi-cookie header and picks the session cookie", () => {
+    const header = "foo=1; redive_session=abc%2Fdef; bar=2";
+    expect(AuthSessionService.parseCookies(header)).toMatchObject({
+      foo: "1",
+      redive_session: "abc/def",
+      bar: "2",
+    });
+    expect(AuthSessionService.readSessionToken(header)).toBe("abc/def");
+  });
+
+  it("returns null for missing / malformed headers", () => {
+    expect(AuthSessionService.readSessionToken(undefined)).toBeNull();
+    expect(AuthSessionService.readSessionToken("")).toBeNull();
+    expect(AuthSessionService.readSessionToken("redive_session")).toBeNull();
+    expect(AuthSessionService.readSessionToken("other=x")).toBeNull();
+  });
+
+  it("keeps the first occurrence so a duplicate cookie cannot shadow the real one", () => {
+    expect(AuthSessionService.readSessionToken("redive_session=real; redive_session=fake")).toBe(
+      "real"
+    );
+  });
+});
+
+describe("isAllowedOrigin", () => {
+  it("accepts the canonical APP_DOMAIN origin with or without a scheme", () => {
+    expect(AuthSessionService.isAllowedOrigin("https://pudding.example")).toBe(true);
+    process.env.APP_DOMAIN = "https://pudding.example";
+    expect(AuthSessionService.isAllowedOrigin("https://pudding.example")).toBe(true);
+  });
+
+  it("rejects other origins in production", () => {
+    process.env.NODE_ENV = "production";
+    expect(AuthSessionService.isAllowedOrigin("https://evil.example")).toBe(false);
+    expect(AuthSessionService.isAllowedOrigin("http://localhost:3000")).toBe(false);
+    expect(AuthSessionService.isAllowedOrigin("null")).toBe(false);
+    // suffix / prefix tricks must not pass
+    expect(AuthSessionService.isAllowedOrigin("https://pudding.example.evil.com")).toBe(false);
+    expect(AuthSessionService.isAllowedOrigin("https://evil-pudding.example")).toBe(false);
+  });
+
+  it("allows localhost outside production for the Vite proxy", () => {
+    process.env.NODE_ENV = "development";
+    expect(AuthSessionService.isAllowedOrigin("http://localhost:3000")).toBe(true);
+    expect(AuthSessionService.isAllowedOrigin("http://127.0.0.1:3000")).toBe(true);
+  });
+
+  it("allows an absent Origin (non-browser caller already holds the cookie)", () => {
+    expect(AuthSessionService.isAllowedOrigin(undefined)).toBe(true);
+    expect(AuthSessionService.isAllowedOrigin("")).toBe(true);
+  });
+});
+
+describe("verifyIdToken", () => {
+  const validPayload = {
+    iss: "https://access.line.me",
+    aud: "1234567890",
+    sub: USER_ID,
+    name: "Alice",
+    picture: "https://cdn.example/a.jpg",
+  };
+
+  it("posts to LINE with the configured client_id and returns only verified claims", async () => {
+    axios.post.mockResolvedValue({ data: { ...validPayload, email: "leak@example.com" } });
+
+    const profile = await AuthSessionService.verifyIdToken("id-token");
+
+    const [url, body] = axios.post.mock.calls[0];
+    expect(url).toBe("https://api.line.me/oauth2/v2.1/verify");
+    expect(body).toContain("client_id=1234567890");
+    expect(body).toContain("id_token=id-token");
+    expect(profile).toEqual({
+      userId: USER_ID,
+      displayName: "Alice",
+      pictureUrl: "https://cdn.example/a.jpg",
+    });
+  });
+
+  // Every rejection must be an AuthError carrying a code — the router
+  // classifies on `code` alone, so an uncoded throw would silently degrade
+  // to the 502 fallback.
+  async function expectAuthError(promise, code) {
+    await expect(promise).rejects.toBeInstanceOf(AuthSessionService.AuthError);
+    await expect(promise).rejects.toMatchObject({ code });
+  }
+
+  it("rejects a token minted for another channel", async () => {
+    axios.post.mockResolvedValue({ data: { ...validPayload, aud: "9999" } });
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "INVALID_ID_TOKEN");
+  });
+
+  it("rejects a foreign issuer", async () => {
+    axios.post.mockResolvedValue({ data: { ...validPayload, iss: "https://evil.example" } });
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "INVALID_ID_TOKEN");
+  });
+
+  it("rejects a subject that is not a LINE user id", async () => {
+    axios.post.mockResolvedValue({ data: { ...validPayload, sub: "not-a-user" } });
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "INVALID_ID_TOKEN");
+  });
+
+  it("rejects an empty or non-object 200 payload", async () => {
+    axios.post.mockResolvedValue({ data: null });
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "INVALID_ID_TOKEN");
+
+    axios.post.mockResolvedValue({ data: "not-an-object" });
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "INVALID_ID_TOKEN");
+  });
+
+  it("accepts an aud array that contains our channel", async () => {
+    axios.post.mockResolvedValue({ data: { ...validPayload, aud: ["other", "1234567890"] } });
+    await expect(AuthSessionService.verifyIdToken("t")).resolves.toMatchObject({
+      userId: USER_ID,
+    });
+  });
+
+  it.each([400, 401, 403, 404, 429])("classifies a LINE %i as INVALID_ID_TOKEN", async status => {
+    axios.post.mockRejectedValue({ response: { status } });
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "INVALID_ID_TOKEN");
+  });
+
+  it.each([500, 502, 503, 504])("classifies a LINE %i as LINE_UNAVAILABLE", async status => {
+    axios.post.mockRejectedValue({ response: { status } });
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "LINE_UNAVAILABLE");
+  });
+
+  it("classifies a timeout as LINE_UNAVAILABLE, never as an invalid token", async () => {
+    axios.post.mockRejectedValue(
+      Object.assign(new Error("timeout of 5000ms exceeded"), { code: "ECONNABORTED" })
+    );
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "LINE_UNAVAILABLE");
+  });
+
+  it("classifies a network failure (no response) as LINE_UNAVAILABLE", async () => {
+    axios.post.mockRejectedValue(
+      Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" })
+    );
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "LINE_UNAVAILABLE");
+  });
+
+  it("preserves the underlying error as `cause` for debugging", async () => {
+    const underlying = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    axios.post.mockRejectedValue(underlying);
+    await expect(AuthSessionService.verifyIdToken("t")).rejects.toMatchObject({
+      cause: underlying,
+    });
+  });
+
+  it("refuses to run without LINE_LOGIN_CHANNEL_ID, before calling LINE", async () => {
+    delete process.env.LINE_LOGIN_CHANNEL_ID;
+    await expectAuthError(AuthSessionService.verifyIdToken("t"), "AUTH_CONFIG");
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});
+
+describe("createSession", () => {
+  it("stores a hashed key with a 30-day TTL and NX, and returns the raw token", async () => {
+    redis.set.mockResolvedValue("OK");
+
+    const token = await AuthSessionService.createSession({
+      userId: USER_ID,
+      displayName: "Alice",
+      pictureUrl: null,
+    });
+
+    // base64url of 32 random bytes
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+    const [key, value, options] = redis.set.mock.calls[0];
+    const expected = crypto.createHash("sha256").update(token).digest("hex");
+    expect(key).toBe(`auth:session:${expected}`);
+    // the raw token must never be the Redis key
+    expect(key).not.toContain(token);
+    expect(options).toEqual({ EX: 30 * 24 * 60 * 60, NX: true });
+
+    const stored = JSON.parse(value);
+    expect(stored.profile).toEqual({
+      userId: USER_ID,
+      displayName: "Alice",
+      pictureUrl: null,
+    });
+    expect(typeof stored.createdAt).toBe("string");
+  });
+
+  it("stores nothing beyond the normalized profile (no LINE credentials)", async () => {
+    redis.set.mockResolvedValue("OK");
+    await AuthSessionService.createSession({
+      userId: USER_ID,
+      displayName: "Alice",
+      pictureUrl: null,
+      accessToken: "SECRET",
+      idToken: "SECRET",
+    });
+
+    const value = redis.set.mock.calls[0][1];
+    expect(value).not.toContain("SECRET");
+    expect(Object.keys(JSON.parse(value))).toEqual(["profile", "createdAt"]);
+  });
+
+  it("throws when Redis refuses the write", async () => {
+    redis.set.mockResolvedValue(null);
+    await expect(AuthSessionService.createSession({ userId: USER_ID })).rejects.toThrow(
+      "failed to persist session"
+    );
+  });
+
+  it("propagates Redis outages instead of swallowing them", async () => {
+    redis.set.mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(AuthSessionService.createSession({ userId: USER_ID })).rejects.toThrow(
+      "ECONNREFUSED"
+    );
+  });
+});
+
+describe("getSession", () => {
+  it("returns the normalized profile for a live session", async () => {
+    redis.get.mockResolvedValue(
+      JSON.stringify({ profile: { userId: USER_ID, displayName: "Alice", pictureUrl: null } })
+    );
+    await expect(AuthSessionService.getSession("token")).resolves.toEqual({
+      userId: USER_ID,
+      displayName: "Alice",
+      pictureUrl: null,
+    });
+  });
+
+  it("returns null for a missing, corrupt, or malformed session", async () => {
+    redis.get.mockResolvedValue(null);
+    await expect(AuthSessionService.getSession("token")).resolves.toBeNull();
+
+    redis.get.mockResolvedValue("{not json");
+    await expect(AuthSessionService.getSession("token")).resolves.toBeNull();
+
+    redis.get.mockResolvedValue(JSON.stringify({ profile: { userId: "bogus" } }));
+    await expect(AuthSessionService.getSession("token")).resolves.toBeNull();
+  });
+
+  it("returns null for an empty token without hitting Redis", async () => {
+    await expect(AuthSessionService.getSession("")).resolves.toBeNull();
+    await expect(AuthSessionService.getSession(undefined)).resolves.toBeNull();
+    expect(redis.get).not.toHaveBeenCalled();
+  });
+
+  it("propagates Redis outages so callers can answer 503 rather than 401", async () => {
+    redis.get.mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(AuthSessionService.getSession("token")).rejects.toThrow("ECONNREFUSED");
+  });
+});
+
+describe("checkOriginConfig", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  it("passes quietly in production with a usable APP_DOMAIN", () => {
+    process.env.NODE_ENV = "production";
+    expect(AuthSessionService.checkOriginConfig()).toBe(true);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("logs loudly in production when APP_DOMAIN cannot yield an origin", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.APP_DOMAIN;
+
+    expect(AuthSessionService.checkOriginConfig()).toBe(false);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error.mock.calls[0][0]).toContain("APP_DOMAIN");
+  });
+
+  it("stays silent outside production, where localhost is allowed anyway", () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.APP_DOMAIN;
+
+    expect(AuthSessionService.checkOriginConfig()).toBe(true);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("destroySession", () => {
+  it("deletes the hashed key", async () => {
+    redis.del.mockResolvedValue(1);
+    await AuthSessionService.destroySession("token");
+    const expected = crypto.createHash("sha256").update("token").digest("hex");
+    expect(redis.del).toHaveBeenCalledWith(`auth:session:${expected}`);
+  });
+
+  it("is a no-op for an empty token", async () => {
+    await expect(AuthSessionService.destroySession("")).resolves.toBe(0);
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/util/connection.js
+++ b/app/src/util/connection.js
@@ -4,9 +4,21 @@ const server = express();
 exports.server = server;
 exports.http = require("http").createServer(this.server);
 
+// The removed `origins: "*:*"` was a Socket.IO v2 key that v4 ignores outright,
+// so dropping it changes no behaviour — it was just misleading.
+//
+// No `cors` option either, which means engine.io sends no CORS headers and a
+// browser cannot read a cross-origin polling response. That is NOT the security
+// boundary though: WebSocket upgrades are not subject to CORS at all. What
+// actually protects the `/admin/messages` namespace is
+//   1. SameSite=Lax on redive_session — the browser will not attach the session
+//      cookie to a cross-site handshake in the first place, and
+//   2. socketSetProfile / socketVerifyAdmin, which check the handshake Origin
+//      and resolve the session server-side before any event is delivered.
+// Hence no global `allowRequest`: it would duplicate (2) for every namespace,
+// including the unauthenticated default one that only counts online users.
 exports.io = require("socket.io")().attach(this.http, {
   log: false,
   agent: false,
-  origins: "*:*",
   transports: ["websocket", "htmlfile", "xhr-polling", "jsonp-polling", "polling"],
 });

--- a/frontend/src/context/LiffProvider.jsx
+++ b/frontend/src/context/LiffProvider.jsx
@@ -1,11 +1,10 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import liff from "@line/liff";
-import api, { setAuthToken, clearAuthToken } from "../services/api";
+import api from "../services/api";
 import { FullPageLoading } from "../components/Loading";
 import { debugLog } from "../utils/debugLogger";
 import { LiffContext } from "./LiffContext";
 
-const TOKEN_KEY = "liff_access_token";
 const SIZE_KEY = "liff_size";
 const DEFAULT_SIZE = "full";
 
@@ -33,39 +32,65 @@ export default function LiffProvider({ children }) {
   const initPromiseRef = useRef(null);
   const initStartedRef = useRef(false);
 
+  // `loggedIn` now means "the backend holds a session for us", not "the LIFF
+  // SDK has a token". The only credential in the browser is the HttpOnly
+  // redive_session cookie, which JS cannot read — so /api/me is the probe.
+  const applyProfile = useCallback(data => {
+    setProfile(data);
+    setIsAdmin(data.privilege !== undefined);
+    setLoggedIn(true);
+  }, []);
+
+  const clearProfile = useCallback(() => {
+    setProfile(null);
+    setIsAdmin(false);
+    setLoggedIn(false);
+  }, []);
+
+  /**
+   * @returns {Promise<"ok"|"unauthorized"|"error">}
+   */
   const fetchProfile = useCallback(async () => {
-    debugLog("FETCH_PROFILE_START");
     try {
       const { data } = await api.get("/api/me");
-      setProfile(data);
-      const admin = data.privilege !== undefined;
-      setIsAdmin(admin);
-      debugLog("FETCH_PROFILE_OK", { isAdmin: admin, userId: data.userId?.substring(0, 8) });
+      applyProfile(data);
+      debugLog("FETCH_PROFILE_OK", {
+        isAdmin: data.privilege !== undefined,
+        userId: data.userId?.substring(0, 8),
+      });
+      return "ok";
     } catch (err) {
       const status = err.response?.status;
       debugLog("FETCH_PROFILE_FAIL", { status, message: err.message });
-      // Only the 401 path means "token is dead" — the axios interceptor
-      // (services/api.js) already cleared storage and redirected; just sync
-      // local state. Network errors / 5xx are transient: keep the token so
-      // the next request can succeed without forcing a fresh LIFF login.
       if (status === 401) {
-        setLoggedIn(false);
-        setProfile(null);
-        setIsAdmin(false);
+        clearProfile();
+        return "unauthorized";
       }
+      // 503 (Redis down) / network / 5xx are transient: the cookie may still
+      // be perfectly valid, so don't tear the session down over it.
+      return "error";
     }
-  }, []);
+  }, [applyProfile, clearProfile]);
+
+  // Any 401 anywhere in the app means the cookie session is gone. Sync the
+  // logged-out state and stop there: no automatic re-exchange, because the
+  // bootstrap effect below owns the single exchange attempt and a second
+  // trigger point is exactly how this turns into a login loop.
+  //
+  // Registered before the bootstrap effect so the bootstrap's own initial 401
+  // is observed too — that path is harmless, it clears state that a later
+  // successful exchange then restores via applyProfile.
+  useEffect(() => {
+    window.addEventListener("auth:unauthorized", clearProfile);
+    return () => window.removeEventListener("auth:unauthorized", clearProfile);
+  }, [clearProfile]);
 
   useEffect(() => {
     // Guard against StrictMode double-invoke — ref survives unmount/remount
     if (initStartedRef.current) return;
     initStartedRef.current = true;
 
-    const storedToken = window.localStorage.getItem(TOKEN_KEY);
-    debugLog("INIT_START", {
-      route: window.location.pathname,
-      hasStoredToken: !!storedToken,
-    });
+    debugLog("INIT_START", { route: window.location.pathname });
 
     // Always run liff.init(): LIFF's secondary redirect lands on the user's
     // intended path (e.g. /rankings) without a /liff/ prefix or liff.state
@@ -75,51 +100,68 @@ export default function LiffProvider({ children }) {
     if (!initPromiseRef.current) {
       initPromiseRef.current = initLiffSdk();
     }
+
     initPromiseRef.current
-      .then(async () => {
-        const isLoggedIn = liff.isLoggedIn();
-        debugLog("LIFF_SDK_INIT", { success: true, isLoggedIn });
-        if (isLoggedIn) {
-          const token = liff.getAccessToken();
-          debugLog("LIFF_LOGGED_IN", { tokenPrefix: token?.substring(0, 8) });
-          window.localStorage.setItem(TOKEN_KEY, token);
-          setAuthToken(token);
-          setLoggedIn(true);
-          try {
-            setLiffCtx(liff.getContext() || {});
-          } catch (err) {
-            console.warn("Failed to get LIFF context:", err);
-          }
-          await fetchProfile();
-        } else if (storedToken) {
-          // SDK initialized but says not logged in (typical for external
-          // browsers that haven't gone through liff.login yet). Try the
-          // stored token; the API will tell us via 401 if it's stale.
-          debugLog("FALLBACK_STORED_TOKEN", { tokenPrefix: storedToken.substring(0, 8) });
-          setAuthToken(storedToken);
-          setLoggedIn(true);
-          await fetchProfile();
-        } else {
-          debugLog("LIFF_NOT_LOGGED_IN");
+      .then(() => {
+        debugLog("LIFF_SDK_INIT", { success: true, isLoggedIn: liff.isLoggedIn() });
+        try {
+          setLiffCtx(liff.getContext() || {});
+        } catch (err) {
+          console.warn("Failed to get LIFF context:", err);
         }
+        return true;
       })
       .catch(err => {
         debugLog("LIFF_SDK_INIT", { success: false, error: err.message });
         console.warn("LIFF init failed:", err);
-        // Init failed (LIFF ID fetch died, page outside LIFF endpoint, etc).
-        // Stored token is the last lifeline.
-        if (storedToken) {
-          debugLog("FALLBACK_STORED_TOKEN", { tokenPrefix: storedToken.substring(0, 8) });
-          setAuthToken(storedToken);
-          setLoggedIn(true);
-          return fetchProfile();
+        return false;
+      })
+      .then(async sdkReady => {
+        // Existing cookie session first — the common case, and the only path
+        // available to a browser that never went through LIFF login.
+        if ((await fetchProfile()) !== "unauthorized") return;
+
+        // Exactly one ID-token exchange attempt. Anything that fails here
+        // leaves the user logged out until they press login, which is what
+        // stops this from becoming a redirect loop.
+        if (!sdkReady || !liff.isLoggedIn()) return;
+
+        let idToken;
+        try {
+          idToken = liff.getIDToken();
+        } catch (err) {
+          debugLog("ID_TOKEN_FAIL", { message: err.message });
+          return;
         }
+        if (!idToken) {
+          debugLog("ID_TOKEN_MISSING");
+          return;
+        }
+
+        try {
+          await api.post("/api/auth/session", { idToken });
+          debugLog("SESSION_EXCHANGE_OK");
+        } catch (err) {
+          debugLog("SESSION_EXCHANGE_FAIL", {
+            status: err.response?.status,
+            message: err.message,
+          });
+          return;
+        }
+
+        await fetchProfile();
+      })
+      .catch(err => {
+        // Never let bootstrap reject: `ready` must still flip or the app
+        // stays stuck on the full-page spinner forever.
+        debugLog("BOOTSTRAP_FAIL", { message: err.message });
+        console.warn("Auth bootstrap failed:", err);
       })
       .finally(() => {
         debugLog("READY");
         setReady(true);
       });
-  }, []);
+  }, [fetchProfile]);
 
   const login = useCallback(async () => {
     // Reuse in-flight init or start a new one
@@ -137,18 +179,25 @@ export default function LiffProvider({ children }) {
     liff.login({ redirectUri });
   }, []);
 
-  const logout = useCallback(() => {
-    window.localStorage.removeItem(TOKEN_KEY);
-    clearAuthToken();
-    setProfile(null);
-    setIsAdmin(false);
+  const logout = useCallback(async () => {
+    // Server first: the cookie is HttpOnly, so only the backend can revoke
+    // it. Bailing out on failure keeps the UI honest instead of showing a
+    // logged-out shell that still carries a live session.
+    try {
+      await api.post("/api/auth/logout");
+    } catch (err) {
+      console.warn("Logout failed:", err);
+      return;
+    }
+
+    clearProfile();
     try {
       liff.logout();
     } catch {
       // SDK not initialized, nothing to clean up
     }
     window.location.reload();
-  }, []);
+  }, [clearProfile]);
 
   const value = useMemo(
     () => ({ ready, loggedIn, isAdmin, profile, liffContext: liffCtx, login, logout }),

--- a/frontend/src/hooks/useLiff.js
+++ b/frontend/src/hooks/useLiff.js
@@ -1,5 +1,6 @@
 import { useReducer } from "react";
 import liff from "@line/liff";
+import { runLiffAction } from "../utils/liffAuth";
 
 const sendMsgReducer = (state, action) => {
   switch (action.type) {
@@ -23,12 +24,11 @@ export const useSendMessage = () => {
 
   const handleSend = async text => {
     dispatch({ type: "SEND_INIT" });
-    try {
-      await liff.sendMessages([{ type: "text", text }]);
-      dispatch({ type: "SEND_SUCCESS" });
-    } catch {
-      dispatch({ type: "SEND_FAIL" });
-    }
+    const result = await runLiffAction(() => liff.sendMessages([{ type: "text", text }]));
+    // A reauth result means the page is already redirecting to LINE login;
+    // don't flash an error on the way out.
+    if (result.ok) dispatch({ type: "SEND_SUCCESS" });
+    else if (!result.reauth) dispatch({ type: "SEND_FAIL" });
   };
 
   return [state, handleSend];

--- a/frontend/src/pages/Admin/Messages.jsx
+++ b/frontend/src/pages/Admin/Messages.jsx
@@ -22,7 +22,6 @@ import CloseIcon from "@mui/icons-material/Close";
 import ForumIcon from "@mui/icons-material/Forum";
 import InboxIcon from "@mui/icons-material/Inbox";
 import AlertLogin from "../../components/AlertLogin";
-import liff from "@line/liff";
 import useLiff from "../../context/useLiff";
 
 // --- Helper functions ---
@@ -328,13 +327,13 @@ export default function AdminMessages() {
     if (!isLoggedIn) return;
     document.title = "訊息實況";
     const socket = io("/admin/messages", {
-      auth: {
-        token: liff.getAccessToken(),
-      },
+      // Auth rides the HttpOnly redive_session cookie; nothing to pass here.
+      withCredentials: true,
     });
 
     socket.on("newEvent", event => handleEvent(event));
     socket.on("error", msg => alert(msg));
+    socket.on("connect_error", err => console.warn("Socket auth failed:", err.message));
 
     return () => {
       socket.close();

--- a/frontend/src/pages/Trade/TradeDetail.jsx
+++ b/frontend/src/pages/Trade/TradeDetail.jsx
@@ -6,6 +6,7 @@ import RedeemIcon from "@mui/icons-material/Redeem";
 import DiamondIcon from "@mui/icons-material/Diamond";
 import StarIcon from "@mui/icons-material/Star";
 import liff from "@line/liff";
+import { runLiffAction } from "../../utils/liffAuth";
 import AlertLogin from "../../components/AlertLogin";
 import useLiff from "../../context/useLiff";
 import { STATUS, STATUS_MAP, ROLE, fmtDate, getViewerRole } from "./_shared";
@@ -313,8 +314,8 @@ export default function TradeDetail() {
   };
 
   const handleShare = async () => {
-    try {
-      const result = await liff.shareTargetPicker([
+    const result = await runLiffAction(() =>
+      liff.shareTargetPicker([
         {
           type: "flex",
           altText: "交易邀請",
@@ -327,12 +328,14 @@ export default function TradeDetail() {
             star: market.star ?? 0,
           }),
         },
-      ]);
-      if (result === null) openSnack("已取消分享", "info");
-      else openSnack("已發送邀請", "success");
-    } catch {
-      openSnack("分享失敗，請稍後再試", "error");
-    }
+      ])
+    );
+
+    // reauth === redirecting to LINE login; stay quiet.
+    if (result.reauth) return;
+    if (!result.ok) openSnack("分享失敗，請稍後再試", "error");
+    else if (result.value === null) openSnack("已取消分享", "info");
+    else openSnack("已發送邀請", "success");
   };
 
   return (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,28 +1,22 @@
 import axios from "axios";
 
-const TOKEN_KEY = "liff_access_token";
-
+// Auth is a same-origin HttpOnly cookie; nothing token-shaped is ever held in
+// JS, so there is no Authorization header to set and nothing to clear.
 const api = axios.create({
   timeout: 10000,
+  withCredentials: true,
 });
 
-export function setAuthToken(token) {
-  api.defaults.headers.common["Authorization"] = `Bearer ${token}`;
-}
-
-export function clearAuthToken() {
-  delete api.defaults.headers.common["Authorization"];
-}
-
-// Clear expired token and redirect on 401; dispatch event and redirect on 403
+// 403 keeps its old behaviour (bounce home). 401 only announces itself:
+// LiffProvider listens and syncs its logged-out state. Redirecting or
+// re-authenticating from here would race the provider's one-shot session
+// exchange into a login loop.
 api.interceptors.response.use(
   res => res,
   err => {
     const status = err.response?.status;
     if (status === 401) {
-      window.localStorage.removeItem(TOKEN_KEY);
-      clearAuthToken();
-      window.location.href = "/";
+      window.dispatchEvent(new CustomEvent("auth:unauthorized"));
     } else if (status === 403) {
       window.dispatchEvent(new CustomEvent("auth:forbidden"));
       window.location.href = "/";

--- a/frontend/src/utils/liffAuth.js
+++ b/frontend/src/utils/liffAuth.js
@@ -1,0 +1,70 @@
+import liff from "@line/liff";
+
+// LIFF error shapes we can actually rely on (@line/liff 2.29.1):
+// `@liff/server-api` throws a LiffError whose `code` is either the literal
+// HTTP status string ("401" is in its HTTPStatusCodes set) or an error code
+// echoed from LINE's response body; a missing access token throws the
+// UNAUTHORIZED const. Nothing else about the shape is documented, so we match
+// only those and treat every other failure as a plain error.
+const AUTH_ERROR_CODES = new Set(["401", "UNAUTHORIZED", "INVALID_ID_TOKEN"]);
+
+export function isLiffAuthError(err) {
+  if (!err) return false;
+
+  const code = err.code;
+  if (code === 401) return true;
+  if (typeof code === "string" && AUTH_ERROR_CODES.has(code.toUpperCase())) return true;
+
+  return false;
+}
+
+/**
+ * Re-login only when the SDK itself says we have no LIFF session. Never call
+ * this speculatively: liff.login() is a full page redirect, so firing it on a
+ * generic failure (network blip, 429, user cancel) is how you get a loop.
+ *
+ * Throws whatever the SDK throws — notably INIT_FAILED when liff.init() never
+ * ran. `runLiffAction` is what converts that into a plain failure result.
+ *
+ * @returns {boolean} false when a redirect was triggered — stop what you were doing.
+ */
+export function ensureLiffLogin() {
+  if (liff.isLoggedIn()) return true;
+  liff.login({ redirectUri: window.location.href });
+  return false;
+}
+
+/**
+ * Run a LIFF action that needs a live LINE credential (sendMessages,
+ * shareTargetPicker). Re-auths once, and only on an explicit auth error.
+ *
+ * Never throws and never leaves a pending promise: an uninitialised SDK
+ * resolves to `{ ok: false, error }`, so callers like useSendMessage always
+ * get to clear their loading state.
+ *
+ * @returns {Promise<{ ok: boolean, value?: unknown, error?: unknown, reauth?: boolean }>}
+ */
+export async function runLiffAction(action) {
+  try {
+    // liff.isLoggedIn() / liff.login() both throw INIT_FAILED when the SDK
+    // was never initialised. Redirecting to login cannot fix that, so it is
+    // reported as an ordinary failure.
+    if (!ensureLiffLogin()) return { ok: false, reauth: true };
+  } catch (err) {
+    return { ok: false, error: err };
+  }
+
+  try {
+    return { ok: true, value: await action() };
+  } catch (err) {
+    if (!isLiffAuthError(err)) return { ok: false, error: err };
+
+    // Explicit unauthorized / expired token: one redirect, no retry loop.
+    try {
+      liff.login({ redirectUri: window.location.href });
+    } catch (loginErr) {
+      return { ok: false, error: loginErr };
+    }
+    return { ok: false, error: err, reauth: true };
+  }
+}


### PR DESCRIPTION
## Summary
- 以 LINE ID token 交換 30 天 Redis opaque session，session cookie 採 HttpOnly、SameSite=Lax
- REST 與管理員 Socket.IO 共用 cookie authentication，移除 LIFF bearer token 與 localStorage
- 一般本站功能不再受 LIFF access token 約 12 小時效期影響
- `sendMessages`、`shareTargetPicker` 僅在需要 LINE credential 時局部重新登入
- 加入 Origin/CSRF 防護、session rotation、Redis outage 與 LINE verify 錯誤分流

## Test plan
- [x] Auth focused tests：72 passed
- [x] Backend full suite：126 suites / 1113 tests passed
- [x] Backend ESLint
- [x] Frontend ESLint（0 errors；57 個既有 warnings）
- [x] Frontend production build
- [x] Independent security review：no blocking findings
- [ ] 合併部署後，以真實 LIFF browser 驗證登入、登出、Socket.IO、sendMessages、shareTargetPicker

## Deployment prerequisites
- production stack 已預先加入 `LINE_LOGIN_CHANNEL_ID`，由現有 production LIFF ID 推導並確認所有 LIFF IDs 同屬該 channel
- production `APP_DOMAIN` 已由 compose 設為 `pudding.hanshino.dev`
- 無 migration、無新 dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)