### PR TITLE
fix(auth): 統一 LIFF 登入返回路徑

### DIFF
--- a/frontend/src/context/LiffProvider.jsx
+++ b/frontend/src/context/LiffProvider.jsx
@@ -3,16 +3,8 @@ import liff from "@line/liff";
 import api from "../services/api";
 import { FullPageLoading } from "../components/Loading";
 import { debugLog } from "../utils/debugLogger";
+import { buildLiffRedirectUri, getLiffSize } from "../utils/liffAuth";
 import { LiffContext } from "./LiffContext";
-
-const SIZE_KEY = "liff_size";
-const DEFAULT_SIZE = "full";
-
-function getLiffSize() {
-  const match = window.location.pathname.match(/^\/liff\/([^/]+)/);
-  if (match) return match[1];
-  return window.localStorage.getItem(SIZE_KEY) || DEFAULT_SIZE;
-}
 
 /**
  * Fetch LIFF ID and call liff.init().
@@ -174,9 +166,7 @@ export default function LiffProvider({ children }) {
       console.warn("LIFF init failed:", err);
       return;
     }
-    const { pathname, search } = window.location;
-    const redirectUri = `${window.location.origin}/liff/${getLiffSize()}${pathname}${search}`;
-    liff.login({ redirectUri });
+    liff.login({ redirectUri: buildLiffRedirectUri(getLiffSize()) });
   }, []);
 
   const logout = useCallback(async () => {

--- a/frontend/src/utils/liffAuth.js
+++ b/frontend/src/utils/liffAuth.js
@@ -1,5 +1,29 @@
 import liff from "@line/liff";
 
+const SIZE_KEY = "liff_size";
+const DEFAULT_SIZE = "full";
+
+export function getLiffSize() {
+  const match = window.location.pathname.match(/^\/liff\/([^/]+)/);
+  return match?.[1] || window.localStorage.getItem(SIZE_KEY) || DEFAULT_SIZE;
+}
+
+export function buildLiffRedirectUri(size, location = window.location) {
+  const current = new URL(
+    location.href || `${location.origin}${location.pathname}${location.search}${location.hash}`
+  );
+  const liffPath = current.pathname.match(/^\/liff\/[^/]+(\/.*)?$/);
+  const childPath = liffPath ? liffPath[1] || "/" : current.pathname;
+  const search = new URLSearchParams(current.search);
+
+  ["code", "state", "liffClientId", "liffRedirectUri", "liff.state"].forEach(param =>
+    search.delete(param)
+  );
+
+  const query = search.toString();
+  return `${current.origin}/liff/${size}${childPath}${query ? `?${query}` : ""}${current.hash}`;
+}
+
 // LIFF error shapes we can actually rely on (@line/liff 2.29.1):
 // `@liff/server-api` throws a LiffError whose `code` is either the literal
 // HTTP status string ("401" is in its HTTPStatusCodes set) or an error code
@@ -30,7 +54,7 @@ export function isLiffAuthError(err) {
  */
 export function ensureLiffLogin() {
   if (liff.isLoggedIn()) return true;
-  liff.login({ redirectUri: window.location.href });
+  liff.login({ redirectUri: buildLiffRedirectUri(getLiffSize()) });
   return false;
 }
 
@@ -61,7 +85,7 @@ export async function runLiffAction(action) {
 
     // Explicit unauthorized / expired token: one redirect, no retry loop.
     try {
-      liff.login({ redirectUri: window.location.href });
+      liff.login({ redirectUri: buildLiffRedirectUri(getLiffSize()) });
     } catch (loginErr) {
       return { ok: false, error: loginErr };
     }


### PR DESCRIPTION
## Summary
- 統一一般登入與 LINE 原生功能 reauth 的 LIFF redirect URI
- 避免重複拼接 `/liff/:size` endpoint prefix
- 保留原頁 path/query/hash，並移除 OAuth/LIFF 暫態參數

## Test plan
- [x] ESLint：`src/utils/liffAuth.js`、`src/context/LiffProvider.jsx`
- [x] Frontend production build
- [x] URL cases：root、一般 route、既有 LIFF prefix、callback transient params
- [x] `git diff --check`

## Deployment
- LINE Developers Console 的 LIFF apps 已由使用者加入 `openid` scope
- 無 migration、新 dependency 或新環境變數

🤖 Generated with [Claude Code](https://claude.com/claude-code)