### PR TITLE
feat(trade): raise public market price cap

### DIFF
--- a/app/src/service/PublicMarketService.js
+++ b/app/src/service/PublicMarketService.js
@@ -9,7 +9,7 @@ const { DefaultLogger } = require("../util/Logger");
 const FEE_PERCENT = 5;
 const MAX_OPEN_LISTINGS = 10;
 const MIN_PRICE = 1;
-const MAX_PRICE = 99999;
+const MAX_PRICE = 10000000;
 const GOD_STONE_ITEM_ID = 999;
 
 /**
@@ -32,7 +32,7 @@ function calcNetProceeds(price) {
 }
 
 /**
- * 價格必須是 1 ～ 99999 的整數。
+ * 價格必須是 1 ～ 10000000 的整數。
  * @param {*} price
  * @returns {Boolean}
  */

--- a/app/src/service/__tests__/PublicMarketService.test.js
+++ b/app/src/service/__tests__/PublicMarketService.test.js
@@ -93,7 +93,7 @@ describe("手續費計算", () => {
     [1, 1, 0],
     [20, 1, 19],
     [21, 2, 19],
-    [99999, 5000, 94999],
+    [10000000, 500000, 9500000],
   ])("price %i -> fee %i / net %i（5%% 無條件進位）", (price, fee, net) => {
     expect(Service.calcFee(price)).toBe(fee);
     expect(Service.calcNetProceeds(price)).toBe(net);
@@ -107,9 +107,9 @@ describe("手續費計算", () => {
 });
 
 describe("價格驗證", () => {
-  it.each([1, 2, 99998, 99999])("接受 %i", p => expect(Service.isValidPrice(p)).toBe(true));
+  it.each([1, 2, 9999999, 10000000])("接受 %i", p => expect(Service.isValidPrice(p)).toBe(true));
 
-  it.each([0, -1, 100000, 1.5, NaN, Infinity, "500", null, undefined])("拒絕 %p", p =>
+  it.each([0, -1, 10000001, 1.5, NaN, Infinity, "500", null, undefined])("拒絕 %p", p =>
     expect(Service.isValidPrice(p)).toBe(false)
   );
 });

--- a/frontend/src/pages/Trade/Sell.jsx
+++ b/frontend/src/pages/Trade/Sell.jsx
@@ -367,7 +367,7 @@ export default function Sell() {
           onChange={e => setPrice(e.target.value.replace(/[^0-9]/g, ""))}
           disabled={capped}
           error={price !== "" && !priceValid}
-          helperText="可填 1 ～ 99,999。買家付的就是這個價。"
+          helperText="可填 1 ～ 10,000,000。買家付的就是這個價。"
           slotProps={{
             input: {
               endAdornment: (

--- a/frontend/src/pages/Trade/_market.js
+++ b/frontend/src/pages/Trade/_market.js
@@ -6,7 +6,7 @@
 
 export const FEE_PERCENT = 5;
 export const PRICE_MIN = 1;
-export const PRICE_MAX = 99999;
+export const PRICE_MAX = 10000000;
 export const MAX_OPEN_FALLBACK = 10;
 
 /** 手續費無條件進位，實收為售價扣掉手續費。與後端同一條公式。 */
@@ -69,7 +69,7 @@ export const MARKET_ERROR = {
   },
   NOT_OWNED: { title: "你目前沒有這個角色，無法掛單" },
   ALREADY_LISTED: { title: "這個角色你已經有一張掛單了" },
-  INVALID_PRICE: { title: "售價只能填 1 ～ 99,999" },
+  INVALID_PRICE: { title: "售價只能填 1 ～ 10,000,000" },
 };
 
 export function errorInfo(err, fallback = "操作失敗，請稍後再試") {


### PR DESCRIPTION
## Summary
- raise the public market listing price cap from 99,999 to 10,000,000 goddess stones
- align frontend validation and error/help copy with the backend limit
- cover the new maximum, over-limit rejection, and fee calculation in service tests

## Test plan
- [x] `yarn test --runInBand src/service/__tests__/PublicMarketService.test.js`
- [x] backend ESLint for changed files
- [x] frontend ESLint for changed files
- [x] `yarn build` in `frontend/`

No migration, dependency, environment variable, or deployment configuration changes required.