### PR TITLE
feat(market): 公開市場掛單簿（角色委託所）+ 修正 MUI v9 靜默失效

### DIFF
--- a/app/migrations/20260807172325_create_public_market.js
+++ b/app/migrations/20260807172325_create_public_market.js
@@ -1,0 +1,45 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * public_market：公開市場（角色委託所）掛單簿。
+ *
+ * 與 market_detail（1 對 1 指名交易）完全獨立，兩張表互不影響。
+ *
+ * status 使用字串 enum 而非 market_detail 的 tinyint：
+ * 這裡有四種狀態（open/sold/cancelled/invalid），tinyint 的 0/1/-1 慣例撐不到第四種，
+ * 而且 API 合約本來就以字串回傳，DB 直接存字串可省掉一層對照表。
+ *
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable("public_market", table => {
+    table.bigIncrements("id").primary();
+    table.string("seller_id", 33).notNullable().comment("賣家 LINE userId");
+    table.string("buyer_id", 33).nullable().comment("買家 LINE userId，成交才有值");
+    table.integer("item_id").unsigned().notNullable().comment("角色 ID，對應 gacha_pool.ID");
+    table.integer("price").unsigned().notNullable().comment("掛單售價（買家實付）");
+    table.integer("fee").unsigned().notNullable().comment("手續費，成交價 5% 無條件進位，銷毀");
+    table
+      .enu("status", ["open", "sold", "cancelled", "invalid"])
+      .notNullable()
+      .defaultTo("open")
+      .comment("open:掛單中, sold:已成交, cancelled:賣家取消, invalid:賣家已無此角色自動下架");
+    table.datetime("sold_at").nullable().comment("成交時間");
+    table.datetime("closed_at").nullable().comment("取消／失效時間");
+    table.timestamps(true, true);
+
+    // 掛單簿主查詢：某角色的開放掛單，價低優先
+    table.index(["item_id", "status", "price"], "idx_public_market_book");
+    // 賣家掛單上限檢查
+    table.index(["seller_id", "status"], "idx_public_market_seller_status");
+    table.index(["buyer_id"], "idx_public_market_buyer");
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists("public_market");
+};

--- a/app/migrations/20260807184425_public_market_updated_at_on_update.js
+++ b/app/migrations/20260807184425_public_market_updated_at_on_update.js
@@ -1,0 +1,36 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * public_market.updated_at 補上 `ON UPDATE CURRENT_TIMESTAMP`。
+ *
+ * 原本的 `table.timestamps(true, true)` 只會產出 `DEFAULT CURRENT_TIMESTAMP`，
+ * 於是 updated_at 永遠停在建立當下，改狀態（成交／取消／失效）都不會前進 ——
+ * 語意上是錯的，任何把它當「最後修改時間」讀的人都會被誤導。
+ *
+ * 目前實際影響為零：getClosedListingsByUser 的
+ * `COALESCE(sold_at, closed_at, updated_at)` 前兩者在已結束的列上必有值，
+ * 走不到 updated_at 這個 fallback。這裡純粹是把欄位語意修正。
+ *
+ * 用 raw ALTER 而非 knex schema builder：後者沒有表達 ON UPDATE 的 API。
+ *
+ * @param {Knex} knex
+ */
+exports.up = function (knex) {
+  return knex.raw(
+    "ALTER TABLE `public_market` MODIFY `updated_at` TIMESTAMP NOT NULL " +
+      "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+  );
+};
+
+/**
+ * 還原成單純的 DEFAULT CURRENT_TIMESTAMP（沒有 ON UPDATE），
+ * 即 timestamps(true, true) 原本的樣子。
+ *
+ * @param {Knex} knex
+ */
+exports.down = function (knex) {
+  return knex.raw(
+    "ALTER TABLE `public_market` MODIFY `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+  );
+};

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -28,6 +28,7 @@ const AchievementController = require("./controller/application/AchievementContr
 const DonateListController = require("./controller/application/DonateListController");
 const AliasController = require("./controller/application/AliasController");
 const MarketController = require("./controller/application/MarketController");
+const PublicMarketController = require("./controller/application/PublicMarketController");
 const CouponController = require("./controller/application/CouponController");
 const ImageController = require("./controller/application/ImageController");
 const StatusController = require("./controller/application/StatusController");
@@ -168,6 +169,8 @@ async function OrderBased(context, { next }) {
     ...AchievementController.router,
     ...AchievementController.titleRouter,
     ...MarketController.router,
+    // 放在 MarketController 之後：`.市場` 與 `.交易`/`.trade` 前綴不重疊，不會互相遮蔽
+    ...PublicMarketController.router,
     ...CouponController.router,
     ...ImageController.router,
     ...StatusController.router,

--- a/app/src/controller/application/PublicMarketController.js
+++ b/app/src/controller/application/PublicMarketController.js
@@ -1,0 +1,25 @@
+const { text } = require("bottender/router");
+const PublicMarketService = require("../../service/PublicMarketService");
+const { generateMarketBubble } = require("../../templates/application/PublicMarket");
+const { DefaultLogger } = require("../../util/Logger");
+
+exports.router = [text(/^[./#](市場|market)$/i, showMarket)];
+
+/**
+ * 顯示公開市場總覽
+ * @param {import("bottender").LineContext} context
+ */
+async function showMarket(context) {
+  const { userId } = context.event.source;
+  if (!userId) return;
+
+  try {
+    const summary = await PublicMarketService.getSummary(userId);
+    return context.replyFlex("公開市場", generateMarketBubble(summary));
+  } catch (e) {
+    DefaultLogger.error(e);
+    return context.replyText("市場現在有點忙，等一下再試試");
+  }
+}
+
+exports.showMarket = showMarket;

--- a/app/src/model/application/PublicMarket.js
+++ b/app/src/model/application/PublicMarket.js
@@ -1,0 +1,173 @@
+const base = require("../base");
+
+const OPEN = "open";
+
+class PublicMarket extends base {
+  /**
+   * 單筆掛單 + 角色名稱。
+   * @param {Number} id
+   * @param {import("knex").Knex.Transaction} [trx]
+   */
+  getById(id, trx) {
+    return this.selectWithName(trx)
+      .where({ [`${this.table}.id`]: id })
+      .first();
+  }
+
+  /**
+   * 同 getById，但加上 `FOR UPDATE` 行鎖 —— 購買流程用，
+   * 兩個買家同時打進來時第二個會卡在這裡直到第一個 commit，
+   * 之後讀到的 status 已是 sold，於是拿到 ALREADY_TAKEN。
+   * @param {Number} id
+   * @param {import("knex").Knex.Transaction} trx
+   */
+  lockById(id, trx) {
+    return this.qb(trx).where({ id }).forUpdate().first();
+  }
+
+  selectWithName(trx) {
+    return this.qb(trx)
+      .select([
+        { id: `${this.table}.id` },
+        { itemId: "item_id" },
+        { sellerId: "seller_id" },
+        { buyerId: "buyer_id" },
+        "price",
+        "fee",
+        "status",
+        { createdAt: `${this.table}.created_at` },
+        { soldAt: "sold_at" },
+        { closedAt: "closed_at" },
+        { name: "gacha_pool.Name" },
+        { headImage: "gacha_pool.HeadImage_Url" },
+        { star: "gacha_pool.Star" },
+      ])
+      .leftJoin("gacha_pool", "gacha_pool.ID", `${this.table}.item_id`);
+  }
+
+  /**
+   * 掛單簿：目前有開放掛單的角色，附掛單數與最低價。
+   * Star 一併帶出給前端渲染 ★；它跟著 item_id 走（函數相依），
+   * 但 MySQL 8 預設 ONLY_FULL_GROUP_BY 不認這層推導，所以必須列進 groupBy。
+   */
+  getOpenCharacters() {
+    return this.qb()
+      .select([
+        { itemId: `${this.table}.item_id` },
+        { name: "gacha_pool.Name" },
+        { headImage: "gacha_pool.HeadImage_Url" },
+        { star: "gacha_pool.Star" },
+        { listingCount: this.connection.raw("COUNT(*)") },
+        { minPrice: this.connection.raw("MIN(`price`)") },
+      ])
+      .leftJoin("gacha_pool", "gacha_pool.ID", `${this.table}.item_id`)
+      .where({ status: OPEN })
+      .groupBy(
+        `${this.table}.item_id`,
+        "gacha_pool.Name",
+        "gacha_pool.HeadImage_Url",
+        "gacha_pool.Star"
+      )
+      .orderBy("minPrice", "asc");
+  }
+
+  /**
+   * 某角色的開放掛單，價低優先。
+   * @param {Number} itemId
+   */
+  getOpenListingsByItemId(itemId) {
+    return this.selectWithName()
+      .where({ [`${this.table}.item_id`]: itemId, [`${this.table}.status`]: OPEN })
+      .orderBy("price", "asc")
+      .orderBy(`${this.table}.id`, "asc");
+  }
+
+  /**
+   * 賣家的開放掛單。
+   * @param {String} sellerId
+   * @param {import("knex").Knex.Transaction} [trx]
+   */
+  getOpenListingsBySeller(sellerId, trx) {
+    return this.selectWithName(trx)
+      .where({ [`${this.table}.seller_id`]: sellerId, [`${this.table}.status`]: OPEN })
+      .orderBy(`${this.table}.created_at`, "desc");
+  }
+
+  /**
+   * 使用者參與過、已結束的掛單（賣家或買家皆算）。
+   * @param {String} userId
+   * @param {Number} limit
+   */
+  getClosedListingsByUser(userId, limit = 50) {
+    return this.selectWithName()
+      .whereNot({ [`${this.table}.status`]: OPEN })
+      .where(qb =>
+        qb.where(`${this.table}.seller_id`, userId).orWhere(`${this.table}.buyer_id`, userId)
+      )
+      .orderByRaw("COALESCE(`sold_at`, `closed_at`, `public_market`.`updated_at`) DESC")
+      .limit(limit);
+  }
+
+  /**
+   * 賣家目前開放掛單數。
+   * @param {String} sellerId
+   * @param {import("knex").Knex.Transaction} [trx]
+   * @returns {Promise<Number>}
+   */
+  async countOpenBySeller(sellerId, trx) {
+    const row = await this.qb(trx)
+      .where({ seller_id: sellerId, status: OPEN })
+      .count({ c: "*" })
+      .first();
+    return Number(row && row.c ? row.c : 0);
+  }
+
+  /**
+   * 全站開放掛單數。
+   * @returns {Promise<Number>}
+   */
+  async countOpen() {
+    const row = await this.qb().where({ status: OPEN }).count({ c: "*" }).first();
+    return Number(row && row.c ? row.c : 0);
+  }
+
+  /**
+   * 賣家是否已對同一角色掛過單。
+   * @param {String} sellerId
+   * @param {Number} itemId
+   * @param {import("knex").Knex.Transaction} [trx]
+   */
+  findOpenBySellerAndItem(sellerId, itemId, trx) {
+    return this.qb(trx).where({ seller_id: sellerId, item_id: itemId, status: OPEN }).first();
+  }
+
+  /**
+   * 條件式成交：只有還在 open 的列會被更新，回傳受影響列數。
+   * 即使沒有 FOR UPDATE 也不可能兩個買家都拿到 1。
+   * @param {Number} id
+   * @param {String} buyerId
+   * @param {import("knex").Knex.Transaction} trx
+   * @returns {Promise<Number>}
+   */
+  markSold(id, buyerId, trx) {
+    return this.qb(trx)
+      .where({ id, status: OPEN })
+      .update({ status: "sold", buyer_id: buyerId, sold_at: new Date() });
+  }
+
+  /**
+   * 條件式關閉（取消 / 失效）。
+   * @param {Number} id
+   * @param {"cancelled"|"invalid"} status
+   * @param {import("knex").Knex.Transaction} [trx]
+   * @returns {Promise<Number>}
+   */
+  markClosed(id, status, trx) {
+    return this.qb(trx).where({ id, status: OPEN }).update({ status, closed_at: new Date() });
+  }
+}
+
+module.exports = new PublicMarket({
+  table: "public_market",
+  fillable: ["seller_id", "buyer_id", "item_id", "price", "fee", "status", "sold_at", "closed_at"],
+});

--- a/app/src/router/PublicMarket/index.js
+++ b/app/src/router/PublicMarket/index.js
@@ -1,0 +1,169 @@
+const createRouter = require("express").Router;
+const router = createRouter();
+const { verifyToken } = require("../../middleware/validation");
+const PublicMarketService = require("../../service/PublicMarketService");
+const { DefaultLogger } = require("../../util/Logger");
+
+const MESSAGES = {
+  NOT_FOUND: "找不到這筆委託",
+  FORBIDDEN: "你不是這筆委託的賣家",
+  NOT_OPEN: "這筆委託已結束，無法再操作",
+  INVALID_PRICE: `價格必須是 ${PublicMarketService.MIN_PRICE} ～ ${PublicMarketService.MAX_PRICE} 的整數`,
+  INVALID_ITEM: "角色 ID 不正確",
+  LISTING_CAP: `最多只能同時掛 ${PublicMarketService.MAX_OPEN_LISTINGS} 筆委託`,
+  NOT_OWNED: "你沒有這個角色",
+  ALREADY_LISTED: "你已經掛過這個角色了",
+  ALREADY_TAKEN: "此委託已被其他玩家買走或取消",
+  INSUFFICIENT_FUNDS: "女神石不足",
+  ALREADY_OWNED: "你已經擁有這個角色了",
+  SELLER_LOST_ITEM: "賣家已無此角色，系統已自動下架這筆委託",
+  IS_SELLER: "不能購買自己的委託",
+  INTERNAL: "系統忙碌中，請稍後再試",
+};
+
+function fail(res, status, code, extra = {}) {
+  return res.status(status).json({ message: MESSAGES[code] || MESSAGES.INTERNAL, code, ...extra });
+}
+
+function asyncHandler(fn) {
+  return (req, res) =>
+    fn(req, res).catch(e => {
+      DefaultLogger.error(e);
+      if (!res.headersSent) fail(res, 500, "INTERNAL");
+    });
+}
+
+/**
+ * 從路由參數解析正整數 id，不合法回傳 null。
+ */
+function parseId(raw) {
+  const id = Number(raw);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+router.get(
+  "/public-market/summary",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    res.json(await PublicMarketService.getSummary(req.profile.userId));
+  })
+);
+
+router.get(
+  "/public-market/characters",
+  verifyToken,
+  asyncHandler(async (_req, res) => {
+    res.json(await PublicMarketService.getOpenCharacters());
+  })
+);
+
+// 注意順序：/listings/:id 必須排在 /listings 之後才不會吃掉字面路徑，
+// 但兩者 method 不同（GET /listings 需要 itemId query），仍明確分開宣告。
+router.get(
+  "/public-market/listings",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    const itemId = parseId(req.query.itemId);
+    if (!itemId) return fail(res, 400, "INVALID_ITEM");
+
+    res.json(await PublicMarketService.getListingsByItemId(itemId, req.profile.userId));
+  })
+);
+
+router.get(
+  "/public-market/my-listings",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    res.json(await PublicMarketService.getMyListings(req.profile.userId));
+  })
+);
+
+router.get(
+  "/public-market/listings/:id",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    const id = parseId(req.params.id);
+    if (!id) return fail(res, 404, "NOT_FOUND");
+
+    const detail = await PublicMarketService.getListingDetail(id, req.profile.userId);
+    if (!detail) return fail(res, 404, "NOT_FOUND");
+
+    res.json(detail);
+  })
+);
+
+router.post(
+  "/public-market/listings",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    const { userId } = req.profile;
+    const itemId = Number(req.body.itemId);
+    const price = Number(req.body.price);
+
+    if (!Number.isInteger(itemId) || itemId <= 0) return fail(res, 400, "INVALID_ITEM");
+    if (!PublicMarketService.isValidPrice(price)) return fail(res, 400, "INVALID_PRICE");
+
+    const result = await PublicMarketService.createListing(userId, { itemId, price });
+    if (result.ok) return res.status(201).json(result.listing);
+
+    if (result.code === "INVALID_PRICE") return fail(res, 400, result.code);
+    return fail(res, 409, result.code, {
+      ...(result.code === "LISTING_CAP"
+        ? { myOpenCount: result.myOpenCount, maxOpen: result.maxOpen }
+        : {}),
+    });
+  })
+);
+
+router.delete(
+  "/public-market/listings/:id",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    const id = parseId(req.params.id);
+    if (!id) return fail(res, 404, "NOT_FOUND");
+
+    const result = await PublicMarketService.cancelListing(id, req.profile.userId);
+    if (result.ok) return res.json({ listingId: result.listingId, status: "cancelled" });
+
+    if (result.code === "NOT_FOUND") return fail(res, 404, result.code);
+    if (result.code === "FORBIDDEN") return fail(res, 403, result.code);
+    return fail(res, 409, result.code);
+  })
+);
+
+router.post(
+  "/public-market/listings/:id/purchase",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    const id = parseId(req.params.id);
+    if (!id) return fail(res, 404, "NOT_FOUND");
+
+    const result = await PublicMarketService.purchase(id, req.profile.userId);
+
+    if (result.ok) {
+      return res.json({
+        listingId: result.listingId,
+        itemId: result.itemId,
+        name: result.name,
+        price: result.price,
+        fee: result.fee,
+        netProceeds: result.netProceeds,
+        balanceAfter: result.balanceAfter,
+      });
+    }
+
+    if (result.code === "NOT_FOUND") return fail(res, 404, result.code);
+    if (result.code === "IS_SELLER") return fail(res, 403, result.code);
+    if (result.code === "INSUFFICIENT_FUNDS") {
+      return fail(res, 409, result.code, {
+        balance: result.balance,
+        price: result.price,
+        shortfall: result.shortfall,
+      });
+    }
+
+    return fail(res, 409, result.code);
+  })
+);
+
+exports.router = router;

--- a/app/src/router/__tests__/PublicMarket.test.js
+++ b/app/src/router/__tests__/PublicMarket.test.js
@@ -1,0 +1,128 @@
+// 一次性接線檢查：router 有掛上預期路徑、template 產出的動態欄位正確。
+jest.mock("../../service/PublicMarketService", () => {
+  const actual = jest.requireActual("../../service/PublicMarketService");
+  return { ...actual, purchase: jest.fn() };
+});
+
+const request = require("supertest");
+const express = require("express");
+const routerModule = require("../../router/PublicMarket");
+const PublicMarketService = require("../../service/PublicMarketService");
+const { generateMarketBubble } = require("../../templates/application/PublicMarket");
+
+describe("PublicMarket 接線", () => {
+  it("router 掛上全部 8 條路徑", () => {
+    const routes = routerModule.router.stack
+      .filter(l => l.route)
+      .map(l => `${Object.keys(l.route.methods)[0].toUpperCase()} ${l.route.path}`);
+
+    expect(routes).toEqual([
+      "GET /public-market/summary",
+      "GET /public-market/characters",
+      "GET /public-market/listings",
+      "GET /public-market/my-listings",
+      "GET /public-market/listings/:id",
+      "POST /public-market/listings",
+      "DELETE /public-market/listings/:id",
+      "POST /public-market/listings/:id/purchase",
+    ]);
+  });
+
+  it("/my-listings 排在 /listings/:id 之前，才不會被當成 id", () => {
+    const paths = routerModule.router.stack.filter(l => l.route).map(l => l.route.path);
+    expect(paths.indexOf("/public-market/my-listings")).toBeLessThan(
+      paths.indexOf("/public-market/listings/:id")
+    );
+  });
+
+  it.each([
+    [0, "0%"],
+    [3, "30%"],
+    [10, "100%"],
+    [12, "100%"],
+  ])("myOpenCount %i -> 配額條寬 %s", (myOpenCount, expected) => {
+    const bubble = generateMarketBubble({
+      myOpenCount,
+      maxOpen: 10,
+      totalOpenCount: 128,
+      feePercent: 5,
+    });
+    expect(bubble.body.contents[1].contents[0].width).toBe(expected);
+  });
+
+  it("footer 兩顆按鈕都是 LIFF 連結，沒有殘留 PLACEHOLDER", () => {
+    const bubble = generateMarketBubble({
+      myOpenCount: 3,
+      maxOpen: 10,
+      totalOpenCount: 128,
+      feePercent: 5,
+    });
+    const uris = bubble.footer.contents.map(b => b.action.uri);
+
+    expect(uris).toHaveLength(2);
+    uris.forEach(uri => {
+      expect(uri).toContain("https://liff.line.me/");
+      expect(uri).not.toContain("PLACEHOLDER");
+    });
+    expect(uris[0]).toContain("/trade/market");
+    expect(uris[1]).toContain("/trade/sell");
+  });
+
+  it("header 漸層與文案與設計稿一致", () => {
+    const bubble = generateMarketBubble({
+      myOpenCount: 3,
+      maxOpen: 10,
+      totalOpenCount: 128,
+      feePercent: 5,
+    });
+
+    expect(bubble.header.background).toMatchObject({
+      type: "linearGradient",
+      angle: "135deg",
+      startColor: "#00838F",
+      endColor: "#00ACC1",
+    });
+    expect(bubble.header.contents[0].contents[0].text).toBe("公開市場");
+    expect(bubble.header.contents[0].contents[1].text).toBe("手續費 5%");
+    expect(bubble.body.contents[0].contents[1].text).toBe("3 / 10");
+    expect(bubble.body.contents[3].contents[1].text).toBe("128 筆");
+  });
+});
+
+describe("購買回應欄位白名單", () => {
+  function createApp() {
+    const app = express();
+    app.use(express.json());
+    app.use("/api", routerModule.router);
+    return app;
+  }
+
+  it("service 回傳的 sellerId 不會外洩到 HTTP 回應", async () => {
+    // service 內部帶 sellerId 只為了 commit 後結算成就，不該讓買家看到賣家的 LINE userId
+    PublicMarketService.purchase.mockResolvedValue({
+      ok: true,
+      listingId: 42,
+      itemId: 101,
+      name: "佩可莉ーヌ",
+      sellerId: "U" + "1".repeat(32),
+      price: 1000,
+      fee: 50,
+      netProceeds: 950,
+      balanceAfter: 4000,
+    });
+
+    const res = await request(createApp()).post("/api/public-market/listings/42/purchase");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      listingId: 42,
+      itemId: 101,
+      name: "佩可莉ーヌ",
+      price: 1000,
+      fee: 50,
+      netProceeds: 950,
+      balanceAfter: 4000,
+    });
+    expect(res.body).not.toHaveProperty("sellerId");
+  });
+});

--- a/app/src/router/api.js
+++ b/app/src/router/api.js
@@ -34,6 +34,7 @@ const { admin: AdminCouponRouter } = require("./Coupon");
 const { router: InventoryRouter } = require("./Inventory");
 const { router: TradeRouter } = require("./Trade");
 const { router: MarketRouter } = require("./Market");
+const { router: PublicMarketRouter } = require("./PublicMarket");
 const { getProfile } = require("../handler/Profile");
 const moment = require("moment");
 const XpHistoryService = require("../service/XpHistoryService");
@@ -41,6 +42,7 @@ const { todayUtc8 } = require("../util/date");
 
 router.use(require("./auth"));
 router.use(MarketRouter);
+router.use(PublicMarketRouter);
 router.use(InventoryRouter);
 router.use(TradeRouter);
 router.use(ImgurRouter);

--- a/app/src/service/PublicMarketService.js
+++ b/app/src/service/PublicMarketService.js
@@ -1,0 +1,501 @@
+const PublicMarketModel = require("../model/application/PublicMarket");
+const { inventory: InventoryModel } = require("../model/application/Inventory");
+const { model: GachaPoolModel } = require("../model/princess/gacha");
+const { resolveDisplayName } = require("./ProfileService");
+const AchievementEngine = require("./AchievementEngine");
+const mysql = require("../util/mysql");
+const { DefaultLogger } = require("../util/Logger");
+
+const FEE_PERCENT = 5;
+const MAX_OPEN_LISTINGS = 10;
+const MIN_PRICE = 1;
+const MAX_PRICE = 99999;
+const GOD_STONE_ITEM_ID = 999;
+
+/**
+ * 手續費：成交價的 5%，無條件進位。手續費是「銷毀」的 —— 買家付 price，
+ * 賣家收 price - fee，沒有第三方入帳，差額直接從流通量消失。
+ * @param {Number} price
+ * @returns {Number}
+ */
+function calcFee(price) {
+  return Math.ceil((price * FEE_PERCENT) / 100);
+}
+
+/**
+ * 賣家實收。
+ * @param {Number} price
+ * @returns {Number}
+ */
+function calcNetProceeds(price) {
+  return price - calcFee(price);
+}
+
+/**
+ * 價格必須是 1 ～ 99999 的整數。
+ * @param {*} price
+ * @returns {Boolean}
+ */
+function isValidPrice(price) {
+  return Number.isInteger(price) && price >= MIN_PRICE && price <= MAX_PRICE;
+}
+
+/**
+ * 角色的初始星數（升星強化不隨交易轉移）。
+ * @param {Object} character gacha_pool 資料列
+ * @returns {Number}
+ */
+function baseStarOf(character) {
+  const raw = character && (character.Star !== undefined ? character.Star : character.star);
+  const star = parseInt(raw, 10);
+  return Number.isFinite(star) && star > 0 ? star : 1;
+}
+
+/**
+ * 買家取得角色時寫入的 attributes —— 一律基礎星數，不繼承賣家的升星。
+ * 形狀與 GachaService / GodStoneShop 一致。
+ * @param {Object} character
+ * @returns {String}
+ */
+function baseAttributes(character) {
+  return JSON.stringify([{ key: "star", value: baseStarOf(character) }]);
+}
+
+async function getBalance(userId, trx) {
+  // 女神石是 append-only 帳本，餘額 = SUM(itemAmount)。
+  // 帶 trx 時加上 FOR UPDATE，讓同一買家的並發購買排隊，避免用同一筆餘額買兩單。
+  let query = (trx || mysql)("inventory")
+    .where({ userId, itemId: GOD_STONE_ITEM_ID })
+    .sum({ amount: "itemAmount" });
+
+  if (trx) query = query.forUpdate();
+
+  const row = await query.first();
+  return Number((row && row.amount) || 0);
+}
+
+async function ownsCharacter(userId, itemId, trx) {
+  const row = await (trx || mysql)("inventory")
+    .where({ userId, itemId })
+    .sum({ amount: "itemAmount" })
+    .first();
+
+  return Number((row && row.amount) || 0) > 0;
+}
+
+/**
+ * 批次解析 displayName，同一個 userId 只查一次。
+ * @param {Array<String>} userIds
+ * @returns {Promise<Object>} userId -> displayName
+ */
+async function resolveNames(userIds) {
+  const unique = [...new Set(userIds.filter(Boolean))];
+  const names = await Promise.all(unique.map(id => resolveDisplayName(id)));
+  return unique.reduce((acc, id, i) => ({ ...acc, [id]: names[i] }), {});
+}
+
+/**
+ * 把 model 的資料列整成 API 形狀。
+ * star 一律取 gacha_pool 的基礎星數（升星不隨交易轉移），
+ * baseStarOf 讀得懂 Star / star 兩種鍵，查無值退回 1。
+ * @param {Object} row
+ * @param {Object} [param1]
+ * @param {String} [param1.viewerId] 觀看者，用來算 mine
+ * @param {Object} [param1.names] userId -> displayName 對照
+ * @returns {Object}
+ */
+function shapeListing(row, { viewerId, names = {} } = {}) {
+  return {
+    id: Number(row.id),
+    itemId: Number(row.itemId),
+    name: row.name,
+    star: baseStarOf(row),
+    price: Number(row.price),
+    fee: Number(row.fee),
+    netProceeds: Number(row.price) - Number(row.fee),
+    status: row.status,
+    sellerId: row.sellerId,
+    sellerName: names[row.sellerId] || null,
+    buyerId: row.buyerId || null,
+    buyerName: row.buyerId ? names[row.buyerId] || null : null,
+    mine: viewerId ? row.sellerId === viewerId : undefined,
+    createdAt: row.createdAt,
+    soldAt: row.soldAt || null,
+    closedAt: row.closedAt || null,
+  };
+}
+
+/**
+ * 首頁／Flex 用的總覽數字。
+ * @param {String} userId
+ */
+async function getSummary(userId) {
+  const [balance, myOpenCount, totalOpenCount] = await Promise.all([
+    getBalance(userId),
+    PublicMarketModel.countOpenBySeller(userId),
+    PublicMarketModel.countOpen(),
+  ]);
+
+  return {
+    balance,
+    myOpenCount,
+    maxOpen: MAX_OPEN_LISTINGS,
+    totalOpenCount,
+    feePercent: FEE_PERCENT,
+  };
+}
+
+/**
+ * 掛單簿：目前有開放掛單的角色。
+ * @returns {Promise<Array<Object>>}
+ */
+async function getOpenCharacters() {
+  const rows = await PublicMarketModel.getOpenCharacters();
+  return rows.map(row => ({
+    itemId: Number(row.itemId),
+    name: row.name,
+    star: baseStarOf(row),
+    headImage: row.headImage,
+    listingCount: Number(row.listingCount),
+    minPrice: Number(row.minPrice),
+  }));
+}
+
+/**
+ * 某角色的開放掛單，價低優先。
+ * @param {Number} itemId
+ * @param {String} viewerId
+ */
+async function getListingsByItemId(itemId, viewerId) {
+  const rows = await PublicMarketModel.getOpenListingsByItemId(itemId);
+  const names = await resolveNames(rows.map(r => r.sellerId));
+
+  return rows.map(row => {
+    const listing = shapeListing(row, { viewerId, names });
+    // 掛單簿列表不需要買家欄位（open 掛單本來就沒買家）
+    delete listing.buyerId;
+    delete listing.buyerName;
+    delete listing.soldAt;
+    delete listing.closedAt;
+    delete listing.status;
+    return listing;
+  });
+}
+
+/**
+ * 判斷觀看者能不能買這張單，以及不能買的原因。
+ * 前端會依 blockReason 換整頁畫面，所以順序不能亂：
+ * 單子本身不是 open 最優先，其次才是觀看者身分。
+ */
+function resolveBlockReason({ status, isSeller, owns, balance, price }) {
+  if (status !== "open") return "NOT_OPEN";
+  if (isSeller) return "IS_SELLER";
+  if (owns) return "ALREADY_OWNED";
+  if (balance < price) return "INSUFFICIENT_FUNDS";
+  return null;
+}
+
+/**
+ * 單張掛單 + 觀看者情境。
+ * @param {Number} id
+ * @param {String} viewerId
+ */
+async function getListingDetail(id, viewerId) {
+  const row = await PublicMarketModel.getById(id);
+  if (!row) return null;
+
+  const [names, balance, owns] = await Promise.all([
+    resolveNames([row.sellerId, row.buyerId]),
+    getBalance(viewerId),
+    ownsCharacter(viewerId, row.itemId),
+  ]);
+
+  const listing = shapeListing(row, { viewerId, names });
+  const isSeller = row.sellerId === viewerId;
+  const blockReason = resolveBlockReason({
+    status: row.status,
+    isSeller,
+    owns,
+    balance,
+    price: listing.price,
+  });
+
+  delete listing.mine;
+
+  return {
+    ...listing,
+    viewer: {
+      balance,
+      ownsCharacter: owns,
+      isSeller,
+      canBuy: blockReason === null,
+      blockReason,
+    },
+  };
+}
+
+/**
+ * 建立掛單。
+ *
+ * ponytail: 掛單「不」把角色從 inventory 移走 —— 純狀態列，取消就是把 status 翻成
+ * cancelled，賣家的升星強化自始至終沒被動過（對應文案「解除鎖定，不收手續費，
+ * 升星強化留在你手上」）。反正成交當下無論如何都得重驗賣家還在不在（錯誤碼
+ * SELLER_LOST_ITEM 就是為此存在），先搬走只是多一條要回滾的路徑，不會少一次驗證。
+ * 代價：角色可能同時被別的功能消耗掉，此時該單在成交時自動轉 invalid 下架。
+ *
+ * @param {String} sellerId
+ * @param {Object} param1
+ * @param {Number} param1.itemId
+ * @param {Number} param1.price
+ */
+async function createListing(sellerId, { itemId, price }) {
+  if (!isValidPrice(price)) {
+    return { ok: false, code: "INVALID_PRICE" };
+  }
+
+  if (!Number.isInteger(itemId) || itemId <= 0 || itemId === GOD_STONE_ITEM_ID) {
+    return { ok: false, code: "NOT_OWNED" };
+  }
+
+  const openCount = await PublicMarketModel.countOpenBySeller(sellerId);
+  if (openCount >= MAX_OPEN_LISTINGS) {
+    return { ok: false, code: "LISTING_CAP", myOpenCount: openCount, maxOpen: MAX_OPEN_LISTINGS };
+  }
+
+  if (!(await ownsCharacter(sellerId, itemId))) {
+    return { ok: false, code: "NOT_OWNED" };
+  }
+
+  const duplicated = await PublicMarketModel.findOpenBySellerAndItem(sellerId, itemId);
+  if (duplicated) {
+    return { ok: false, code: "ALREADY_LISTED" };
+  }
+
+  const id = await PublicMarketModel.create({
+    seller_id: sellerId,
+    item_id: itemId,
+    price,
+    fee: calcFee(price),
+    status: "open",
+  });
+
+  const row = await PublicMarketModel.getById(id);
+  const names = await resolveNames([sellerId]);
+  const listing = shapeListing(row, { viewerId: sellerId, names });
+
+  return { ok: true, listing };
+}
+
+/**
+ * 賣家取消掛單。不收手續費，角色本來就沒離開過賣家身上。
+ * @param {Number} id
+ * @param {String} userId
+ */
+async function cancelListing(id, userId) {
+  const row = await PublicMarketModel.find(id);
+  if (!row) return { ok: false, code: "NOT_FOUND" };
+  if (row.seller_id !== userId) return { ok: false, code: "FORBIDDEN" };
+  if (row.status !== "open") return { ok: false, code: "NOT_OPEN" };
+
+  const affected = await PublicMarketModel.markClosed(id, "cancelled");
+  if (!affected) return { ok: false, code: "NOT_OPEN" };
+
+  return { ok: true, listingId: Number(id) };
+}
+
+/**
+ * 執行購買。整段包在單一 mysql.transaction 內。
+ *
+ * 競態安全靠兩層：
+ * 1. 進交易先 `SELECT ... FOR UPDATE` 鎖住掛單列，後到的買家會卡住直到前一筆
+ *    commit，醒來時讀到的已是 sold。
+ * 2. 收尾的 UPDATE 帶 `WHERE status = 'open'`，受影響列數為 0 就整筆 rollback。
+ *    即使 1 因故失效也不可能兩個買家都成功。
+ *
+ * 成交後（交易外）替買賣雙方結算 trade_complete 成就，與 1 對 1 交易的做法一致。
+ *
+ * @param {Number} id
+ * @param {String} buyerId
+ * @returns {Promise<Object>} `{ ok: true, ... }` 或 `{ ok: false, code }`
+ */
+async function purchase(id, buyerId) {
+  let result;
+
+  try {
+    await mysql.transaction(async trx => {
+      const listing = await PublicMarketModel.lockById(id, trx);
+      if (!listing) {
+        result = { ok: false, code: "NOT_FOUND" };
+        return;
+      }
+
+      if (listing.status !== "open") {
+        result = { ok: false, code: "ALREADY_TAKEN" };
+        return;
+      }
+
+      const sellerId = listing.seller_id;
+      const itemId = Number(listing.item_id);
+      const price = Number(listing.price);
+      const fee = Number(listing.fee);
+
+      if (sellerId === buyerId) {
+        result = { ok: false, code: "IS_SELLER" };
+        return;
+      }
+
+      if (await ownsCharacter(buyerId, itemId, trx)) {
+        result = { ok: false, code: "ALREADY_OWNED" };
+        return;
+      }
+
+      const balance = await getBalance(buyerId, trx);
+      if (balance < price) {
+        result = {
+          ok: false,
+          code: "INSUFFICIENT_FUNDS",
+          balance,
+          price,
+          shortfall: price - balance,
+        };
+        return;
+      }
+
+      // 賣家可能在掛單後把角色弄丟（其他功能消耗）。刪除受影響列數為 0 即代表已無此角色，
+      // 此時把掛單標記 invalid 自動下架，且不動任何女神石。
+      const removed = await InventoryModel.deleteUserItem(sellerId, itemId, trx);
+      if (!removed) {
+        await PublicMarketModel.markClosed(id, "invalid", trx);
+        result = { ok: false, code: "SELLER_LOST_ITEM" };
+        return;
+      }
+
+      const character = await GachaPoolModel.find(itemId, trx);
+
+      // 升星強化不轉移：買家拿到的是基礎星數。
+      await InventoryModel.create(
+        {
+          userId: buyerId,
+          itemId,
+          itemAmount: 1,
+          attributes: baseAttributes(character),
+          note: `public_market:buy:${id}`,
+        },
+        trx
+      );
+
+      await InventoryModel.decreaseGodStone({
+        userId: buyerId,
+        amount: price,
+        note: `public_market:buy:${id}`,
+        trx,
+      });
+
+      // 手續費銷毀：賣家只入帳 price - fee，沒有任何第三方收到 fee。
+      await InventoryModel.increaseGodStone({
+        userId: sellerId,
+        amount: price - fee,
+        note: `public_market:sell:${id}`,
+        trx,
+      });
+
+      const sold = await PublicMarketModel.markSold(id, buyerId, trx);
+      if (!sold) {
+        // 理論上被 FOR UPDATE 擋掉了，走到這裡代表有人繞過鎖，整筆回滾比較安全。
+        throw new Error("PUBLIC_MARKET_RACE");
+      }
+
+      result = {
+        ok: true,
+        listingId: Number(id),
+        itemId,
+        name: character ? character.Name : null,
+        // sellerId 只給 commit 後的成就結算用；router 的回應欄位是白名單，不會外流
+        sellerId,
+        price,
+        fee,
+        netProceeds: price - fee,
+        balanceAfter: balance - price,
+      };
+    });
+  } catch (e) {
+    if (e && e.message === "PUBLIC_MARKET_RACE") {
+      return { ok: false, code: "ALREADY_TAKEN" };
+    }
+    DefaultLogger.error(e);
+    throw e;
+  }
+
+  // 成就結算一定要在 commit 之後：放在交易內的話，後續 rollback 會留下已發的成就，
+  // 而且成就自己的寫入會把掛單的行鎖一路撐住。失敗一律吞掉，不能反過來弄壞已成交的交易。
+  if (result && result.ok) {
+    await Promise.all([
+      AchievementEngine.evaluate(buyerId, "trade_complete", {}).catch(() => {}),
+      AchievementEngine.evaluate(result.sellerId, "trade_complete", {}).catch(() => {}),
+    ]);
+  }
+
+  return result;
+}
+
+/**
+ * 我的掛單：開放中 + 已結束。
+ * @param {String} userId
+ */
+async function getMyListings(userId) {
+  const [openRows, closedRows] = await Promise.all([
+    PublicMarketModel.getOpenListingsBySeller(userId),
+    PublicMarketModel.getClosedListingsByUser(userId),
+  ]);
+
+  const names = await resolveNames([
+    ...openRows.map(r => r.sellerId),
+    ...closedRows.map(r => r.sellerId),
+    ...closedRows.map(r => r.buyerId),
+  ]);
+
+  const open = openRows.map(row => {
+    const listing = shapeListing(row, { viewerId: userId, names });
+    delete listing.buyerId;
+    delete listing.buyerName;
+    return listing;
+  });
+
+  const closed = closedRows.map(row => {
+    const listing = shapeListing(row, { viewerId: userId, names });
+    const role = row.sellerId === userId ? "seller" : "buyer";
+    const counterpartyId = role === "seller" ? row.buyerId : row.sellerId;
+
+    return {
+      ...listing,
+      role,
+      counterpartyId: counterpartyId || null,
+      counterpartyName: counterpartyId ? names[counterpartyId] || null : null,
+    };
+  });
+
+  return { open, closed };
+}
+
+module.exports = {
+  FEE_PERCENT,
+  MAX_OPEN_LISTINGS,
+  MIN_PRICE,
+  MAX_PRICE,
+  calcFee,
+  calcNetProceeds,
+  isValidPrice,
+  baseStarOf,
+  baseAttributes,
+  resolveBlockReason,
+  getBalance,
+  ownsCharacter,
+  getSummary,
+  getOpenCharacters,
+  getListingsByItemId,
+  getListingDetail,
+  createListing,
+  cancelListing,
+  purchase,
+  getMyListings,
+};

--- a/app/src/service/__tests__/PublicMarketService.test.js
+++ b/app/src/service/__tests__/PublicMarketService.test.js
@@ -1,0 +1,510 @@
+// PublicMarketService 的純邏輯與購買競態測試。
+// 全域 setup（app/__tests__/setup.js）已把 util/mysql 換成 mock query builder，
+// 其 `transaction(cb)` 會直接執行 cb，因此不需要實體 MySQL。
+// model 層一律 mock，測的是 service 的決策而非 SQL。
+
+jest.mock("../../model/application/PublicMarket", () => ({
+  find: jest.fn(),
+  getById: jest.fn(),
+  lockById: jest.fn(),
+  create: jest.fn(),
+  countOpenBySeller: jest.fn(),
+  countOpen: jest.fn(),
+  findOpenBySellerAndItem: jest.fn(),
+  getOpenListingsBySeller: jest.fn(),
+  getClosedListingsByUser: jest.fn(),
+  markSold: jest.fn(),
+  markClosed: jest.fn(),
+}));
+
+jest.mock("../../model/application/Inventory", () => ({
+  inventory: {
+    create: jest.fn(),
+    deleteUserItem: jest.fn(),
+    increaseGodStone: jest.fn(),
+    decreaseGodStone: jest.fn(),
+  },
+}));
+
+jest.mock("../../model/princess/gacha", () => ({
+  model: { find: jest.fn() },
+}));
+
+jest.mock("../ProfileService", () => ({
+  resolveDisplayName: jest.fn(async id => `Name-${id}`),
+}));
+
+jest.mock("../AchievementEngine", () => ({
+  evaluate: jest.fn().mockResolvedValue({ unlocked: [] }),
+}));
+
+const Service = require("../PublicMarketService");
+const PublicMarketModel = require("../../model/application/PublicMarket");
+const { inventory: InventoryModel } = require("../../model/application/Inventory");
+const { model: GachaPoolModel } = require("../../model/princess/gacha");
+const AchievementEngine = require("../AchievementEngine");
+
+const SELLER = "U" + "1".repeat(32);
+const BUYER = "U" + "2".repeat(32);
+
+/**
+ * getBalance / ownsCharacter 都是直接打 mysql("inventory")，
+ * 這裡改寫 mock builder 的 first()，依查詢條件回不同 sum。
+ */
+function stubInventoryReads({ balance = 0, buyerOwns = false } = {}) {
+  const mysql = require("../../util/mysql");
+  let lastWhere = {};
+
+  mysql.where.mockImplementation(cond => {
+    if (cond && typeof cond === "object") lastWhere = cond;
+    return mysql;
+  });
+
+  mysql.first.mockImplementation(async () => {
+    if (lastWhere.itemId === 999) return { amount: balance };
+    return { amount: buyerOwns ? 1 : 0 };
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  const mysql = require("../../util/mysql");
+  mysql.where.mockReturnValue(mysql);
+  mysql.sum.mockReturnValue(mysql);
+  mysql.forUpdate = jest.fn().mockReturnValue(mysql);
+  mysql.first.mockResolvedValue(null);
+
+  InventoryModel.deleteUserItem.mockResolvedValue(1);
+  InventoryModel.create.mockResolvedValue(1);
+  InventoryModel.increaseGodStone.mockResolvedValue([1]);
+  InventoryModel.decreaseGodStone.mockResolvedValue([1]);
+  GachaPoolModel.find.mockResolvedValue({ ID: 101, Name: "佩可莉ーヌ", Star: "3" });
+  PublicMarketModel.markSold.mockResolvedValue(1);
+  PublicMarketModel.markClosed.mockResolvedValue(1);
+  AchievementEngine.evaluate.mockResolvedValue({ unlocked: [] });
+});
+
+describe("手續費計算", () => {
+  it.each([
+    [1000, 50, 950],
+    [8600, 430, 8170],
+    [999, 50, 949],
+    [1, 1, 0],
+    [20, 1, 19],
+    [21, 2, 19],
+    [99999, 5000, 94999],
+  ])("price %i -> fee %i / net %i（5%% 無條件進位）", (price, fee, net) => {
+    expect(Service.calcFee(price)).toBe(fee);
+    expect(Service.calcNetProceeds(price)).toBe(net);
+  });
+
+  it("手續費是銷毀的：買家付的 price 不等於賣家收到的 net", () => {
+    const price = 8600;
+    expect(Service.calcNetProceeds(price)).toBeLessThan(price);
+    expect(price - Service.calcNetProceeds(price)).toBe(Service.calcFee(price));
+  });
+});
+
+describe("價格驗證", () => {
+  it.each([1, 2, 99998, 99999])("接受 %i", p => expect(Service.isValidPrice(p)).toBe(true));
+
+  it.each([0, -1, 100000, 1.5, NaN, Infinity, "500", null, undefined])("拒絕 %p", p =>
+    expect(Service.isValidPrice(p)).toBe(false)
+  );
+});
+
+describe("升星不轉移", () => {
+  it("attributes 用 gacha_pool 的基礎星數，不是賣家的升星值", () => {
+    expect(Service.baseAttributes({ Star: "3" })).toBe(JSON.stringify([{ key: "star", value: 3 }]));
+  });
+
+  it("查無角色資料時退回 1 星，不會寫入 NaN", () => {
+    expect(Service.baseStarOf(null)).toBe(1);
+    expect(Service.baseStarOf({ Star: "" })).toBe(1);
+  });
+});
+
+describe("blockReason 判定順序", () => {
+  const ctx = { status: "open", isSeller: false, owns: false, balance: 100, price: 50 };
+
+  it("可買時為 null", () => expect(Service.resolveBlockReason(ctx)).toBeNull());
+
+  it("非 open 一律 NOT_OPEN，優先於身分判定", () => {
+    expect(
+      Service.resolveBlockReason({ ...ctx, status: "sold", isSeller: true, owns: true, balance: 0 })
+    ).toBe("NOT_OPEN");
+  });
+
+  it.each([
+    [{ isSeller: true }, "IS_SELLER"],
+    [{ owns: true }, "ALREADY_OWNED"],
+    [{ balance: 10 }, "INSUFFICIENT_FUNDS"],
+  ])("%p -> %s", (patch, expected) => {
+    expect(Service.resolveBlockReason({ ...ctx, ...patch })).toBe(expected);
+  });
+});
+
+describe("掛單上限", () => {
+  it("已有 10 筆開放掛單時回 LISTING_CAP，且不寫入", async () => {
+    PublicMarketModel.countOpenBySeller.mockResolvedValue(10);
+
+    const res = await Service.createListing(SELLER, { itemId: 101, price: 1000 });
+
+    expect(res).toMatchObject({ ok: false, code: "LISTING_CAP", maxOpen: 10 });
+    expect(PublicMarketModel.create).not.toHaveBeenCalled();
+  });
+
+  it("第 10 筆（已有 9 筆）可以掛", async () => {
+    PublicMarketModel.countOpenBySeller.mockResolvedValue(9);
+    PublicMarketModel.findOpenBySellerAndItem.mockResolvedValue(null);
+    PublicMarketModel.create.mockResolvedValue(77);
+    PublicMarketModel.getById.mockResolvedValue({
+      id: 77,
+      itemId: 101,
+      sellerId: SELLER,
+      price: 1000,
+      fee: 50,
+      status: "open",
+      name: "佩可莉ーヌ",
+      star: "3",
+    });
+    stubInventoryReads({ balance: 0, buyerOwns: true }); // 賣家持有該角色
+
+    const res = await Service.createListing(SELLER, { itemId: 101, price: 1000 });
+
+    expect(res.ok).toBe(true);
+    expect(res.listing).toMatchObject({ fee: 50, netProceeds: 950, star: 3 });
+    expect(PublicMarketModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({ price: 1000, fee: 50, status: "open" })
+    );
+  });
+
+  it("價格不合法時連上限都不查", async () => {
+    const res = await Service.createListing(SELLER, { itemId: 101, price: 0 });
+    expect(res).toEqual({ ok: false, code: "INVALID_PRICE" });
+    expect(PublicMarketModel.countOpenBySeller).not.toHaveBeenCalled();
+  });
+});
+
+describe("購買競態", () => {
+  function openListing(overrides = {}) {
+    return {
+      id: 42,
+      seller_id: SELLER,
+      buyer_id: null,
+      item_id: 101,
+      price: 1000,
+      fee: 50,
+      status: "open",
+      ...overrides,
+    };
+  }
+
+  function expectNoMoneyMoved() {
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+    expect(InventoryModel.deleteUserItem).not.toHaveBeenCalled();
+    expect(InventoryModel.create).not.toHaveBeenCalled();
+  }
+
+  it.each(["sold", "cancelled", "invalid"])(
+    "狀態 %s 的掛單回 ALREADY_TAKEN，且不動任何女神石",
+    async status => {
+      PublicMarketModel.lockById.mockResolvedValue(openListing({ status }));
+      stubInventoryReads({ balance: 999999 });
+
+      const res = await Service.purchase(42, BUYER);
+
+      expect(res).toEqual({ ok: false, code: "ALREADY_TAKEN" });
+      expectNoMoneyMoved();
+      expect(PublicMarketModel.markSold).not.toHaveBeenCalled();
+    }
+  );
+
+  it("鎖失效導致 markSold 影響 0 列時整筆回滾成 ALREADY_TAKEN", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    PublicMarketModel.markSold.mockResolvedValue(0);
+    stubInventoryReads({ balance: 5000 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_TAKEN" });
+  });
+
+  it("餘額不足回 INSUFFICIENT_FUNDS 並附差額，不扣款", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 300 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res).toEqual({
+      ok: false,
+      code: "INSUFFICIENT_FUNDS",
+      balance: 300,
+      price: 1000,
+      shortfall: 700,
+    });
+    expectNoMoneyMoved();
+  });
+
+  it("已擁有該角色回 ALREADY_OWNED，不扣款", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 5000, buyerOwns: true });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_OWNED" });
+    expectNoMoneyMoved();
+  });
+
+  it("買自己的單回 IS_SELLER", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 5000 });
+
+    const res = await Service.purchase(42, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "IS_SELLER" });
+    expectNoMoneyMoved();
+  });
+
+  it("賣家已無角色時標記 invalid 自動下架，且沒有女神石異動", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    InventoryModel.deleteUserItem.mockResolvedValue(0);
+    stubInventoryReads({ balance: 5000 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "SELLER_LOST_ITEM" });
+    expect(PublicMarketModel.markClosed).toHaveBeenCalledWith(42, "invalid", expect.anything());
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("成功成交：買家扣 price、賣家收 price-fee、手續費無人收", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing({ price: 8600, fee: 430 }));
+    stubInventoryReads({ balance: 10000 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res).toMatchObject({
+      ok: true,
+      listingId: 42,
+      price: 8600,
+      fee: 430,
+      netProceeds: 8170,
+      balanceAfter: 1400,
+    });
+
+    expect(InventoryModel.decreaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: BUYER, amount: 8600 })
+    );
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: SELLER, amount: 8170 })
+    );
+    // 只有這兩筆金流：手續費沒有轉給任何第三方
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledTimes(1);
+    expect(InventoryModel.decreaseGodStone).toHaveBeenCalledTimes(1);
+  });
+
+  it("成交時買家拿到的是基礎星數，不是賣家的升星值", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    GachaPoolModel.find.mockResolvedValue({ ID: 101, Name: "佩可莉ーヌ", Star: "3" });
+    stubInventoryReads({ balance: 10000 });
+
+    await Service.purchase(42, BUYER);
+
+    expect(InventoryModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: BUYER,
+        itemId: 101,
+        itemAmount: 1,
+        attributes: JSON.stringify([{ key: "star", value: 3 }]),
+      }),
+      expect.anything()
+    );
+  });
+});
+
+describe("star 欄位輸出", () => {
+  const baseRow = {
+    id: 7,
+    itemId: 101,
+    sellerId: SELLER,
+    buyerId: null,
+    price: 1000,
+    fee: 50,
+    status: "open",
+    name: "佩可莉ーヌ",
+  };
+
+  it("掛單簿列表帶出 star，且沒被 delete 剪掉", async () => {
+    PublicMarketModel.getOpenListingsByItemId = jest
+      .fn()
+      .mockResolvedValue([{ ...baseRow, star: "3" }]);
+
+    const [listing] = await Service.getListingsByItemId(101, BUYER);
+
+    expect(listing.star).toBe(3);
+    expect(typeof listing.star).toBe("number");
+  });
+
+  it("單張掛單詳情帶出 star", async () => {
+    PublicMarketModel.getById.mockResolvedValue({ ...baseRow, star: "2" });
+    stubInventoryReads({ balance: 5000 });
+
+    const detail = await Service.getListingDetail(7, BUYER);
+
+    expect(detail.star).toBe(2);
+  });
+
+  it("我的掛單 open / closed 兩個陣列都有 star", async () => {
+    PublicMarketModel.getOpenListingsBySeller.mockResolvedValue([{ ...baseRow, star: "1" }]);
+    PublicMarketModel.getClosedListingsByUser.mockResolvedValue([
+      { ...baseRow, id: 8, status: "sold", buyerId: BUYER, star: "3" },
+    ]);
+
+    const { open, closed } = await Service.getMyListings(SELLER);
+
+    expect(open[0].star).toBe(1);
+    expect(closed[0].star).toBe(3);
+  });
+
+  it("角色清單（GROUP BY 查詢）也帶出 star", async () => {
+    PublicMarketModel.getOpenCharacters = jest
+      .fn()
+      .mockResolvedValue([
+        { itemId: 770, name: "可可蘿", star: "3", headImage: null, listingCount: 2, minPrice: 500 },
+      ]);
+
+    const [character] = await Service.getOpenCharacters();
+
+    expect(character).toMatchObject({ itemId: 770, star: 3, listingCount: 2, minPrice: 500 });
+  });
+
+  it.each([
+    [undefined, 1],
+    [null, 1],
+    ["", 1],
+    ["0", 1],
+    [0, 1],
+    ["abc", 1],
+    ["2", 2],
+    [3, 3],
+  ])("Star=%p 時 star 輸出 %i（baseStarOf 既有 fallback 契約）", async (rawStar, expected) => {
+    PublicMarketModel.getOpenListingsByItemId = jest
+      .fn()
+      .mockResolvedValue([{ ...baseRow, star: rawStar }]);
+
+    const [listing] = await Service.getListingsByItemId(101, BUYER);
+
+    expect(listing.star).toBe(expected);
+  });
+});
+
+describe("trade_complete 成就結算", () => {
+  function openListing(overrides = {}) {
+    return {
+      id: 42,
+      seller_id: SELLER,
+      buyer_id: null,
+      item_id: 101,
+      price: 1000,
+      fee: 50,
+      status: "open",
+      ...overrides,
+    };
+  }
+
+  it("成交後買賣雙方各結算一次，事件型別為 trade_complete", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 10000 });
+
+    await Service.purchase(42, BUYER);
+
+    expect(AchievementEngine.evaluate).toHaveBeenCalledTimes(2);
+    expect(AchievementEngine.evaluate).toHaveBeenCalledWith(BUYER, "trade_complete", {});
+    expect(AchievementEngine.evaluate).toHaveBeenCalledWith(SELLER, "trade_complete", {});
+  });
+
+  it("結算發生在 commit 之後：呼叫時 markSold 已經完成", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 10000 });
+
+    const callOrder = [];
+    PublicMarketModel.markSold.mockImplementation(async () => {
+      callOrder.push("markSold");
+      return 1;
+    });
+    AchievementEngine.evaluate.mockImplementation(async () => {
+      callOrder.push("evaluate");
+      return { unlocked: [] };
+    });
+
+    await Service.purchase(42, BUYER);
+
+    expect(callOrder[0]).toBe("markSold");
+    expect(callOrder.slice(1)).toEqual(["evaluate", "evaluate"]);
+  });
+
+  it("ALREADY_TAKEN 不結算成就", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing({ status: "sold" }));
+    stubInventoryReads({ balance: 10000 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res.code).toBe("ALREADY_TAKEN");
+    expect(AchievementEngine.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("INSUFFICIENT_FUNDS 不結算成就", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 10 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res.code).toBe("INSUFFICIENT_FUNDS");
+    expect(AchievementEngine.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("SELLER_LOST_ITEM 雖然改了掛單狀態，仍不算一次交易成就", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    InventoryModel.deleteUserItem.mockResolvedValue(0);
+    stubInventoryReads({ balance: 10000 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res.code).toBe("SELLER_LOST_ITEM");
+    expect(PublicMarketModel.markClosed).toHaveBeenCalledWith(42, "invalid", expect.anything());
+    expect(AchievementEngine.evaluate).not.toHaveBeenCalled();
+  });
+
+  it.each(["ALREADY_OWNED", "IS_SELLER"])("%s 不結算成就", async code => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 10000, buyerOwns: code === "ALREADY_OWNED" });
+
+    const res = await Service.purchase(42, code === "IS_SELLER" ? SELLER : BUYER);
+
+    expect(res.code).toBe(code);
+    expect(AchievementEngine.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("成就爆炸不會弄壞已成交的交易（.catch 真的吞得住）", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 10000 });
+    AchievementEngine.evaluate.mockRejectedValue(new Error("achievement exploded"));
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res).toMatchObject({ ok: true, listingId: 42, price: 1000 });
+  });
+
+  it("sellerId 有進 service 結果，成就才找得到賣家", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 10000 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res.sellerId).toBe(SELLER);
+  });
+});

--- a/app/src/templates/application/PublicMarket.js
+++ b/app/src/templates/application/PublicMarket.js
@@ -1,0 +1,224 @@
+const { getLiffUri } = require("../common");
+
+/**
+ * 公開市場總覽 bubble（`.市場`）。
+ * 版型來自設計稿 line-flex-market.json，數字改為由 service 帶入。
+ *
+ * @param {Object} param0
+ * @param {Number} param0.myOpenCount 我的開放掛單數
+ * @param {Number} param0.maxOpen 掛單上限
+ * @param {Number} param0.totalOpenCount 全站開放掛單數
+ * @param {Number} param0.feePercent 手續費百分比
+ * @returns {Object} Flex bubble
+ */
+exports.generateMarketBubble = ({ myOpenCount, maxOpen, totalOpenCount, feePercent }) => {
+  // 配額條寬度：0 也給 0%，滿了就 100%，避免超出容器。
+  const quotaRatio = maxOpen > 0 ? Math.min(myOpenCount / maxOpen, 1) : 0;
+  const quotaWidth = `${Math.round(quotaRatio * 100)}%`;
+
+  return {
+    type: "bubble",
+    size: "mega",
+    header: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "20px",
+      paddingBottom: "16px",
+      background: {
+        type: "linearGradient",
+        angle: "135deg",
+        startColor: "#00838F",
+        endColor: "#00ACC1",
+      },
+      contents: [
+        {
+          type: "box",
+          layout: "baseline",
+          contents: [
+            {
+              type: "text",
+              text: "公開市場",
+              size: "xl",
+              weight: "bold",
+              color: "#FFFFFF",
+              flex: 0,
+            },
+            {
+              type: "text",
+              text: `手續費 ${feePercent}%`,
+              size: "xs",
+              color: "#FFFFFF",
+              align: "end",
+              gravity: "center",
+            },
+          ],
+        },
+        {
+          type: "text",
+          text: "角色掛單簿 · 最低價優先",
+          size: "xs",
+          color: "#CDEFF3",
+          margin: "sm",
+        },
+      ],
+    },
+    body: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "20px",
+      spacing: "md",
+      contents: [
+        {
+          type: "box",
+          layout: "baseline",
+          contents: [
+            {
+              type: "text",
+              text: "我的開放掛單",
+              size: "sm",
+              color: "#5A6B7F",
+              flex: 0,
+            },
+            {
+              type: "text",
+              text: `${myOpenCount} / ${maxOpen}`,
+              size: "md",
+              weight: "bold",
+              color: "#1A2332",
+              align: "end",
+            },
+          ],
+        },
+        {
+          type: "box",
+          layout: "vertical",
+          height: "6px",
+          backgroundColor: "#E0F7FA",
+          cornerRadius: "3px",
+          contents: [
+            {
+              type: "box",
+              layout: "vertical",
+              width: quotaWidth,
+              height: "6px",
+              backgroundColor: "#00ACC1",
+              cornerRadius: "3px",
+              contents: [{ type: "filler" }],
+            },
+          ],
+        },
+        {
+          type: "separator",
+          margin: "lg",
+          color: "#E8EEF0",
+        },
+        {
+          type: "box",
+          layout: "baseline",
+          margin: "lg",
+          contents: [
+            {
+              type: "text",
+              text: "全站開放掛單",
+              size: "sm",
+              color: "#5A6B7F",
+              flex: 0,
+            },
+            {
+              type: "text",
+              text: `${totalOpenCount} 筆`,
+              size: "sm",
+              weight: "bold",
+              color: "#1A2332",
+              align: "end",
+            },
+          ],
+        },
+        {
+          type: "box",
+          layout: "baseline",
+          margin: "sm",
+          contents: [
+            {
+              type: "text",
+              text: "手續費",
+              size: "sm",
+              color: "#5A6B7F",
+              flex: 0,
+            },
+            {
+              type: "text",
+              text: `成交價 ${feePercent}%（向上取整，銷毀）`,
+              size: "xs",
+              color: "#5A6B7F",
+              align: "end",
+              wrap: true,
+            },
+          ],
+        },
+        {
+          type: "box",
+          layout: "horizontal",
+          margin: "lg",
+          spacing: "sm",
+          paddingAll: "12px",
+          backgroundColor: "#FFF7E6",
+          cornerRadius: "8px",
+          borderWidth: "1px",
+          borderColor: "#FBBF24",
+          contents: [
+            {
+              type: "text",
+              text: "⚠",
+              size: "sm",
+              color: "#B45309",
+              flex: 0,
+            },
+            {
+              type: "text",
+              text: "賣出時你的升星強化不會轉移，買家收到的是角色初始星數。",
+              size: "xs",
+              color: "#B45309",
+              wrap: true,
+            },
+          ],
+        },
+      ],
+    },
+    footer: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "16px",
+      paddingTop: "none",
+      spacing: "sm",
+      contents: [
+        {
+          type: "button",
+          style: "primary",
+          height: "sm",
+          color: "#00ACC1",
+          action: {
+            type: "uri",
+            label: "前往市場",
+            uri: getLiffUri("full", "/trade/market"),
+          },
+        },
+        {
+          type: "button",
+          style: "link",
+          height: "sm",
+          action: {
+            type: "uri",
+            label: "我要掛賣單",
+            uri: getLiffUri("full", "/trade/sell"),
+          },
+        },
+      ],
+    },
+    styles: {
+      footer: {
+        separator: false,
+      },
+    },
+  };
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,10 @@ import Equipment from "./pages/Equipment";
 import TradeOrder from "./pages/Trade/Order";
 import TradeManage from "./pages/Trade/Manage";
 import TradeDetail from "./pages/Trade/TradeDetail";
+import Market from "./pages/Trade/Market";
+import MarketListing from "./pages/Trade/MarketListing";
+import MarketSell from "./pages/Trade/Sell";
+import MyListings from "./pages/Trade/MyListings";
 import GroupList from "./pages/Group";
 import GroupRecord from "./pages/Group/Record";
 import GroupConfig from "./pages/Group/Config";
@@ -75,6 +79,12 @@ export default function App() {
           <Route path="equipment" element={<Equipment />} />
 
           {/* Trade */}
+          {/* 公開市場 / 角色委託所 —— 必須排在 trade/:marketId 之前，
+              否則 "market" / "sell" / "my-listings" 會被當成 marketId 吃掉。 */}
+          <Route path="trade/market" element={<Market />} />
+          <Route path="trade/sell" element={<MarketSell />} />
+          <Route path="trade/my-listings" element={<MyListings />} />
+          <Route path="trade/listings/:id" element={<MarketListing />} />
           <Route path="trade/order" element={<TradeOrder />} />
           <Route path="trade/manage" element={<TradeManage />} />
           <Route path="trade/:marketId" element={<TradeDetail />} />

--- a/frontend/src/components/GroupConfig/ConfigCard.jsx
+++ b/frontend/src/components/GroupConfig/ConfigCard.jsx
@@ -30,7 +30,7 @@ export default function ConfigCard({ title, description, status, name, handle, i
           onChange={isLoggedIn ? handleChange : undefined}
           color="primary"
           disabled={!isLoggedIn}
-          inputProps={{ "aria-label": `toggle ${name}` }}
+          slotProps={{ input: { "aria-label": `toggle ${name}` } }}
         />
       </CardActions>
     </Card>

--- a/frontend/src/components/NavDrawer.jsx
+++ b/frontend/src/components/NavDrawer.jsx
@@ -65,6 +65,8 @@ const botItems = [{ label: "使用手冊", path: "/panel/manual", icon: LibraryB
 const personalItems = [
   { label: "我的群組", path: "/groups", icon: GroupsIcon },
   { label: "聊天文字雲", path: "/topics", icon: BubbleChartIcon },
+  { label: "角色交易所", path: "/trade/market", icon: ShoppingBasketIcon },
+  { label: "我的掛單", path: "/trade/my-listings", icon: ShoppingBasketIcon },
   { label: "交易管理", path: "/trade/manage", icon: ShoppingBasketIcon },
   { label: "自動設定", path: "/auto/settings", icon: AutoAwesomeIcon },
   { label: "自動行為紀錄", path: "/auto/history", icon: HistoryIcon },

--- a/frontend/src/pages/Admin/Coupon/CouponFormDialog.jsx
+++ b/frontend/src/pages/Admin/Coupon/CouponFormDialog.jsx
@@ -71,8 +71,10 @@ export default function CouponFormDialog({ open, editing, saving, onClose, onSub
             disabled={codeLocked}
             error={!!err.code}
             helperText={err.code || (codeLocked ? "已有人領取，無法修改" : "最多 50 字")}
-            inputProps={{ maxLength: 50 }}
             fullWidth
+            slotProps={{
+              htmlInput: { maxLength: 50 },
+            }}
           />
           <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
             <TextField
@@ -103,8 +105,10 @@ export default function CouponFormDialog({ open, editing, saving, onClose, onSub
             onChange={set("reward")}
             error={!!err.reward}
             helperText={err.reward}
-            inputProps={{ min: 1 }}
             fullWidth
+            slotProps={{
+              htmlInput: { min: 1 },
+            }}
           />
         </Stack>
       </DialogContent>

--- a/frontend/src/pages/Admin/GachaShop.jsx
+++ b/frontend/src/pages/Admin/GachaShop.jsx
@@ -267,7 +267,7 @@ export default function AdminGachaShop() {
         onClose={() => setEditDialogOpen(false)}
         maxWidth="sm"
         fullWidth
-        PaperProps={{ sx: { borderRadius: 3 } }}
+        slotProps={{ paper: { sx: { borderRadius: 3 } } }}
       >
         <DialogTitle sx={{ fontWeight: 700 }}>編輯商品</DialogTitle>
         <DialogContent>

--- a/frontend/src/pages/Admin/WorldbossEvent.jsx
+++ b/frontend/src/pages/Admin/WorldbossEvent.jsx
@@ -58,7 +58,7 @@ function EditDialog({ open, onClose, onSubmit, loading: parentLoading }) {
       onClose={onClose}
       maxWidth="sm"
       fullWidth
-      PaperProps={{ sx: { borderRadius: 3 } }}
+      slotProps={{ paper: { sx: { borderRadius: 3 } } }}
     >
       <DialogTitle sx={{ fontWeight: 700 }}>新增世界王活動</DialogTitle>
       <DialogContent>

--- a/frontend/src/pages/Trade/CharacterPickerDrawer.jsx
+++ b/frontend/src/pages/Trade/CharacterPickerDrawer.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   SwipeableDrawer,
   Box,
@@ -9,8 +9,12 @@ import {
   Avatar,
   Button,
   IconButton,
+  InputAdornment,
+  TextField,
 } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CloseIcon from "@mui/icons-material/Close";
+import SearchIcon from "@mui/icons-material/Search";
 
 /**
  * Bottom-sheet character picker.
@@ -20,15 +24,30 @@ import CloseIcon from "@mui/icons-material/Close";
  *   items        - [{ itemId, name, headImage }]
  *   initialId    - itemId currently selected (may be null)
  *   onConfirm    - (itemId) => void
+ *   title        - heading copy (defaults to the trade wording)
  */
-export default function CharacterPickerDrawer({ open, onClose, items, initialId, onConfirm }) {
+export default function CharacterPickerDrawer({
+  open,
+  onClose,
+  items,
+  initialId,
+  onConfirm,
+  title = "選擇要交易的角色",
+}) {
   const [localId, setLocalId] = useState(initialId ?? null);
+  const [keyword, setKeyword] = useState("");
 
   // Re-syncing on each open keeps the picker honest if the parent's
   // selection changes between opens.
   useEffect(() => {
     if (open) setLocalId(initialId ?? null);
   }, [open, initialId]);
+
+  const hits = useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(i => i.name?.toLowerCase().includes(q) || String(i.itemId).includes(q));
+  }, [items, keyword]);
 
   const handleConfirm = () => {
     onConfirm(localId);
@@ -41,11 +60,13 @@ export default function CharacterPickerDrawer({ open, onClose, items, initialId,
       open={open}
       onClose={onClose}
       onOpen={() => {}}
-      PaperProps={{
-        sx: {
-          borderTopLeftRadius: 16,
-          borderTopRightRadius: 16,
-          maxHeight: "85dvh",
+      slotProps={{
+        paper: {
+          sx: {
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            maxHeight: "85dvh",
+          },
         },
       }}
     >
@@ -63,11 +84,45 @@ export default function CharacterPickerDrawer({ open, onClose, items, initialId,
         }}
       >
         <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-          選擇要交易的角色
+          {title}
         </Typography>
-        <IconButton onClick={onClose} size="small" aria-label="關閉">
-          <CloseIcon />
-        </IconButton>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            {hits.length} / {items.length} 位
+          </Typography>
+          <IconButton onClick={onClose} size="small" aria-label="關閉角色選擇">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </Box>
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: { md: 720 },
+          mx: { md: "auto" },
+          px: 2,
+          pb: 1.5,
+        }}
+      >
+        <TextField
+          type="search"
+          size="small"
+          fullWidth
+          value={keyword}
+          onChange={e => setKeyword(e.target.value)}
+          placeholder="搜尋角色名稱或編號"
+          aria-label="搜尋角色名稱或編號"
+          autoComplete="off"
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
       </Box>
       <Box
         sx={{
@@ -84,9 +139,15 @@ export default function CharacterPickerDrawer({ open, onClose, items, initialId,
           <Box sx={{ py: 6, textAlign: "center", color: "text.secondary" }}>
             您目前沒有可交易的角色
           </Box>
+        ) : hits.length === 0 ? (
+          <Box sx={{ py: 6, textAlign: "center", color: "text.secondary", fontSize: 13 }}>
+            沒有符合「{keyword}」的角色。
+            <br />
+            可以搜名字或角色編號。
+          </Box>
         ) : (
           <Grid container spacing={1.5}>
-            {items.map(item => {
+            {hits.map(item => {
               const selected = item.itemId === localId;
               return (
                 <Grid size={{ xs: 4, sm: 3, md: 2 }} key={item.itemId}>
@@ -111,6 +172,20 @@ export default function CharacterPickerDrawer({ open, onClose, items, initialId,
                             borderRadius: 0,
                           }}
                         />
+                        {selected && (
+                          <CheckCircleIcon
+                            aria-hidden="true"
+                            sx={{
+                              position: "absolute",
+                              right: 4,
+                              top: 4,
+                              fontSize: 20,
+                              color: "primary.main",
+                              bgcolor: "background.paper",
+                              borderRadius: "50%",
+                            }}
+                          />
+                        )}
                       </Box>
                       <Box sx={{ p: 0.75 }}>
                         <Typography

--- a/frontend/src/pages/Trade/Market.jsx
+++ b/frontend/src/pages/Trade/Market.jsx
@@ -1,0 +1,633 @@
+import { useEffect, useMemo, useState } from "react";
+import useAxios from "axios-hooks";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Skeleton,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import SearchIcon from "@mui/icons-material/Search";
+import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
+import DiamondIcon from "@mui/icons-material/Diamond";
+import AlertLogin from "../../components/AlertLogin";
+import HintSnackBar from "../../components/HintSnackBar";
+import useHintBar from "../../hooks/useHintBar";
+import useLiff from "../../context/useLiff";
+import { NUMS, calcFee, displayName, errorText, fmtStone } from "./_market";
+import { CharAvatar, BaseStar, GradientPanel, Row, Tag } from "./_marketUi";
+
+/* ---------------------------------------------------------------- 錢包 chip */
+function WalletChip({ balance, loading }) {
+  return (
+    <Box
+      sx={theme => ({
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.75,
+        px: 1.25,
+        py: 0.625,
+        borderRadius: 999,
+        border: "1px solid",
+        borderColor: "divider",
+        bgcolor: alpha(theme.palette.primary.main, 0.1),
+        color: theme.palette.mode === "dark" ? "primary.light" : "primary.dark",
+        fontSize: 13,
+        fontWeight: 600,
+        ...NUMS,
+      })}
+    >
+      <DiamondIcon sx={{ fontSize: 14 }} />
+      {loading ? "…" : fmtStone(balance)}
+      <Box component="span" sx={{ position: "absolute", width: 1, height: 1, overflow: "hidden" }}>
+        女神石
+      </Box>
+    </Box>
+  );
+}
+
+function PageHeader({ balance, loading }) {
+  return (
+    <Box
+      sx={{
+        position: "sticky",
+        top: 0,
+        zIndex: 3,
+        display: "flex",
+        alignItems: "center",
+        gap: 1.25,
+        py: 1,
+        mb: -0.5,
+        bgcolor: "background.default",
+      }}
+    >
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: "1 1 auto" }}>
+        角色交易所
+      </Typography>
+      <WalletChip balance={balance} loading={loading} />
+    </Box>
+  );
+}
+
+/* ---------------------------------------------------------------- 角色 chip */
+function CharacterChip({ char, selected, onClick }) {
+  return (
+    <Box
+      component="button"
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      sx={theme => ({
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.875,
+        pl: 0.625,
+        pr: 1.5,
+        py: 0.625,
+        borderRadius: 999,
+        cursor: "pointer",
+        font: "inherit",
+        fontSize: 13,
+        fontWeight: 600,
+        color: selected
+          ? theme.palette.mode === "dark"
+            ? theme.palette.primary.light
+            : theme.palette.primary.dark
+          : theme.palette.text.primary,
+        border: "1px solid",
+        borderColor: selected ? "primary.main" : "divider",
+        bgcolor: selected
+          ? alpha(theme.palette.primary.main, 0.14)
+          : theme.palette.background.paper,
+        transition: "transform .16s ease, box-shadow .16s ease, background .16s ease",
+        "&:hover": { transform: "translateY(-1px)", boxShadow: theme.shadows[2] },
+      })}
+    >
+      <CharAvatar
+        itemId={char.itemId}
+        name={char.name}
+        headImage={char.headImage}
+        size={24}
+        sx={{ fontSize: 11 }}
+      />
+      <span>{char.name}</span>
+      <BaseStar star={char.star} size={11} />
+      <Box
+        component="span"
+        sx={theme => ({
+          fontSize: 11,
+          fontWeight: 600,
+          color: "text.secondary",
+          bgcolor: alpha(theme.palette.text.primary, 0.04),
+          borderRadius: 999,
+          px: 0.75,
+          py: "1px",
+        })}
+      >
+        {char.listingCount}
+      </Box>
+    </Box>
+  );
+}
+
+/* ---------------------------------------------------------------- 掛單一列 */
+function OrderCard({ listing, lowest, onBuy }) {
+  const mine = Boolean(listing.mine);
+  const navigate = useNavigate();
+  return (
+    <Paper
+      component="li"
+      elevation={0}
+      sx={theme => ({
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        p: 1.5,
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: mine ? alpha(theme.palette.secondary.main, 0.45) : "divider",
+        transition: "transform .18s ease, box-shadow .18s ease, border-color .18s ease",
+        "&:hover": {
+          transform: "translateY(-2px)",
+          boxShadow: theme.shadows[4],
+          borderColor: mine
+            ? alpha(theme.palette.secondary.main, 0.6)
+            : alpha(theme.palette.primary.main, 0.4),
+        },
+      })}
+    >
+      <CharAvatar itemId={listing.itemId} name={listing.name} headImage={listing.headImage} />
+      <Box
+        onClick={() => navigate(`/trade/listings/${listing.id}`)}
+        sx={{ flex: "1 1 auto", minWidth: 0, cursor: "pointer" }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.75,
+            flexWrap: "wrap",
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        >
+          {listing.name}
+          <BaseStar star={listing.star} />
+          {lowest && !mine && <Tag label="最低價" color="success" />}
+          {mine && <Tag label="你的掛單" color="secondary" />}
+        </Box>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          noWrap
+          sx={{ display: "block", mt: "3px" }}
+        >
+          賣家 {displayName(listing.sellerName)} ・ {listing.itemId}
+        </Typography>
+        <Box
+          sx={theme => ({
+            display: "flex",
+            alignItems: "center",
+            gap: 0.625,
+            mt: 0.625,
+            fontSize: 15,
+            fontWeight: 600,
+            color: theme.palette.mode === "dark" ? "primary.light" : "primary.dark",
+            ...NUMS,
+          })}
+        >
+          <DiamondIcon sx={{ fontSize: 13 }} />
+          {fmtStone(listing.price)}
+          <Box component="span" sx={{ fontSize: 11, fontWeight: 400, color: "text.secondary" }}>
+            女神石
+          </Box>
+        </Box>
+      </Box>
+      {mine ? (
+        // 依設計稿：自己的掛單保留按鈕但停用。用 aria-disabled 而非 disabled，
+        // 讀屏會唸出來；同時不掛 onClick，按下去真的不會發生任何事。
+        <Button
+          size="small"
+          variant="outlined"
+          component="span"
+          role="button"
+          tabIndex={0}
+          aria-disabled="true"
+          aria-label="這是你自己的掛單，無法購買"
+          sx={{
+            flex: "0 0 auto",
+            color: "text.secondary",
+            borderColor: "divider",
+            bgcolor: theme => alpha(theme.palette.text.primary, 0.04),
+            cursor: "not-allowed",
+            "&:hover": {
+              borderColor: "divider",
+              bgcolor: theme => alpha(theme.palette.text.primary, 0.04),
+            },
+          }}
+        >
+          立即購買
+        </Button>
+      ) : (
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => onBuy(listing)}
+          sx={{ flex: "0 0 auto" }}
+        >
+          立即購買
+        </Button>
+      )}
+    </Paper>
+  );
+}
+
+/* ---------------------------------------------------------------- 空狀態 */
+function EmptyBook({ onPickOther }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        textAlign: "center",
+        py: 5,
+        px: 2.5,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 1.25,
+      }}
+    >
+      <Box
+        aria-hidden="true"
+        sx={theme => ({
+          width: 72,
+          height: 72,
+          borderRadius: "50%",
+          border: "2px dashed",
+          borderColor: alpha(theme.palette.primary.main, 0.45),
+          display: "grid",
+          placeItems: "center",
+          color: "primary.main",
+          fontSize: 26,
+        })}
+      >
+        ◌
+      </Box>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, mt: 0.5 }}>
+        該角色目前沒有掛單
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.7 }}>
+        等其他玩家上架，或改看別的角色。
+        <br />
+        你也可以自己掛一張。
+      </Typography>
+      <Button variant="outlined" onClick={onPickOther} sx={{ mt: 0.75 }}>
+        看其他角色
+      </Button>
+    </Paper>
+  );
+}
+
+function Note({ children }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={theme => ({
+        p: 1.5,
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        bgcolor: alpha(theme.palette.text.primary, 0.04),
+        fontSize: 12,
+        lineHeight: 1.7,
+        color: "text.secondary",
+      })}
+    >
+      {children}
+    </Paper>
+  );
+}
+
+/* ---------------------------------------------------------------- 主頁面 */
+export default function Market() {
+  const { loggedIn: isLoggedIn } = useLiff();
+  const navigate = useNavigate();
+
+  const [keyword, setKeyword] = useState("");
+  const [selectedId, setSelectedId] = useState(null);
+  const [pickerOpen, setPickerOpen] = useState(true);
+  const [pending, setPending] = useState(null);
+
+  const [{ data: summary, loading: summaryLoading }, refetchSummary] = useAxios(
+    "/api/public-market/summary",
+    { manual: true }
+  );
+  const [{ data: characters, loading: charsLoading, error: charsError }, refetchChars] = useAxios(
+    "/api/public-market/characters",
+    { manual: true }
+  );
+  const [{ data: listings, loading: listingsLoading, error: listingsError }, fetchListings] =
+    useAxios("/api/public-market/listings", { manual: true });
+  const [{ loading: buying }, purchase] = useAxios({ method: "POST" }, { manual: true });
+  const [{ message, severity, open: snackOpen }, { handleOpen, handleClose }] = useHintBar();
+
+  useEffect(() => {
+    document.title = "角色交易所";
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    refetchSummary();
+    refetchChars();
+  }, [isLoggedIn, refetchSummary, refetchChars]);
+
+  const charList = useMemo(() => (Array.isArray(characters) ? characters : []), [characters]);
+  const rows = useMemo(() => (Array.isArray(listings) ? listings : []), [listings]);
+
+  const selected = useMemo(
+    () => charList.find(c => String(c.itemId) === String(selectedId)) || null,
+    [charList, selectedId]
+  );
+
+  const filtered = useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    if (!q) return charList;
+    return charList.filter(c => c.name?.toLowerCase().includes(q) || String(c.itemId).includes(q));
+  }, [charList, keyword]);
+
+  const loadListings = itemId => fetchListings({ params: { itemId } }).catch(() => {});
+
+  const handleSelect = itemId => {
+    setSelectedId(itemId);
+    setPickerOpen(false);
+    loadListings(itemId);
+  };
+
+  const handleConfirmBuy = async () => {
+    if (!pending) return;
+    try {
+      const { data } = await purchase({
+        url: `/api/public-market/listings/${pending.id}/purchase`,
+      });
+      setPending(null);
+      handleOpen(`已購買 ${data.name}，花費 ${fmtStone(data.price)} 女神石`, "success");
+      refetchSummary();
+      refetchChars();
+      if (selectedId != null) loadListings(selectedId);
+    } catch (err) {
+      setPending(null);
+      handleOpen(errorText(err, "購買失敗，請稍後再試"), "error");
+      refetchSummary();
+      if (selectedId != null) loadListings(selectedId);
+    }
+  };
+
+  if (!isLoggedIn) return <AlertLogin />;
+
+  const hasMine = rows.some(r => r.mine);
+  const balance = summary?.balance;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.75,
+        pb: "calc(env(safe-area-inset-bottom) + 32px)",
+      }}
+    >
+      <PageHeader balance={balance} loading={summaryLoading} />
+
+      <GradientPanel>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.75 }}>
+          公開掛單簿
+        </Typography>
+        <Box component="ul" sx={{ m: 0, pl: 2, fontSize: 12, lineHeight: 1.7, opacity: 0.92 }}>
+          <li>成交時抽取 5% 手續費，該部分女神石直接銷毀</li>
+          <li>每位玩家同一角色只能持有一張，已擁有的角色無法購買</li>
+        </Box>
+      </GradientPanel>
+
+      {charsError && (
+        <Alert severity="error" sx={{ borderRadius: 3 }}>
+          載入掛單簿失敗，請稍後再試
+        </Alert>
+      )}
+
+      {selected && !pickerOpen ? (
+        <Paper
+          elevation={0}
+          sx={{
+            p: 1.5,
+            borderRadius: 3,
+            border: "1px solid",
+            borderColor: "divider",
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+          }}
+        >
+          <CharAvatar
+            itemId={selected.itemId}
+            name={selected.name}
+            headImage={selected.headImage}
+          />
+          <Box sx={{ flex: "1 1 auto", minWidth: 0 }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+              <Typography sx={{ fontSize: 15, fontWeight: 600 }} noWrap>
+                {selected.name}
+              </Typography>
+              <BaseStar star={selected.star} />
+            </Box>
+            <Typography variant="caption" color="text.secondary" sx={{ ...NUMS }}>
+              {selected.itemId} ・ 目前 {rows.length} 張掛單
+            </Typography>
+          </Box>
+          <IconButton aria-label="更換角色" onClick={() => setPickerOpen(true)}>
+            <SwapHorizIcon />
+          </IconButton>
+        </Paper>
+      ) : (
+        <>
+          <Typography
+            variant="caption"
+            sx={{ fontWeight: 600, letterSpacing: ".06em", color: "text.secondary" }}
+          >
+            選擇角色
+          </Typography>
+          <TextField
+            type="search"
+            size="small"
+            fullWidth
+            value={keyword}
+            onChange={e => setKeyword(e.target.value)}
+            placeholder="搜尋角色名稱或編號，例如 宮子 / 100701"
+            aria-label="搜尋角色名稱或編號"
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+          {charsLoading && charList.length === 0 ? (
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              {[1, 2, 3, 4, 5, 6].map(i => (
+                <Skeleton key={i} variant="rounded" width={104} height={36} animation="wave" />
+              ))}
+            </Box>
+          ) : (
+            <Box
+              role="group"
+              aria-label="角色列表"
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 1,
+                maxHeight: 168,
+                overflowY: "auto",
+                p: 0.25,
+              }}
+            >
+              {filtered.map(c => (
+                <CharacterChip
+                  key={c.itemId}
+                  char={c}
+                  selected={String(c.itemId) === String(selectedId)}
+                  onClick={() => handleSelect(c.itemId)}
+                />
+              ))}
+            </Box>
+          )}
+          {!charsLoading && filtered.length === 0 && (
+            <Typography variant="body2" color="text.secondary" sx={{ px: 0.25, py: 0.75 }}>
+              找不到符合的角色。
+            </Typography>
+          )}
+        </>
+      )}
+
+      <Box sx={{ display: "flex", alignItems: "baseline", gap: 1 }}>
+        <Typography
+          variant="caption"
+          sx={{ fontWeight: 600, letterSpacing: ".06em", color: "text.secondary" }}
+        >
+          {selected ? `${selected.name} 的掛單` : "掛單"}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {selected ? (rows.length ? `${rows.length} 張 ・ 價格由低到高` : "0 張") : "價格由低到高"}
+        </Typography>
+      </Box>
+
+      {listingsError && (
+        <Alert severity="error" sx={{ borderRadius: 3 }}>
+          載入掛單失敗，請稍後再試
+        </Alert>
+      )}
+
+      {!selected && !listingsLoading && <Note>先從上面挑一個角色，就會看到目前的掛單。</Note>}
+
+      {listingsLoading ? (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} variant="rounded" height={88} animation="wave" />
+          ))}
+        </Box>
+      ) : selected && rows.length === 0 ? (
+        <EmptyBook onPickOther={() => setPickerOpen(true)} />
+      ) : (
+        rows.length > 0 && (
+          <Box
+            component="ul"
+            sx={{
+              listStyle: "none",
+              m: 0,
+              p: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: 1.25,
+            }}
+          >
+            {rows.map((listing, i) => (
+              <OrderCard key={listing.id} listing={listing} lowest={i === 0} onBuy={setPending} />
+            ))}
+          </Box>
+        )
+      )}
+
+      {selected && rows.length === 0 && (
+        <Note>掛單簿只顯示目前還沒成交的賣單，成交或撤單後會立刻從這裡消失。</Note>
+      )}
+      {hasMine && (
+        <Note>
+          你自己的掛單會一起顯示，方便對照別人的價格。要撤單請到
+          <Box
+            component={RouterLink}
+            to="/trade/my-listings"
+            sx={{ color: "primary.main", fontWeight: 600 }}
+          >
+            「我的掛單」
+          </Box>
+          。
+        </Note>
+      )}
+
+      <Button variant="outlined" onClick={() => navigate("/trade/sell")}>
+        我要掛賣單
+      </Button>
+
+      <Dialog open={Boolean(pending)} onClose={() => setPending(null)} fullWidth maxWidth="xs">
+        <DialogTitle sx={{ fontWeight: 600 }}>確認購買</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.7 }}>
+            購買後角色直接進入你的box，此操作無法取消。
+          </Typography>
+          {pending && (
+            <Box sx={{ mt: 1.5 }}>
+              <Row label="角色" value={`${pending.name}（${pending.itemId}）`} />
+              {Number(pending.star) >= 1 && (
+                <Row label="你會取得" value={`基礎 ${Number(pending.star)} 星`} />
+              )}
+              <Row label="賣家" value={displayName(pending.sellerName)} />
+              <Row label="售價" value={`${fmtStone(pending.price)} 女神石`} />
+              <Row
+                label="手續費（5%，銷毀）"
+                value={`${fmtStone(pending.fee ?? calcFee(pending.price))} 女神石`}
+              />
+              <Row
+                label="你的餘額"
+                value={`${fmtStone(balance)} → ${fmtStone((balance ?? 0) - pending.price)} 女神石`}
+              />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button color="inherit" onClick={() => setPending(null)} disabled={buying}>
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleConfirmBuy} disabled={buying} autoFocus>
+            確認購買
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <HintSnackBar open={snackOpen} message={message} severity={severity} onClose={handleClose} />
+    </Box>
+  );
+}

--- a/frontend/src/pages/Trade/MarketListing.jsx
+++ b/frontend/src/pages/Trade/MarketListing.jsx
@@ -1,0 +1,650 @@
+import { useEffect, useMemo, useState } from "react";
+import useAxios from "axios-hooks";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Paper,
+  Skeleton,
+  Typography,
+} from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import AlertLogin from "../../components/AlertLogin";
+import HintSnackBar from "../../components/HintSnackBar";
+import useHintBar from "../../hooks/useHintBar";
+import useLiff from "../../context/useLiff";
+import { NUMS, calcFee, calcNet, displayName, errorInfo, fmtShortDate, fmtStone } from "./_market";
+import {
+  CharAvatar,
+  BaseStarBadge,
+  GradientPanel,
+  Row,
+  SectionTitle,
+  StatusChip,
+  Tag,
+} from "./_marketUi";
+
+/* ---------------------------------------------------------------- 零件 */
+function PageSkeleton() {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Skeleton variant="rounded" height={140} animation="wave" />
+      <Skeleton variant="rounded" height={180} animation="wave" />
+      <Skeleton variant="rounded" height={120} animation="wave" />
+      <Skeleton variant="rounded" height={48} animation="wave" />
+    </Box>
+  );
+}
+
+function Card({ children, sx }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{ p: 1.75, borderRadius: 3, border: "1px solid", borderColor: "divider", ...sx }}
+    >
+      {children}
+    </Paper>
+  );
+}
+
+function AppHeader({ listing, orderNo, onRefresh, refreshing }) {
+  const navigate = useNavigate();
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 0.5 }}>
+      <IconButton aria-label="返回列表" size="small" onClick={() => navigate("/trade/market")}>
+        <ArrowBackIosNewIcon fontSize="small" />
+      </IconButton>
+      <Box>
+        <Typography sx={{ fontSize: 15.5, fontWeight: 700, lineHeight: 1.2 }}>委託詳情</Typography>
+        <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
+          {orderNo}
+          {listing?.viewer?.isSeller ? " · 我的掛單" : ""}
+        </Typography>
+      </Box>
+      <Box sx={{ flex: "1 1 auto" }} />
+      <IconButton aria-label="重新整理" size="small" onClick={onRefresh} disabled={refreshing}>
+        <RefreshIcon fontSize="small" />
+      </IconButton>
+    </Box>
+  );
+}
+
+/** 開放中用漸層 banner；終態 / 失效用平的卡片，跟設計稿一致。 */
+function HeroBanner({ listing, kicker }) {
+  return (
+    <GradientPanel>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <CharAvatar
+          itemId={listing.itemId}
+          name={listing.name}
+          headImage={listing.headImage}
+          size={62}
+        />
+        <Box>
+          <Typography sx={{ fontSize: 11, letterSpacing: "1.4px", opacity: 0.82 }}>
+            {kicker}
+          </Typography>
+          <Typography sx={{ fontSize: 21, fontWeight: 700, lineHeight: 1.2, mt: "2px" }}>
+            {listing.name}
+          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.875, mt: "3px" }}>
+            <Typography sx={{ fontSize: 11.5, opacity: 0.82, ...NUMS }}>
+              ID {listing.itemId}
+            </Typography>
+            <BaseStarBadge star={listing.star} onGradient />
+          </Box>
+        </Box>
+      </Box>
+      <Box sx={{ mt: 1.75, display: "flex", alignItems: "baseline", gap: 0.875 }}>
+        <Box component="b" sx={{ fontSize: 30, fontWeight: 700, letterSpacing: "-.5px", ...NUMS }}>
+          {fmtStone(listing.price)}
+        </Box>
+        <Box component="span" sx={{ fontSize: 13, opacity: 0.9 }}>
+          女神石
+        </Box>
+      </Box>
+    </GradientPanel>
+  );
+}
+
+function HeroFlat({ listing, status, dimmed }) {
+  return (
+    <Card sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
+      <CharAvatar
+        itemId={listing.itemId}
+        name={listing.name}
+        headImage={listing.headImage}
+        size={62}
+        dimmed={dimmed}
+      />
+      <Box sx={{ minWidth: 0 }}>
+        <Typography sx={{ fontSize: 19, fontWeight: 700 }} noWrap>
+          {listing.name}
+        </Typography>
+        <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
+          ID {listing.itemId}
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.875 }}>
+          <StatusChip status={status} />
+          <BaseStarBadge star={listing.star} />
+        </Box>
+      </Box>
+    </Card>
+  );
+}
+
+function WalletStrip({ balance, short }) {
+  return (
+    <Card
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.25,
+        px: 1.5,
+        py: 1.25,
+        fontSize: 13,
+      }}
+    >
+      <Box
+        aria-hidden="true"
+        sx={{
+          width: 24,
+          height: 24,
+          borderRadius: "6px",
+          display: "grid",
+          placeItems: "center",
+          fontSize: 12,
+          fontWeight: 700,
+          color: "#fff",
+          background: "linear-gradient(140deg, #FBBF24, #F59E0B)",
+        }}
+      >
+        石
+      </Box>
+      <Typography component="span" sx={{ fontSize: 13 }}>
+        你的女神石餘額
+      </Typography>
+      <Typography
+        component="span"
+        sx={{ ml: "auto", fontWeight: 700, color: short ? "error.main" : "text.primary", ...NUMS }}
+      >
+        {fmtStone(balance)}
+      </Typography>
+    </Card>
+  );
+}
+
+function BtnNote({ children }) {
+  return (
+    <Typography
+      sx={{ fontSize: 11.5, color: "text.secondary", textAlign: "center", lineHeight: 1.5 }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+/* ---------------------------------------------------------------- 主頁面 */
+export default function MarketListing() {
+  const { loggedIn: isLoggedIn, profile } = useLiff();
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const viewerId = profile?.userId;
+
+  // 購買失敗回來的終態：把畫面原地降級成 B1 / B4，不重新導頁。
+  const [deadCode, setDeadCode] = useState(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const [{ data: listing, loading, error }, refetch] = useAxios(
+    `/api/public-market/listings/${id}`,
+    { manual: true }
+  );
+  const [{ loading: buying }, purchase] = useAxios(
+    { url: `/api/public-market/listings/${id}/purchase`, method: "POST" },
+    { manual: true }
+  );
+  const [{ loading: cancelling }, cancelListing] = useAxios(
+    { url: `/api/public-market/listings/${id}`, method: "DELETE" },
+    { manual: true }
+  );
+  const [{ message, severity, open: snackOpen }, { handleOpen, handleClose }] = useHintBar();
+
+  useEffect(() => {
+    document.title = "委託詳情";
+  }, []);
+
+  useEffect(() => {
+    if (isLoggedIn) refetch().catch(() => {});
+  }, [isLoggedIn, refetch]);
+
+  const orderNo = useMemo(() => `#EX-${id}`, [id]);
+
+  const handleBuy = async () => {
+    setConfirmOpen(false);
+    try {
+      const { data } = await purchase();
+      handleOpen(`已購買 ${data.name}，花費 ${fmtStone(data.price)} 女神石`, "success");
+      refetch().catch(() => {});
+    } catch (err) {
+      const { code, title, detail, data } = errorInfo(err, "購買失敗，請稍後再試");
+      if (code === "ALREADY_TAKEN" || code === "SELLER_LOST_ITEM") {
+        // 原地降級：畫面直接改為失效狀態，並跳提示。
+        setDeadCode(code);
+      }
+      if (code === "INSUFFICIENT_FUNDS" && data) {
+        handleOpen(
+          `${title}｜餘額 ${fmtStone(data.balance)} / 需要 ${fmtStone(data.price)} / 還差 ${fmtStone(data.shortfall)}`,
+          "error"
+        );
+      } else {
+        handleOpen(detail ? `${title}，${detail}` : title, "error");
+      }
+      refetch().catch(() => {});
+    }
+  };
+
+  const handleCancel = async () => {
+    try {
+      await cancelListing();
+      handleOpen("已取消掛單", "success");
+      refetch().catch(() => {});
+    } catch (err) {
+      const { title, detail } = errorInfo(err, "取消失敗，請稍後再試");
+      handleOpen(detail ? `${title}，${detail}` : title, "error");
+    }
+  };
+
+  if (!isLoggedIn) return <AlertLogin />;
+  if (loading && !listing) return <PageSkeleton />;
+
+  if (error && !listing) {
+    const status = error.response?.status;
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <Alert severity="error" sx={{ borderRadius: 3 }}>
+          {status === 404 ? "找不到這筆委託" : "載入委託失敗，請稍後再試"}
+        </Alert>
+        <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+          回列表
+        </Button>
+      </Box>
+    );
+  }
+
+  if (!listing) return <PageSkeleton />;
+
+  const viewer = listing.viewer || {};
+  const fee = listing.fee ?? calcFee(listing.price);
+  const net = listing.netProceeds ?? calcNet(listing.price);
+  const balance = viewer.balance ?? 0;
+  const shortfall = Math.max(0, listing.price - balance);
+
+  // 顯示狀態：本地失效碼優先，再看後端 status。
+  const dead = Boolean(deadCode) || listing.status === "invalid";
+  const shownStatus = deadCode ? "invalid" : listing.status;
+
+  const wrap = children => (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
+        pb: "calc(env(safe-area-inset-bottom) + 32px)",
+      }}
+    >
+      <AppHeader
+        listing={listing}
+        orderNo={orderNo}
+        onRefresh={() => {
+          setDeadCode(null);
+          refetch().catch(() => {});
+        }}
+        refreshing={loading}
+      />
+      {children}
+      <HintSnackBar open={snackOpen} message={message} severity={severity} onClose={handleClose} />
+    </Box>
+  );
+
+  /* ---- B1：搶單失敗（已被買走） / B4：賣家已無此角色 ------------------ */
+  if (dead) {
+    const isLostItem = deadCode === "SELLER_LOST_ITEM" || listing.status === "invalid";
+    return wrap(
+      <>
+        <HeroFlat listing={listing} status="invalid" dimmed />
+
+        <Alert severity="error" role="status" sx={{ borderRadius: 3 }}>
+          <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+            {isLostItem ? "賣家已無此角色，委託已失效" : "此委託已被其他玩家買走或取消"}
+          </AlertTitle>
+          <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+            {isLostItem ? "系統已自動下架這筆委託，沒有任何女神石異動。" : "你的女神石沒有被扣款。"}
+          </Typography>
+        </Alert>
+
+        <Card>
+          <Row label="掛單價" value={`${fmtStone(listing.price)} 女神石`} strike />
+          <Row label="賣家" value={displayName(listing.sellerName)} />
+          {isLostItem && <Row label="失效時間" value={fmtShortDate(listing.closedAt)} />}
+          <Row label="你的餘額" value={`${fmtStone(balance)}（未變動）`} />
+        </Card>
+
+        {isLostItem ? (
+          <>
+            <Button variant="contained" disabled>
+              委託已失效
+            </Button>
+            <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+              回列表
+            </Button>
+            <Typography sx={{ fontSize: 11.5, color: "text.secondary", lineHeight: 1.6, mx: 0.25 }}>
+              若你認為這是異常，請在群組輸入「客服」回報單號 {orderNo}。
+            </Typography>
+          </>
+        ) : (
+          <>
+            <Button variant="contained" disabled>
+              立即購買
+            </Button>
+            <BtnNote>此委託已不可購買</BtnNote>
+            <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+              看其他{listing.name}的掛單
+            </Button>
+          </>
+        )}
+      </>
+    );
+  }
+
+  /* ---- A3：已成交（終態） --------------------------------------------- */
+  if (shownStatus === "sold") {
+    return wrap(
+      <>
+        <HeroFlat listing={listing} status="sold" />
+
+        <Card>
+          <Row label="成交價" value={`${fmtStone(listing.price)} 女神石`} />
+          <Row label="手續費 5%（已銷毀）" value={fmtStone(fee)} valueColor="text.secondary" />
+          <Row label="賣家實收" value={fmtStone(net)} />
+        </Card>
+
+        <Card>
+          <Row label="賣家" value={displayName(listing.sellerName)} />
+          <Row
+            label="買家"
+            value={
+              viewerId != null && listing.buyerId === viewerId
+                ? "你"
+                : displayName(listing.buyerName)
+            }
+          />
+          <Row label="成交時間" value={fmtShortDate(listing.soldAt)} />
+        </Card>
+
+        <Alert severity="info" icon={false} sx={{ borderRadius: 3 }}>
+          角色已入庫，星數為初始值。這筆委託已結束，沒有可用的操作。
+        </Alert>
+        <BtnNote>紀錄保留 90 天</BtnNote>
+      </>
+    );
+  }
+
+  /* ---- A3b：已取消（終態） -------------------------------------------- */
+  if (shownStatus === "cancelled") {
+    return wrap(
+      <>
+        <HeroFlat listing={listing} status="cancelled" dimmed />
+
+        <Card>
+          <Row label="原掛單價" value={`${fmtStone(listing.price)} 女神石`} strike />
+          <Row label="賣家" value={displayName(listing.sellerName)} />
+          <Row label="掛單時間" value={fmtShortDate(listing.createdAt)} />
+          <Row label="取消時間" value={fmtShortDate(listing.closedAt)} />
+          <Row label="取消原因" value="賣家自行取消" />
+        </Card>
+
+        <Alert severity="info" icon={false} sx={{ borderRadius: 3 }}>
+          這筆委託已取消，無法購買。可以回列表看看其他{listing.name}的掛單。
+        </Alert>
+        <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+          回列表找其他{listing.name}
+        </Button>
+      </>
+    );
+  }
+
+  /* ---- A2：自己的掛單 -------------------------------------------------- */
+  if (viewer.isSeller || viewer.blockReason === "IS_SELLER") {
+    return wrap(
+      <>
+        <HeroBanner listing={listing} kicker="我的賣出委託" />
+
+        <Card>
+          <Row
+            label="狀態"
+            value={
+              <Box component="span" sx={{ display: "inline-flex", gap: 0.75 }}>
+                <StatusChip status="open" />
+                <Box component="span" sx={{ display: "inline-flex", alignItems: "center" }}>
+                  <Tag label="我的" />
+                </Box>
+              </Box>
+            }
+          />
+          <Row label="掛單時間" value={fmtShortDate(listing.createdAt)} />
+          <Row label="角色狀態" value="掛單鎖定中" />
+          {Number(listing.star) >= 1 && (
+            <Row label="買家會取得" value={`基礎 ${Number(listing.star)} 星`} />
+          )}
+        </Card>
+
+        <SectionTitle>成交後結算</SectionTitle>
+        <Card>
+          <Row label="售價" value={fmtStone(listing.price)} />
+          <Row label="手續費 5%（銷毀）" value={fmtStone(fee)} valueColor="text.secondary" />
+          <Row label="你可得" value={fmtStone(net)} />
+        </Card>
+
+        <Alert severity="info" sx={{ borderRadius: 3 }}>
+          取消後角色立即解除鎖定，不收手續費。升星強化留在你手上。
+        </Alert>
+
+        <Button variant="outlined" color="error" onClick={handleCancel} disabled={cancelling}>
+          取消掛單
+        </Button>
+      </>
+    );
+  }
+
+  /* ---- B3：已擁有該角色 ------------------------------------------------ */
+  if (viewer.blockReason === "ALREADY_OWNED" || viewer.ownsCharacter) {
+    return wrap(
+      <>
+        <HeroBanner listing={listing} kicker="賣出委託" />
+
+        <Alert severity="warning" role="status" sx={{ borderRadius: 3 }}>
+          <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+            你已擁有此角色，無法購買
+          </AlertTitle>
+          <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+            角色為一人一隻，重複持有不會生效。
+          </Typography>
+        </Alert>
+
+        <Card>
+          <Row label="狀態" value={<StatusChip status="open" />} />
+          <Row label="賣家" value={displayName(listing.sellerName)} />
+          <Row
+            label="你的持有狀態"
+            value={
+              <Box
+                component="span"
+                sx={{ display: "inline-flex", alignItems: "center", gap: 0.75 }}
+              >
+                <CharAvatar
+                  itemId={listing.itemId}
+                  name={listing.name}
+                  headImage={listing.headImage}
+                  size={28}
+                />
+                已持有
+              </Box>
+            }
+          />
+        </Card>
+
+        <Button variant="contained" disabled>
+          你已擁有{listing.name}
+        </Button>
+        <BtnNote>若要出售自己的{listing.name}，請到「我的掛單」新增委託</BtnNote>
+        <Button variant="outlined" onClick={() => navigate("/trade/sell")}>
+          改為掛售我的{listing.name}
+        </Button>
+      </>
+    );
+  }
+
+  /* ---- B2：女神石不足 -------------------------------------------------- */
+  if (viewer.blockReason === "INSUFFICIENT_FUNDS") {
+    return wrap(
+      <>
+        <HeroBanner listing={listing} kicker="賣出委託" />
+        <WalletStrip balance={balance} short />
+
+        <Alert severity="error" role="status" sx={{ borderRadius: 3 }}>
+          <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+            女神石不足，無法購買
+          </AlertTitle>
+          <Typography sx={{ fontSize: 12.8, lineHeight: 1.6, ...NUMS }}>
+            餘額 {fmtStone(balance)} · 需要 {fmtStone(listing.price)} · 還差{" "}
+            <strong>{fmtStone(shortfall)}</strong>。
+          </Typography>
+        </Alert>
+
+        <Card sx={{ boxShadow: "none" }}>
+          <Row label="售價" value={fmtStone(listing.price)} />
+          <Row label="你的餘額" value={fmtStone(balance)} valueColor="error.main" />
+          <Row label="差額" value={fmtStone(shortfall)} valueColor="error.main" />
+        </Card>
+
+        <Button variant="contained" disabled>
+          女神石不足
+        </Button>
+        <BtnNote>還差 {fmtStone(shortfall)} 女神石</BtnNote>
+        <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+          看預算內的{listing.name}（≤ {fmtStone(balance)}）
+        </Button>
+      </>
+    );
+  }
+
+  /* ---- A1：買家視角，可購買 -------------------------------------------- */
+  const blocked = viewer.canBuy === false;
+  return wrap(
+    <>
+      <HeroBanner listing={listing} kicker="賣出委託" />
+
+      <Card>
+        <Row label="狀態" value={<StatusChip status="open" />} />
+        <Row
+          label="賣家"
+          value={
+            <Box component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.875 }}>
+              <CharAvatar
+                itemId={listing.sellerId}
+                name={displayName(listing.sellerName)}
+                size={28}
+              />
+              {displayName(listing.sellerName)}
+            </Box>
+          }
+        />
+        <Row label="掛單時間" value={fmtShortDate(listing.createdAt)} />
+        <Row label="你的持有狀態" value="未持有" />
+      </Card>
+
+      <WalletStrip balance={balance} />
+
+      <Alert severity="warning" sx={{ borderRadius: 3 }}>
+        <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+          成交後你拿到的是初始星數
+        </AlertTitle>
+        <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+          賣家的升星強化不會轉移，升星所花的女神石會直接消失。
+        </Typography>
+        {Number(listing.star) >= 1 && (
+          <Typography sx={{ fontSize: 12.8, lineHeight: 1.6, fontWeight: 700, mt: 0.5 }}>
+            這筆你會拿到 {listing.name} 基礎 {Number(listing.star)} 星。
+          </Typography>
+        )}
+      </Alert>
+
+      <SectionTitle>費用</SectionTitle>
+      <Card sx={{ boxShadow: "none" }}>
+        <Row label="你支付" value={`${fmtStone(listing.price)} 女神石`} />
+        <Row label="手續費 5%（銷毀）" value={fmtStone(fee)} valueColor="text.secondary" />
+        <Row label="賣家實收" value={fmtStone(net)} />
+      </Card>
+
+      <Button
+        variant="contained"
+        onClick={() => setConfirmOpen(true)}
+        disabled={blocked || buying}
+        sx={{ py: 1.5 }}
+      >
+        立即購買
+      </Button>
+      <BtnNote>交易成立後不可退回，請確認角色與價格。</BtnNote>
+
+      <Dialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        fullWidth
+        maxWidth="xs"
+        aria-labelledby="buy-confirm-title"
+      >
+        <DialogTitle id="buy-confirm-title" sx={{ fontWeight: 700 }}>
+          確認購買{listing.name}？
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ mb: 1.5 }}>
+            {Number(listing.star) >= 1 && (
+              <Row label="你會取得" value={`基礎 ${Number(listing.star)} 星`} />
+            )}
+            <Row label="售價" value={`${fmtStone(listing.price)} 女神石`} />
+            <Row label="應付總額" value={`${fmtStone(listing.price)} 女神石`} />
+            <Row label="目前餘額" value={fmtStone(balance)} />
+            <Row label="交易後餘額" value={fmtStone(balance - listing.price)} />
+          </Box>
+          <Alert severity="warning" sx={{ borderRadius: 3 }}>
+            <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+              你收到的是角色初始星數
+            </AlertTitle>
+            <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+              賣家的升星強化不會轉移。
+            </Typography>
+          </Alert>
+          <Typography sx={{ mt: 1.5, fontSize: 11.5, color: "text.secondary", lineHeight: 1.6 }}>
+            手續費 {fmtStone(fee)} 女神石（5%）於成交時銷毀，賣家實收 {fmtStone(net)}。
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button color="inherit" onClick={() => setConfirmOpen(false)} disabled={buying}>
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleBuy} disabled={buying} autoFocus>
+            確認購買
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/pages/Trade/MyListings.jsx
+++ b/frontend/src/pages/Trade/MyListings.jsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo } from "react";
+import useAxios from "axios-hooks";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
+import { Alert, Box, Button, IconButton, Paper, Skeleton, Typography } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import AddIcon from "@mui/icons-material/Add";
+import AlertLogin from "../../components/AlertLogin";
+import useLiff from "../../context/useLiff";
+import { STATUS } from "./_shared";
+import { NUMS, calcNet, fmtShortDate, fmtShortDay, fmtStone } from "./_market";
+import { CharAvatar, BaseStar, SectionTitle, StatusChip } from "./_marketUi";
+
+/* ---------------------------------------------------------------- 一列委託 */
+function ListingItem({ listing, meta, strike }) {
+  return (
+    <Paper
+      component={RouterLink}
+      to={`/trade/listings/${listing.id}`}
+      elevation={0}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.375,
+        p: 1.5,
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        textDecoration: "none",
+        color: "inherit",
+      }}
+    >
+      <CharAvatar itemId={listing.itemId} name={listing.name} headImage={listing.headImage} />
+      <Box sx={{ minWidth: 0, flex: "1 1 auto" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          <Typography sx={{ fontSize: 14, fontWeight: 600 }} noWrap>
+            {listing.name}
+          </Typography>
+          <BaseStar star={listing.star} />
+        </Box>
+        <Typography sx={{ fontSize: 11.5, color: "text.secondary", mt: "2px", ...NUMS }} noWrap>
+          {meta}
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          textAlign: "right",
+          flex: "0 0 auto",
+          display: "grid",
+          gap: 0.625,
+          justifyItems: "end",
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: 14,
+            fontWeight: 700,
+            textDecoration: strike ? "line-through" : "none",
+            opacity: strike ? 0.6 : 1,
+            ...NUMS,
+          }}
+        >
+          {fmtStone(listing.price)}
+        </Typography>
+        <StatusChip status={listing.status} />
+      </Box>
+    </Paper>
+  );
+}
+
+/* ---------------------------------------------------------------- 舊紀錄 */
+function LegacyBlock({ trades, loading, error }) {
+  return (
+    <Box
+      sx={theme => ({
+        mt: 1.25,
+        p: 1.5,
+        borderRadius: 3,
+        border: "1px dashed",
+        borderColor: "divider",
+        bgcolor: alpha(theme.palette.text.primary, 0.04),
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.125,
+      })}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Typography component="h3" sx={{ fontSize: 13, fontWeight: 700, color: "text.secondary" }}>
+          舊私人交易紀錄
+        </Typography>
+        <Box
+          component="span"
+          sx={{
+            fontSize: 12,
+            fontWeight: 600,
+            px: 1.25,
+            py: 0.25,
+            borderRadius: 999,
+            border: "1px solid",
+            borderColor: "divider",
+            color: "text.secondary",
+          }}
+        >
+          唯讀
+        </Box>
+      </Box>
+      <Typography sx={{ fontSize: 11.5, color: "text.secondary", lineHeight: 1.6 }}>
+        舊的一對一私下交易已停用，這裡只保留過往紀錄，不能再新增或操作。
+      </Typography>
+
+      {error && (
+        <Alert severity="warning" sx={{ borderRadius: 3 }}>
+          載入舊紀錄失敗，請稍後再試
+        </Alert>
+      )}
+
+      {loading && !trades ? (
+        [1, 2, 3].map(i => <Skeleton key={i} variant="rounded" height={56} animation="wave" />)
+      ) : trades?.length ? (
+        trades.map(t => (
+          <Box
+            key={t.id}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.375,
+              p: 1.375,
+              borderRadius: 3,
+              border: "1px dashed",
+              borderColor: "divider",
+              opacity: 0.72,
+            }}
+          >
+            <CharAvatar itemId={t.item_id} name={t.name || ""} headImage={t.image} size={34} />
+            <Box sx={{ minWidth: 0, flex: "1 1 auto" }}>
+              <Typography sx={{ fontSize: 14, fontWeight: 500 }} noWrap>
+                {t.name || `商品 #${t.item_id}`}
+              </Typography>
+              <Typography
+                sx={{ fontSize: 11.5, color: "text.secondary", mt: "2px", ...NUMS }}
+                noWrap
+              >
+                {t.item_id} · {fmtShortDay(t.created_at)} ·{" "}
+                {t.status === STATUS.COMPLETED
+                  ? "已交易"
+                  : t.status === STATUS.CANCELLED
+                    ? "已取消"
+                    : "未交易"}
+              </Typography>
+            </Box>
+            <Typography sx={{ fontSize: 14, fontWeight: 700, color: "text.secondary", ...NUMS }}>
+              {fmtStone(t.price)}
+            </Typography>
+          </Box>
+        ))
+      ) : (
+        <Typography sx={{ fontSize: 11.5, color: "text.secondary" }}>沒有舊的交易紀錄。</Typography>
+      )}
+
+      {trades?.length > 0 && (
+        <Typography sx={{ fontSize: 11.5, color: "text.secondary" }}>
+          共 {trades.length} 筆
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+/* ---------------------------------------------------------------- 主頁面 */
+export default function MyListings() {
+  const { loggedIn: isLoggedIn, profile } = useLiff();
+  const navigate = useNavigate();
+  const viewerId = profile?.userId;
+
+  const [{ data: summary }, refetchSummary] = useAxios("/api/public-market/summary", {
+    manual: true,
+  });
+  const [{ data: mine, loading, error }, refetchMine] = useAxios("/api/public-market/my-listings", {
+    manual: true,
+  });
+  const [{ data: legacy, loading: legacyLoading, error: legacyError }, fetchLegacy] = useAxios(
+    { url: "/api/trades", params: { page: 1, per_page: 20 } },
+    { manual: true }
+  );
+
+  useEffect(() => {
+    document.title = "我的掛單 / 紀錄";
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    refetchSummary().catch(() => {});
+    refetchMine().catch(() => {});
+    fetchLegacy().catch(() => {});
+  }, [isLoggedIn, refetchSummary, refetchMine, fetchLegacy]);
+
+  const open = useMemo(() => (Array.isArray(mine?.open) ? mine.open : []), [mine]);
+  const closed = useMemo(() => (Array.isArray(mine?.closed) ? mine.closed : []), [mine]);
+
+  if (!isLoggedIn) return <AlertLogin />;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
+        pb: "calc(env(safe-area-inset-bottom) + 32px)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
+        <Box>
+          <Typography sx={{ fontSize: 15.5, fontWeight: 700, lineHeight: 1.2 }}>
+            我的掛單 / 紀錄
+          </Typography>
+          <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
+            女神石餘額 {fmtStone(summary?.balance)}
+          </Typography>
+        </Box>
+        <Box sx={{ flex: "1 1 auto" }} />
+        <IconButton aria-label="新增賣出委託" onClick={() => navigate("/trade/sell")}>
+          <AddIcon />
+        </IconButton>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ borderRadius: 3 }}>
+          載入我的掛單失敗，請稍後再試
+        </Alert>
+      )}
+
+      <SectionTitle>開放中 · {open.length}</SectionTitle>
+      {loading && !mine ? (
+        [1, 2].map(i => <Skeleton key={i} variant="rounded" height={72} animation="wave" />)
+      ) : open.length === 0 ? (
+        <Paper
+          elevation={0}
+          sx={{
+            p: 3,
+            borderRadius: 3,
+            border: "1px solid",
+            borderColor: "divider",
+            textAlign: "center",
+          }}
+        >
+          <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
+            目前沒有開放中的委託。
+          </Typography>
+          <Button variant="outlined" sx={{ mt: 1.5 }} onClick={() => navigate("/trade/sell")}>
+            我要掛賣單
+          </Button>
+        </Paper>
+      ) : (
+        open.map(l => (
+          <ListingItem
+            key={l.id}
+            listing={l}
+            meta={`${l.itemId} · ${fmtShortDate(l.createdAt)} · 可得 ${fmtStone(l.netProceeds ?? calcNet(l.price))}`}
+          />
+        ))
+      )}
+
+      <SectionTitle>已結束 · {closed.length}</SectionTitle>
+      {loading && !mine ? (
+        [1, 2].map(i => <Skeleton key={i} variant="rounded" height={72} animation="wave" />)
+      ) : closed.length === 0 ? (
+        <Typography sx={{ fontSize: 12, color: "text.secondary", mx: 0.25 }}>
+          還沒有結束的委託。
+        </Typography>
+      ) : (
+        closed.map(l => {
+          const sold = l.status === "sold";
+          // 後端已標好 role；沒帶到時退回比對 sellerId。
+          const bought = sold && (l.role ? l.role === "buyer" : l.sellerId !== viewerId);
+          const meta = sold
+            ? bought
+              ? `${l.itemId} · ${fmtShortDate(l.soldAt)} · 買入`
+              : `${l.itemId} · ${fmtShortDate(l.soldAt)} · 賣出，實收 ${fmtStone(l.netProceeds ?? calcNet(l.price))}`
+            : `${l.itemId} · ${fmtShortDate(l.closedAt)} · ${l.status === "invalid" ? "逾期自動下架" : "自行取消"}`;
+          return <ListingItem key={l.id} listing={l} meta={meta} strike={!sold} />;
+        })
+      )}
+
+      <LegacyBlock trades={legacy} loading={legacyLoading} error={legacyError} />
+    </Box>
+  );
+}

--- a/frontend/src/pages/Trade/Order.jsx
+++ b/frontend/src/pages/Trade/Order.jsx
@@ -206,12 +206,15 @@ export default function TradeOrder() {
           value={charge}
           onChange={e => setCharge(e.target.value.replace(/[^0-9]/g, ""))}
           disabled={isSelf}
-          inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
-          InputProps={{
-            startAdornment: <DiamondIcon sx={{ mr: 1, color: "text.secondary" }} />,
-          }}
           placeholder="輸入要求金額"
           sx={{ mt: 1 }}
+          slotProps={{
+            input: {
+              startAdornment: <DiamondIcon sx={{ mr: 1, color: "text.secondary" }} />,
+            },
+
+            htmlInput: { inputMode: "numeric", pattern: "[0-9]*" },
+          }}
         />
         <Box sx={{ display: "flex", gap: 1, mt: 1.5, flexWrap: "wrap" }}>
           {QUICK_PRICES.map(p => (

--- a/frontend/src/pages/Trade/Sell.jsx
+++ b/frontend/src/pages/Trade/Sell.jsx
@@ -1,0 +1,514 @@
+import { useEffect, useMemo, useState } from "react";
+import useAxios from "axios-hooks";
+import { useNavigate } from "react-router-dom";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Skeleton,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
+import AlertLogin from "../../components/AlertLogin";
+import HintSnackBar from "../../components/HintSnackBar";
+import useHintBar from "../../hooks/useHintBar";
+import useLiff from "../../context/useLiff";
+import CharacterPickerDrawer from "./CharacterPickerDrawer";
+import { QUICK_PRICES } from "./_shared";
+import {
+  MAX_OPEN_FALLBACK,
+  NUMS,
+  PRICE_MAX,
+  PRICE_MIN,
+  calcFee,
+  calcNet,
+  errorInfo,
+  fmtStone,
+} from "./_market";
+import { CharAvatar, GradientPanel } from "./_marketUi";
+
+/* ---------------------------------------------------------------- banner */
+function SummaryBanner({ balance, openCount, maxOpen, capped, loading }) {
+  return (
+    <GradientPanel>
+      <Box sx={{ display: "flex", alignItems: "flex-end", gap: 1.5 }}>
+        <Box>
+          <Typography sx={{ fontSize: 11.5, opacity: 0.88, letterSpacing: ".4px" }}>
+            持有女神石
+          </Typography>
+          <Typography sx={{ fontSize: 22, fontWeight: 700, lineHeight: 1.15, ...NUMS }}>
+            {loading ? "—" : fmtStone(balance)}
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            width: "1px",
+            alignSelf: "stretch",
+            bgcolor: "rgba(255,255,255,.28)",
+            my: 0.25,
+            mx: 0.5,
+          }}
+        />
+        <Box>
+          <Typography sx={{ fontSize: 11.5, opacity: 0.88, letterSpacing: ".4px" }}>
+            目前上架
+          </Typography>
+          <Typography sx={{ fontSize: 22, fontWeight: 700, lineHeight: 1.15, ...NUMS }}>
+            {loading ? "—" : openCount}{" "}
+            <Box component="small" sx={{ fontSize: 12, fontWeight: 600, opacity: 0.9 }}>
+              / {maxOpen} 筆
+            </Box>
+          </Typography>
+        </Box>
+        {capped && (
+          <Box
+            sx={{
+              ml: "auto",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.625,
+              px: 1.25,
+              py: 0.375,
+              borderRadius: 999,
+              bgcolor: "rgba(255,255,255,.20)",
+              border: "1px solid rgba(255,255,255,.30)",
+              fontSize: 11.5,
+              fontWeight: 700,
+            }}
+          >
+            <Box component="span" aria-hidden="true">
+              ●
+            </Box>
+            已滿
+          </Box>
+        )}
+      </Box>
+    </GradientPanel>
+  );
+}
+
+function Label({ children }) {
+  return (
+    <Typography
+      sx={{
+        fontSize: 11.5,
+        fontWeight: 700,
+        letterSpacing: ".6px",
+        color: "text.secondary",
+        mx: 0.25,
+        mt: 2,
+        mb: 0.875,
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+/* ---------------------------------------------------------------- 費用明細 */
+function FeeBreakdown({ price, feeLabel = "手續費（5%）", netLabel = "實收", showBurnNote }) {
+  const fee = calcFee(price);
+  const net = calcNet(price);
+  const line = (label, value, sx) => (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "baseline",
+        justifyContent: "space-between",
+        py: 0.75,
+        ...sx,
+      }}
+    >
+      <Typography component="span" sx={{ fontSize: 13, color: "text.secondary" }}>
+        {label}
+      </Typography>
+      {value}
+    </Box>
+  );
+
+  return (
+    <Box aria-live="polite">
+      {line(
+        "售價",
+        <Box component="b" sx={{ fontSize: 15, fontWeight: 600, ...NUMS }}>
+          {fmtStone(price)}
+        </Box>
+      )}
+      {line(
+        feeLabel,
+        <Box component="b" sx={{ fontSize: 15, fontWeight: 600, color: "error.main", ...NUMS }}>
+          −{fmtStone(fee)}
+        </Box>
+      )}
+      <Divider sx={{ my: 1 }} />
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          py: 0.75,
+        }}
+      >
+        <Typography component="span" sx={{ fontSize: 13.5, fontWeight: 600 }}>
+          {netLabel}
+        </Typography>
+        <Box component="b" sx={{ fontSize: 22, fontWeight: 600, color: "primary.main", ...NUMS }}>
+          {fmtStone(net)}
+        </Box>
+      </Box>
+      {showBurnNote && (
+        <Typography
+          sx={{
+            mt: 1.25,
+            pt: 1.25,
+            borderTop: "1px dashed",
+            borderColor: "divider",
+            fontSize: 11.5,
+            color: "text.secondary",
+            lineHeight: 1.65,
+          }}
+        >
+          手續費的女神石會直接銷毀，不會進到任何人的口袋。
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+/* ---------------------------------------------------------------- 主頁面 */
+export default function Sell() {
+  const { loggedIn: isLoggedIn } = useLiff();
+  const navigate = useNavigate();
+
+  const [selectedId, setSelectedId] = useState(null);
+  const [price, setPrice] = useState("1000");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const [{ data: summary, loading: summaryLoading, error: summaryError }, refetchSummary] =
+    useAxios("/api/public-market/summary", { manual: true });
+  const [{ data: inventoryItems = [], loading: invLoading }, fetchItems] = useAxios(
+    "/api/inventory",
+    { manual: true }
+  );
+  const [{ loading: creating }, createListing] = useAxios(
+    { url: "/api/public-market/listings", method: "POST" },
+    { manual: true }
+  );
+  const [{ message, severity, open: snackOpen }, { handleOpen, handleClose }] = useHintBar();
+
+  useEffect(() => {
+    document.title = "掛賣單";
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    refetchSummary();
+    fetchItems();
+  }, [isLoggedIn, refetchSummary, fetchItems]);
+
+  // 石頭本身是背包裡的 itemId 999，不是可以掛賣的角色。
+  const characters = useMemo(
+    () => (Array.isArray(inventoryItems) ? inventoryItems : []).filter(i => i.itemId !== 999),
+    [inventoryItems]
+  );
+
+  const selected = useMemo(
+    () => characters.find(c => c.itemId === selectedId) || null,
+    [characters, selectedId]
+  );
+
+  const maxOpen = summary?.maxOpen ?? MAX_OPEN_FALLBACK;
+  const openCount = summary?.myOpenCount ?? 0;
+  const capped = !summaryLoading && !summaryError && openCount >= maxOpen;
+
+  const priceNum = Number(price);
+  const priceValid = Number.isInteger(priceNum) && priceNum >= PRICE_MIN && priceNum <= PRICE_MAX;
+  const submittable = !capped && selectedId != null && priceValid && !creating;
+
+  const handleSubmit = async () => {
+    setConfirmOpen(false);
+    try {
+      const { data } = await createListing({ data: { itemId: selectedId, price: priceNum } });
+      handleOpen(
+        `已建立委託：${data.name ?? selected?.name ?? "角色"} ${fmtStone(data.price ?? priceNum)} 女神石`,
+        "success"
+      );
+      refetchSummary();
+      setTimeout(() => navigate("/trade/my-listings"), 1200);
+    } catch (err) {
+      const { title, detail } = errorInfo(err, "掛單失敗，請稍後再試");
+      handleOpen(detail ? `${title}，${detail}` : title, "error");
+      refetchSummary();
+    }
+  };
+
+  if (!isLoggedIn) return <AlertLogin />;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        pb: "calc(env(safe-area-inset-bottom) + 32px)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.75 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: "1 1 auto" }}>
+          掛賣單
+        </Typography>
+        <IconButton aria-label="我的掛單" onClick={() => navigate("/trade/my-listings")}>
+          <ReceiptLongIcon />
+        </IconButton>
+      </Box>
+
+      {summaryLoading && !summary ? (
+        <Skeleton variant="rounded" height={92} animation="wave" />
+      ) : (
+        <SummaryBanner
+          balance={summary?.balance}
+          openCount={openCount}
+          maxOpen={maxOpen}
+          capped={capped}
+          loading={summaryLoading && !summary}
+        />
+      )}
+
+      {summaryError && (
+        <Alert severity="error" sx={{ borderRadius: 3, mt: 1.75 }}>
+          載入掛單狀態失敗，請稍後再試
+        </Alert>
+      )}
+
+      {capped && (
+        <Alert severity="error" sx={{ borderRadius: 3, mt: 1.75 }}>
+          <AlertTitle sx={{ fontSize: 13.5, fontWeight: 700, mb: 0.25 }}>
+            最多只能同時上架 10 筆
+          </AlertTitle>
+          <Typography sx={{ fontSize: 12, lineHeight: 1.7, color: "text.secondary" }}>
+            先去「我的掛單」取消一筆，或等現有的賣單成交，才能再掛新的。
+          </Typography>
+        </Alert>
+      )}
+
+      <Box sx={{ opacity: capped ? 0.55 : 1, pointerEvents: capped ? "none" : "auto" }}>
+        <Label>要賣的角色</Label>
+        <Paper
+          component="button"
+          type="button"
+          elevation={0}
+          onClick={() => setPickerOpen(true)}
+          aria-haspopup="dialog"
+          aria-disabled={capped || undefined}
+          disabled={capped || invLoading}
+          sx={theme => ({
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            textAlign: "left",
+            px: 1.5,
+            py: 1.375,
+            borderRadius: 3,
+            border: "1px solid",
+            borderColor: "divider",
+            cursor: "pointer",
+            color: "text.primary",
+            font: "inherit",
+            "&:hover": {
+              borderColor: "primary.light",
+              bgcolor: alpha(theme.palette.primary.main, 0.06),
+            },
+          })}
+        >
+          {selected ? (
+            <>
+              <CharAvatar
+                itemId={selected.itemId}
+                name={selected.name}
+                headImage={selected.headImage}
+              />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{ fontSize: 15, fontWeight: 600 }} noWrap>
+                  {selected.name}
+                </Typography>
+                <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
+                  {selected.itemId}
+                </Typography>
+              </Box>
+            </>
+          ) : (
+            <Typography sx={{ fontSize: 15, color: "text.secondary", py: 0.75 }}>
+              {invLoading ? "載入背包中…" : "點此選擇角色"}
+            </Typography>
+          )}
+          <ChevronRightIcon sx={{ ml: "auto", color: "text.secondary" }} />
+        </Paper>
+
+        <Label>售價</Label>
+        <TextField
+          fullWidth
+          id="priceInput"
+          label="單價（女神石）"
+          value={price}
+          onChange={e => setPrice(e.target.value.replace(/[^0-9]/g, ""))}
+          disabled={capped}
+          error={price !== "" && !priceValid}
+          helperText="可填 1 ～ 99,999。買家付的就是這個價。"
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end" sx={{ flexShrink: 0 }}>
+                  <Typography sx={{ fontSize: 13, color: "text.secondary", fontWeight: 600 }}>
+                    女神石
+                  </Typography>
+                </InputAdornment>
+              ),
+              sx: { "& input": { fontSize: 19, fontWeight: 600, ...NUMS } },
+            },
+
+            htmlInput: { inputMode: "numeric", pattern: "[0-9]*", "aria-describedby": "priceHelp" },
+          }}
+        />
+        <Box
+          role="group"
+          aria-label="常用價格"
+          sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1.25 }}
+        >
+          {QUICK_PRICES.map(p => (
+            <Chip
+              key={p}
+              label={String(p)}
+              clickable
+              disabled={capped}
+              aria-pressed={String(p) === price}
+              onClick={() => setPrice(String(p))}
+              variant={String(p) === price ? "filled" : "outlined"}
+              color={String(p) === price ? "primary" : "default"}
+              sx={{ fontWeight: 600, ...NUMS }}
+            />
+          ))}
+        </Box>
+
+        <Label>成交後的金額</Label>
+        <Paper
+          elevation={0}
+          sx={{ px: 1.75, py: 1.5, borderRadius: 3, border: "1px solid", borderColor: "divider" }}
+        >
+          <FeeBreakdown price={priceValid ? priceNum : 0} showBurnNote />
+        </Paper>
+      </Box>
+
+      {capped ? (
+        <>
+          <Button variant="contained" disabled sx={{ mt: 2, py: 1.625 }}>
+            掛單數已達上限
+          </Button>
+          <Button variant="text" onClick={() => navigate("/trade/my-listings")} sx={{ mt: 0.75 }}>
+            前往我的掛單
+          </Button>
+        </>
+      ) : (
+        <Button
+          variant="contained"
+          disabled={!submittable}
+          onClick={() => setConfirmOpen(true)}
+          sx={{ mt: 2, py: 1.625 }}
+        >
+          送出掛單
+        </Button>
+      )}
+
+      <CharacterPickerDrawer
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        items={characters}
+        initialId={selectedId}
+        onConfirm={id => setSelectedId(id)}
+        title="選擇角色"
+      />
+
+      <Dialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        fullWidth
+        maxWidth="xs"
+        aria-labelledby="sell-confirm-title"
+      >
+        <DialogTitle id="sell-confirm-title" sx={{ fontWeight: 600 }}>
+          確認掛單？
+        </DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ borderRadius: 3, mb: 1.5 }}>
+            <AlertTitle sx={{ fontSize: 13.5, fontWeight: 700, mb: 0.5 }}>
+              你的升星強化不會轉移
+            </AlertTitle>
+            <Typography sx={{ fontSize: 12, lineHeight: 1.7, color: "text.secondary" }}>
+              賣掉後，買家拿到的是<strong>初始星數</strong>
+              的角色。你之前用女神石升上去的星等會直接消失，也不會退錢。
+            </Typography>
+          </Alert>
+
+          {selected && (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.375,
+                pt: 1.25,
+                pb: 1.5,
+                borderBottom: "1px solid",
+                borderColor: "divider",
+                mb: 0.75,
+              }}
+            >
+              <CharAvatar
+                itemId={selected.itemId}
+                name={selected.name}
+                headImage={selected.headImage}
+                size={38}
+              />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{ fontSize: 15, fontWeight: 600 }} noWrap>
+                  {selected.name}
+                </Typography>
+                <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
+                  {selected.itemId}
+                </Typography>
+              </Box>
+            </Box>
+          )}
+
+          <FeeBreakdown
+            price={priceValid ? priceNum : 0}
+            feeLabel="手續費（5%，銷毀）"
+            netLabel="成交後實收"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button color="inherit" onClick={() => setConfirmOpen(false)} disabled={creating}>
+            取消
+          </Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={creating} autoFocus>
+            確認掛單
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <HintSnackBar open={snackOpen} message={message} severity={severity} onClose={handleClose} />
+    </Box>
+  );
+}

--- a/frontend/src/pages/Trade/_market.js
+++ b/frontend/src/pages/Trade/_market.js
@@ -1,0 +1,98 @@
+/* =========================================================================
+ * 公開市場 / 角色委託所 —— 共用計算、格式化、狀態對應與版面零件
+ * 舊的一對一交易用語（STATUS 0/1/-1、ROLE）留在 _shared.jsx，
+ * 兩套字彙混在一起只會讓人猜錯，所以這裡另開一個模組。
+ * ====================================================================== */
+
+export const FEE_PERCENT = 5;
+export const PRICE_MIN = 1;
+export const PRICE_MAX = 99999;
+export const MAX_OPEN_FALLBACK = 10;
+
+/** 手續費無條件進位，實收為售價扣掉手續費。與後端同一條公式。 */
+export const calcFee = price => Math.ceil((price * FEE_PERCENT) / 100);
+export const calcNet = price => price - calcFee(price);
+
+/** 金額一律有千分位。 */
+export const fmtStone = n => Number(n ?? 0).toLocaleString("en-US");
+
+/** 數字欄位對齊用（等寬數字）。 */
+export const NUMS = { fontVariantNumeric: "tabular-nums" };
+
+const pad = n => String(n).padStart(2, "0");
+
+/** MM/DD HH:mm */
+export function fmtShortDate(ts) {
+  if (!ts) return "-";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "-";
+  return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** MM/DD */
+export function fmtShortDay(ts) {
+  if (!ts) return "-";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "-";
+  return `${pad(d.getMonth() + 1)}/${pad(d.getDate())}`;
+}
+
+export const LISTING_STATUS = {
+  open: { label: "開放中", color: "primary" },
+  sold: { label: "已成交", color: "success" },
+  cancelled: { label: "已取消", color: "default" },
+  invalid: { label: "已失效", color: "error" },
+};
+
+/**
+ * 後端錯誤碼 → 文案。UI 一律看 code，認不得的才退回 message。
+ */
+export const MARKET_ERROR = {
+  ALREADY_TAKEN: {
+    title: "此委託已被其他玩家買走或取消",
+    detail: "你的女神石沒有被扣款。",
+  },
+  SELLER_LOST_ITEM: {
+    title: "賣家已無此角色，委託已失效",
+    detail: "系統已自動下架這筆委託，沒有任何女神石異動。",
+  },
+  INSUFFICIENT_FUNDS: { title: "女神石不足，無法購買" },
+  ALREADY_OWNED: {
+    title: "你已擁有此角色，無法購買",
+    detail: "角色為一人一隻，重複持有不會生效。",
+  },
+  IS_SELLER: { title: "這是你自己的掛單，無法購買" },
+  NOT_OPEN: { title: "此委託已結束，無法購買" },
+  LISTING_CAP: {
+    title: "最多只能同時上架 10 筆",
+    detail: "先去「我的掛單」取消一筆，或等現有的賣單成交，才能再掛新的。",
+  },
+  NOT_OWNED: { title: "你目前沒有這個角色，無法掛單" },
+  ALREADY_LISTED: { title: "這個角色你已經有一張掛單了" },
+  INVALID_PRICE: { title: "售價只能填 1 ～ 99,999" },
+};
+
+export function errorInfo(err, fallback = "操作失敗，請稍後再試") {
+  const data = err?.response?.data;
+  const known = data?.code ? MARKET_ERROR[data.code] : null;
+  return {
+    code: data?.code ?? null,
+    title: known?.title ?? data?.message ?? fallback,
+    detail: known?.detail ?? null,
+    data: data ?? null,
+  };
+}
+
+export function errorText(err, fallback) {
+  const { title, detail } = errorInfo(err, fallback);
+  return detail ? `${title}，${detail}` : title;
+}
+
+/** 沒有頭像圖時，用角色編號推一個穩定的漸層底色，跟設計稿一致。 */
+export function charGradient(itemId) {
+  const h = (parseInt(itemId, 10) * 7 || 0) % 360;
+  return `linear-gradient(135deg, hsl(${h} 62% 58%), hsl(${(h + 38) % 360} 66% 44%))`;
+}
+
+/** 賣家 / 買家名稱可能是 null（profile 查不到），統一補一個可讀的字。 */
+export const displayName = n => n || "未知玩家";

--- a/frontend/src/pages/Trade/_marketUi.jsx
+++ b/frontend/src/pages/Trade/_marketUi.jsx
@@ -1,0 +1,269 @@
+import { Avatar, Box, Chip, Paper, Typography } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import StarRateRoundedIcon from "@mui/icons-material/StarRateRounded";
+import { LISTING_STATUS, NUMS, charGradient } from "./_market";
+
+/* ---------------------------------------------------------------- 版面零件 */
+
+/**
+ * 基礎星數標記：一顆 ★ 加數字（★3），不是重複三顆星。
+ *
+ * 為什麼是 ★+數字而不是 ★★★：
+ * 掛單列已經擠了賣家名、角色編號、價格、最低價/你的掛單標籤跟購買鍵，
+ * 三顆星在 390px 會把名字那行推到換行；★3 固定寬度，1 星到 6 星都不會變版。
+ *
+ * 為什麼一定要 aria-label：
+ * 純 ★ 會被讀成裝飾或評分小工具，但這裡是「買到手的星數」，
+ * 講錯會讓人花錯錢，所以文字替代一律寫「基礎 N 星」。
+ *
+ * star 缺值（後端還沒上線）時回傳 null —— 不補預設值 1，
+ * 「沒有資料」跟「真的是 1 星」必須長得不一樣。
+ */
+export function BaseStar({ star, size = 12, tone = "secondary", sx }) {
+  const n = Number(star);
+  if (!Number.isFinite(n) || n < 1) return null;
+
+  return (
+    <Box
+      component="span"
+      role="img"
+      aria-label={`基礎 ${n} 星`}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "1px",
+        flexShrink: 0,
+        whiteSpace: "nowrap",
+        lineHeight: 1,
+        fontSize: size,
+        fontWeight: 700,
+        color: tone === "inherit" ? "inherit" : "secondary.main",
+        ...NUMS,
+        ...sx,
+      }}
+    >
+      <StarRateRoundedIcon aria-hidden="true" sx={{ fontSize: size + 3 }} />
+      {n}
+    </Box>
+  );
+}
+
+/**
+ * 詳情頁用的完整版：★N 加上「基礎星數」四個字。
+ * 買家決策就發生在這一頁，光一個 ★3 還是可能被讀成「賣家練到 3 星」，
+ * 所以這裡把字寫滿，跟下面的升星警語同一個口徑。
+ */
+export function BaseStarBadge({ star, onGradient = false, sx }) {
+  const n = Number(star);
+  if (!Number.isFinite(n) || n < 1) return null;
+
+  return (
+    <Box
+      component="span"
+      role="img"
+      aria-label={`基礎 ${n} 星，成交後買家取得的星數`}
+      sx={theme => ({
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.375,
+        px: 0.875,
+        py: 0.375,
+        borderRadius: 999,
+        fontSize: 11.5,
+        fontWeight: 700,
+        lineHeight: 1,
+        whiteSpace: "nowrap",
+        ...NUMS,
+        ...(onGradient
+          ? {
+              color: "#fff",
+              bgcolor: alpha("#fff", 0.22),
+              border: `1px solid ${alpha("#fff", 0.3)}`,
+            }
+          : {
+              color: theme.palette.secondary.main,
+              bgcolor: alpha(theme.palette.secondary.main, 0.14),
+              border: `1px solid ${alpha(theme.palette.secondary.main, 0.34)}`,
+            }),
+        ...sx,
+      })}
+    >
+      <StarRateRoundedIcon aria-hidden="true" sx={{ fontSize: 14 }} />
+      {n}
+      <Box component="span" sx={{ fontWeight: 600, opacity: 0.9 }}>
+        基礎星數
+      </Box>
+    </Box>
+  );
+}
+
+export function CharAvatar({ itemId, name = "", headImage, size = 44, dimmed = false, sx }) {
+  return (
+    <Avatar
+      src={headImage || undefined}
+      alt={name}
+      sx={{
+        width: size,
+        height: size,
+        flex: `0 0 ${size}px`,
+        fontSize: Math.round(size * 0.4),
+        fontWeight: 700,
+        color: "#fff",
+        background: charGradient(itemId),
+        boxShadow: "inset 0 0 0 2px rgba(255,255,255,.35)",
+        filter: dimmed ? "grayscale(.35)" : "none",
+        ...sx,
+      }}
+    >
+      {name.charAt(0)}
+    </Avatar>
+  );
+}
+
+export function StatusChip({ status, size = "small", sx }) {
+  const info = LISTING_STATUS[status] || LISTING_STATUS.invalid;
+  return (
+    <Chip
+      size={size}
+      label={info.label}
+      color={info.color === "default" ? undefined : info.color}
+      variant="outlined"
+      icon={
+        <Box
+          component="span"
+          sx={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            bgcolor: "currentColor",
+            ml: "10px !important",
+            mr: "-2px !important",
+          }}
+        />
+      }
+      sx={{ fontWeight: 600, height: 25, ...sx }}
+    />
+  );
+}
+
+/** 「我的」「最低價」這類小標。 */ export function Tag({ label, color = "secondary" }) {
+  return (
+    <Box
+      component="span"
+      sx={theme => ({
+        fontSize: 10,
+        fontWeight: 700,
+        lineHeight: 1,
+        px: 1,
+        py: 0.5,
+        borderRadius: 999,
+        whiteSpace: "nowrap",
+        color: theme.palette[color].main,
+        bgcolor: alpha(theme.palette[color].main, 0.14),
+        border: `1px solid ${alpha(theme.palette[color].main, 0.34)}`,
+      })}
+    >
+      {label}
+    </Box>
+  );
+}
+
+/** 主色漸層面板，三個頁面的 banner 共用同一層底。 */
+export function GradientPanel({ children, sx }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={theme => ({
+        position: "relative",
+        overflow: "hidden",
+        borderRadius: 3,
+        p: 2,
+        color: "#fff",
+        border: "1px solid",
+        borderColor: alpha("#fff", 0.14),
+        background:
+          theme.palette.mode === "dark"
+            ? `radial-gradient(120% 140% at 88% -20%, ${alpha(theme.palette.primary.light, 0.22)}, transparent 55%),
+               linear-gradient(135deg, #0B3A4C, #0E7A8C 60%, ${theme.palette.primary.main})`
+            : `radial-gradient(120% 140% at 88% -20%, rgba(255,255,255,.28), transparent 55%),
+               linear-gradient(135deg, ${theme.palette.primary.dark}, ${theme.palette.primary.main} 55%, ${theme.palette.primary.light})`,
+        "&::after": {
+          content: '""',
+          position: "absolute",
+          right: -30,
+          bottom: -60,
+          width: 160,
+          height: 160,
+          borderRadius: "50%",
+          background: "rgba(255,255,255,.10)",
+          pointerEvents: "none",
+        },
+        ...sx,
+      })}
+    >
+      <Box sx={{ position: "relative", zIndex: 1 }}>{children}</Box>
+    </Paper>
+  );
+}
+
+/** 小標題 + 延伸細線。 */
+export function SectionTitle({ children, sx }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        mx: 0.25,
+        color: "text.secondary",
+        fontSize: 12,
+        fontWeight: 700,
+        letterSpacing: "1px",
+        "&::after": {
+          content: '""',
+          flex: "1 1 auto",
+          height: "1px",
+          bgcolor: "divider",
+        },
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+/** key / value 一行，第二行起自帶上分隔線。 */
+export function Row({ label, value, valueColor, strike }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 1.25,
+        py: 1.125,
+        fontSize: 13.5,
+        "&:not(:first-of-type)": { borderTop: "1px solid", borderColor: "divider" },
+      }}
+    >
+      <Typography component="span" variant="body2" sx={{ color: "text.secondary" }}>
+        {label}
+      </Typography>
+      <Typography
+        component="span"
+        variant="body2"
+        sx={{
+          fontWeight: 600,
+          color: valueColor || "text.primary",
+          textDecoration: strike ? "line-through" : "none",
+          opacity: strike ? 0.6 : 1,
+          textAlign: "right",
+          ...NUMS,
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/pages/XpHistory/index.jsx
+++ b/frontend/src/pages/XpHistory/index.jsx
@@ -183,7 +183,9 @@ export default function XpHistory() {
         anchor="bottom"
         open={helpOpen}
         onClose={() => setHelpOpen(false)}
-        PaperProps={{ sx: { borderTopLeftRadius: 12, borderTopRightRadius: 12, p: 2 } }}
+        slotProps={{
+          paper: { sx: { borderTopLeftRadius: 12, borderTopRightRadius: 12, p: 2 } },
+        }}
       >
         <Box
           sx={{ width: 40, height: 4, bgcolor: "divider", borderRadius: 2, mx: "auto", mb: 2 }}


### PR DESCRIPTION
## Summary

以掛單簿模式新增公開市場（角色委託所），取代原本需要雙方同時在線的一對一議價。舊的一對一交易**完全未改動**，保留為唯讀紀錄共存。

順帶修掉一個既有的線上 bug：`4b19faa3 chore(frontend): upgrade MUI cluster to v9` 之後，MUI v9 移除的舊 props 造成多處 UI 靜默失效，已壞約 3.5 個月。

本 PR 拆成兩個 commit，MUI 修復與新功能分開以便追溯。

### 公開市場（後端）

- `public_market` 資料表 + 8 個 REST 端點（`/api/public-market`）
- 手續費成交價 5% 無條件進位，賣家實收扣除、買家付全額，**手續費銷毀**（無第三方入帳）
- 購買全程單一 transaction，`SELECT ... FOR UPDATE` 加條件式 `UPDATE ... WHERE status='open'` 雙層防護，同一張單不可能被兩個買家買到
- 掛單**不移動** inventory，成交時才驗證賣家仍持有；若已無此角色自動轉 `invalid` 下架且不動任何女神石
- **升星強化不隨交易轉移**，買家取得 `gacha_pool.Star` 的基礎星數
- 每人同時最多 10 張開放掛單，價格限 1～99,999 整數
- 成交後結算 `trade_complete` 成就（買賣雙方各一次，於 commit 之後，沿用既有事件與私人交易慣例）
- `.市場` 指令與 Flex 入口

### 公開市場（前端）

- 掛單簿、掛賣單、委託詳情、我的掛單四個 LIFF 頁面
- 各處顯示基礎星數，購買前明示「你會取得：基礎 N 星」，與升星不轉移的警語互相印證（而非彼此矛盾）

### MUI v9 修復

v9 已**移除**（非僅 deprecated）`InputProps` / `inputProps` / `PaperProps`，這些 props 直接漏到 DOM 不再被元件讀取，只留下 React unknown-prop warning。實測受影響：

| 症狀 | 影響 |
|---|---|
| 輸入框失去 `inputMode="numeric"` / `pattern` | LIFF 純手機端無法喚出數字鍵盤（實質 bug） |
| `startAdornment` / `endAdornment` 未渲染 | 後綴、搜尋 icon 全部消失 |
| Dialog / Drawer 的 `sx` 未套用 | 圓角等樣式失效 |

已遷移至 `slotProps`，注意各元件家族 slot 名稱不同：

- TextField：外層 Input → `slotProps.input`；原生 input → `slotProps.htmlInput`
- Dialog / SwipeableDrawer → `slotProps.paper`
- Switch：原生 input → `slotProps.input`（**非** `htmlInput`）

其中 Dialog 與 Switch 官方 codemod 不處理，為手動修正。修好後 adornment 首次真的渲染，暴露出 `Sell.jsx` 後綴被擠折行的問題，改用 `InputAdornment` + `flexShrink: 0` 修正。

## Test plan

- [x] `app` 全套測試 128 suites / 1184 tests 通過（公開市場新增 49 → 71 tests）
- [x] `app` lint 乾淨；`frontend` lint 0 errors（57 warnings 為既有基準）
- [x] `frontend` build 成功；prettier 無差異
- [x] migration 實際套用，`SHOW CREATE TABLE` 確認 `updated_at` 帶 `ON UPDATE CURRENT_TIMESTAMP` 且實測會前進
- [x] 測試站實跑掛單→成交全流程，對帳正確：買家扣全額、賣家入 `price - fee`、**無第三方手續費入帳**（確實銷毀）
- [x] 星數不轉移實證：769 賣家已升星，買家取得 `star:1`（= `gacha_pool.Star`）；770 → `star:3`
- [x] 五個端點 `star` 欄位皆為 integer ≥1（`gacha_pool.Star` 是 `varchar(1)`，已確認未透出字串）
- [x] 競態：`ALREADY_TAKEN` / `INSUFFICIENT_FUNDS` / `SELLER_LOST_ITEM` 皆不結算成就
- [x] 瀏覽器實測 390x844（LIFF 尺寸）四個頁面，明暗兩色模式，無 console error
- [x] 修復後實測 `inputmode="numeric"` / `pattern` / `aria-describedby` 回到 DOM

## Deployment notes

- **需要跑 migration**：兩支（建表 + `updated_at` ON UPDATE）
- 無新增環境變數、無新增依賴、無 config / crontab 變動
- 無破壞性 API 變更（舊交易端點與回應形狀未動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)