### PR TITLE
feat: add public market buy orders

### DIFF
--- a/app/bin/ShapeInventory.js
+++ b/app/bin/ShapeInventory.js
@@ -2,13 +2,33 @@ const { inventory: inventoryModel } = require("../src/model/application/Inventor
 const mysql = require("../src/util/mysql");
 const { DefaultLogger } = require("../src/util/Logger");
 
+const GOD_STONE_ITEM_ID = 999;
+
+/**
+ * 女神石帳本瘦身：把某個使用者的多筆 999 列壓成一列。
+ *
+ * 這支腳本目前沒有任何呼叫端（不在 crontab.config.js，也不是 package script），
+ * 只會被人手動 `node bin/ShapeInventory.js` 跑起來。保留是因為它仍是一個有用的
+ * 維運工具，但原本的寫法在有並發寫入時會吃掉別人的錢：
+ *
+ *   舊流程 = 交易「外」先 SUM 出 amount → 交易內 delete 全部 999 列 → insert 那個 amount
+ *
+ * 兩次讀取之間（掃描到實際刪除，可能隔了好幾個使用者的處理時間）只要有任何一筆
+ * 女神石入帳 —— 公開市場收購單的取消退款、履約撥款、ATM 轉帳 —— 那一列會在 delete
+ * 時被一起刪掉，卻不在稍早算好的 amount 裡，錢就這樣蒸發。
+ *
+ * 最小修正：交易外那次 SUM 只當作「誰需要處理」的候選名單，真正要寫回去的金額
+ * 在同一筆交易內用 FOR UPDATE 重算。FOR UPDATE 會在 (userId, itemId) 這段索引範圍
+ * 上鎖，並發的入帳要嘛在重算之前 commit（被算進去），要嘛卡住等我們 commit 之後
+ * 才 append（成為壓縮後的新一列）。兩種情況都不會漏。
+ */
 async function main() {
   const result = await inventoryModel.knex
     .select("userId")
     .count({ count: "itemId" })
     .groupBy("userId")
     .sum({ amount: "itemAmount" })
-    .where("itemId", 999)
+    .where("itemId", GOD_STONE_ITEM_ID)
     .limit(100);
 
   // 只處理有多筆數據的用戶
@@ -19,24 +39,34 @@ async function main() {
   }
 
   for (let i = 0; i < processList.length; i++) {
-    const { userId, amount, count } = processList[i];
+    const { userId, count } = processList[i];
     try {
-      await mysql.transaction(async trx => {
-        await trx.delete().from(inventoryModel.table).where({ userId, itemId: 999 });
+      const amount = await mysql.transaction(async trx => {
+        // 權威金額：交易內重算並上鎖，不能用掃描階段那個過期的 amount。
+        const row = await trx(inventoryModel.table)
+          .where({ userId, itemId: GOD_STONE_ITEM_ID })
+          .sum({ amount: "itemAmount" })
+          .forUpdate()
+          .first();
+        const current = Number((row && row.amount) || 0);
+
+        await trx.delete().from(inventoryModel.table).where({ userId, itemId: GOD_STONE_ITEM_ID });
         await trx
           .insert({
             userId,
-            itemId: 999,
-            itemAmount: amount,
+            itemId: GOD_STONE_ITEM_ID,
+            itemAmount: current,
           })
           .into(inventoryModel.table);
+
+        return current;
       });
 
       DefaultLogger.info(
         `處理用戶 ${userId} 女神石瘦身成功，共處理 ${count} 筆數據，女神石總數 ${amount}`
       );
     } catch (e) {
-      console.log(e);
+      DefaultLogger.error(e);
     }
   }
 }

--- a/app/migrations/20260810155919_extend_public_market_buy_orders.js
+++ b/app/migrations/20260810155919_extend_public_market_buy_orders.js
@@ -1,0 +1,89 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * public_market 第二階段：同一張表同時放賣單與收購單。
+ *
+ * 為什麼不開第二張表：兩種單共用掛單上限、共用「我的掛單」、共用成交結算，
+ * 拆表等於每一條查詢都要 UNION，而欄位其實只差一個方向旗標。
+ *
+ * 方向與欄位對應（不變量，service 全靠這條）：
+ *   sell → 發布者 = seller_id（買家成交時填 buyer_id）
+ *   buy  → 發布者 = buyer_id，seller_id 保持 NULL 直到有人履約才寫入
+ * 所以 seller_id 必須放寬成 nullable；既有資料全部是 sell，靠 DEFAULT 'sell' 自然補齊。
+ *
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable("public_market", table => {
+    table
+      .enu("order_type", ["sell", "buy"])
+      .notNullable()
+      .defaultTo("sell")
+      .comment("sell:賣單（發布者為 seller_id）, buy:收購單（發布者為 buyer_id）");
+  });
+
+  // 收購單開放期間沒有賣家，成交才知道是誰履約。
+  await knex.schema.alterTable("public_market", table => {
+    table
+      .string("seller_id", 33)
+      .nullable()
+      .comment("賣家 LINE userId；收購單在成交前為 NULL")
+      .alter();
+  });
+
+  // 掛單簿查詢多了方向這個等值條件，且它的選擇度比 status 高（各佔一半），
+  // 放在 item_id 之後才能讓 price 那段繼續走索引排序。
+  await knex.schema.alterTable("public_market", table => {
+    table.dropIndex(null, "idx_public_market_book");
+    table.dropIndex(null, "idx_public_market_seller_status");
+    table.dropIndex(null, "idx_public_market_buyer");
+  });
+
+  await knex.schema.alterTable("public_market", table => {
+    table.index(["item_id", "order_type", "status", "price"], "idx_public_market_book");
+    // 掛單上限是「賣單 + 收購單」合計，兩個方向各查一次自己的發布者欄位，
+    // 所以兩支索引都要能單獨吃下 (發布者, 方向, 狀態)。
+    table.index(["seller_id", "order_type", "status"], "idx_public_market_seller_status");
+    table.index(["buyer_id", "order_type", "status"], "idx_public_market_buyer");
+  });
+};
+
+/**
+ * 回滾會刪掉 order_type，收購單的方向資訊就永久消失，
+ * 剩下的資料會被當成賣單（seller_id 還是 NULL）解讀 —— 那是資產錯帳，不是資料遺失而已。
+ * 所以只要表裡還有任何一張收購單就拒絕回滾，要求人工先處理（取消並退款）。
+ *
+ * @param {Knex} knex
+ */
+exports.down = async function (knex) {
+  const row = await knex("public_market").where({ order_type: "buy" }).count({ c: "*" }).first();
+  const buyCount = Number((row && row.c) || 0);
+
+  if (buyCount > 0) {
+    throw new Error(
+      `Refusing destructive rollback: public_market still has ${buyCount} buy order(s). ` +
+        "Cancel and refund them first (each open buy order holds escrowed god stones)."
+    );
+  }
+
+  await knex.schema.alterTable("public_market", table => {
+    table.dropIndex(null, "idx_public_market_book");
+    table.dropIndex(null, "idx_public_market_seller_status");
+    table.dropIndex(null, "idx_public_market_buyer");
+  });
+
+  await knex.schema.alterTable("public_market", table => {
+    table.dropColumn("order_type");
+  });
+
+  await knex.schema.alterTable("public_market", table => {
+    table.string("seller_id", 33).notNullable().comment("賣家 LINE userId").alter();
+  });
+
+  await knex.schema.alterTable("public_market", table => {
+    table.index(["item_id", "status", "price"], "idx_public_market_book");
+    table.index(["seller_id", "status"], "idx_public_market_seller_status");
+    table.index(["buyer_id"], "idx_public_market_buyer");
+  });
+};

--- a/app/src/controller/princess/GodStoneShop/__tests__/api.test.js
+++ b/app/src/controller/princess/GodStoneShop/__tests__/api.test.js
@@ -1,0 +1,122 @@
+// api.js 的接線測試：async handler 的 rejection 必須交給 Express，
+// 不能變成 unhandled rejection（請求永遠掛著，且 Node 預設會讓 bot 行程結束）。
+
+jest.mock("../../../../model/princess/GodStoneShop", () => ({
+  all: jest.fn(),
+  findByItemId: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+}));
+
+jest.mock("../handler", () => ({
+  exchangeItem: jest.fn(),
+  history: jest.fn(),
+  addGodStoneShopItem: jest.fn(),
+  destroyGodStoneShopItem: jest.fn(),
+  updateGodStoneShopItem: jest.fn(),
+}));
+
+const request = require("supertest");
+const express = require("express");
+const router = require("../api");
+const GodStoneShopModel = require("../../../../model/princess/GodStoneShop");
+const handler = require("../handler");
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", router);
+  return app;
+}
+
+/** 讓未捕捉的 rejection 直接讓測試失敗，而不是安靜地污染後續測試。 */
+let unhandled;
+beforeAll(() => {
+  unhandled = jest.fn();
+  process.on("unhandledRejection", unhandled);
+});
+afterAll(() => {
+  process.off("unhandledRejection", unhandled);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  GodStoneShopModel.all.mockResolvedValue([{ itemId: 101, price: 3000 }]);
+  handler.exchangeItem.mockImplementation((req, res) => res.json({ ok: true }));
+  handler.history.mockImplementation((req, res) => res.json({ history: [] }));
+  handler.addGodStoneShopItem.mockImplementation((req, res) => res.status(201).json({ id: 1 }));
+  handler.destroyGodStoneShopItem.mockImplementation((req, res) => res.json({}));
+  handler.updateGodStoneShopItem.mockImplementation((req, res) => res.json({}));
+});
+
+describe("正常路徑仍照舊", () => {
+  it("GET /god-stone-shop 回商品列表", async () => {
+    const res = await request(createApp()).get("/api/god-stone-shop");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ itemId: 101, price: 3000 }]);
+  });
+
+  it("POST /god-stone-shop/purchase 走 exchangeItem", async () => {
+    const res = await request(createApp())
+      .post("/api/god-stone-shop/purchase")
+      .send({ itemId: 101, itemCount: 1 });
+
+    expect(res.status).toBe(200);
+    expect(handler.exchangeItem).toHaveBeenCalled();
+  });
+
+  it("GET /god-stone-shop/history 走 history", async () => {
+    const res = await request(createApp()).get("/api/god-stone-shop/history");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ history: [] });
+  });
+
+  it.each([
+    ["post", "/api/admin/god-stone-shop/items", 201],
+    ["delete", "/api/admin/god-stone-shop/items/10", 200],
+    ["put", "/api/admin/god-stone-shop/items/10", 200],
+  ])("%s %s 仍可用", async (method, path, expected) => {
+    const res = await request(createApp())[method](path).send({});
+
+    expect(res.status).toBe(expected);
+  });
+});
+
+describe("async rejection 交給 Express，不變成 unhandled rejection", () => {
+  it("GET /god-stone-shop 的 model 爆炸時回 500 而不是掛住", async () => {
+    GodStoneShopModel.all.mockRejectedValue(new Error("db down"));
+
+    const res = await request(createApp()).get("/api/god-stone-shop");
+
+    expect(res.status).toBe(500);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["exchangeItem", "post", "/api/god-stone-shop/purchase"],
+    ["history", "get", "/api/god-stone-shop/history"],
+    ["addGodStoneShopItem", "post", "/api/admin/god-stone-shop/items"],
+    ["destroyGodStoneShopItem", "delete", "/api/admin/god-stone-shop/items/10"],
+    ["updateGodStoneShopItem", "put", "/api/admin/god-stone-shop/items/10"],
+  ])("%s reject 時回 500", async (name, method, path) => {
+    handler[name].mockRejectedValue(new Error("boom"));
+
+    const res = await request(createApp())[method](path).send({});
+
+    expect(res.status).toBe(500);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  it("handler 同步 throw 也一樣走到 500（Express 本來就接得住，確認沒被包壞）", async () => {
+    handler.exchangeItem.mockImplementation(() => {
+      throw new Error("sync boom");
+    });
+
+    const res = await request(createApp()).post("/api/god-stone-shop/purchase").send({});
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/src/controller/princess/GodStoneShop/__tests__/handler.test.js
+++ b/app/src/controller/princess/GodStoneShop/__tests__/handler.test.js
@@ -1,0 +1,379 @@
+// GodStoneShop 兌換的信任邊界與金流測試。
+// 重點三件事：
+//   1. itemCount 是使用者可控輸入，只能是 1 —— 否則一份的錢拿多份。
+//   2. 扣款不能吃掉並發入帳（舊寫法會刪光所有 999 列再插一列剩餘額）。
+//   3. 「已持有」的權威檢查必須在交易內用 locking read 做，交易外那次只是 fast-path。
+
+jest.mock("../../../../model/application/Inventory", () => ({
+  fetchUserOwnItems: jest.fn(),
+  deleteItem: jest.fn(),
+  insertItems: jest.fn(),
+  inventory: {
+    create: jest.fn(),
+    increaseGodStone: jest.fn(),
+    decreaseGodStone: jest.fn(),
+  },
+}));
+
+jest.mock("../../../../model/princess/GodStoneShop", () => ({
+  findByItemId: jest.fn(),
+  all: jest.fn(),
+}));
+
+jest.mock("../../../../model/princess/gacha", () => ({
+  model: { find: jest.fn() },
+  getUserGodStoneCount: jest.fn(),
+}));
+
+jest.mock("../../../../service/AchievementEngine", () => ({
+  evaluate: jest.fn().mockResolvedValue({ unlocked: [] }),
+}));
+
+const handler = require("../handler");
+const InventoryModel = require("../../../../model/application/Inventory");
+const GodStoneShopModel = require("../../../../model/princess/GodStoneShop");
+const GachaModel = require("../../../../model/princess/gacha");
+const AchievementEngine = require("../../../../service/AchievementEngine");
+const mysql = require("../../../../util/mysql");
+
+const USER = "U" + "a".repeat(32);
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+/**
+ * 交易內有兩次 locking read，順序固定：先 999（餘額）再 itemId（持有）。
+ * 這裡依 where 條件分派，順便讓測試能斷言鎖序。
+ */
+function stubTrxReads({ balance = 0, owns = false } = {}) {
+  const order = [];
+  let lastWhere = {};
+
+  mysql.where.mockImplementation(cond => {
+    if (cond && typeof cond === "object") lastWhere = cond;
+    return mysql;
+  });
+
+  mysql.first.mockImplementation(async () => {
+    if (lastWhere.itemId === 999) {
+      order.push(999);
+      return { amount: balance };
+    }
+    order.push(lastWhere.itemId);
+    return { amount: owns ? 1 : 0 };
+  });
+
+  return order;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mysql.where.mockReturnValue(mysql);
+  mysql.sum.mockReturnValue(mysql);
+  mysql.forUpdate = jest.fn().mockReturnValue(mysql);
+  mysql.first.mockResolvedValue(null);
+
+  InventoryModel.fetchUserOwnItems.mockResolvedValue([]);
+  InventoryModel.inventory.create.mockResolvedValue(1);
+  InventoryModel.inventory.decreaseGodStone.mockResolvedValue([1]);
+  GodStoneShopModel.findByItemId.mockResolvedValue({ itemId: 101, price: 3000 });
+  GachaModel.model.find.mockResolvedValue({ ID: 101, Name: "佩可莉ーヌ", Star: 3 });
+  AchievementEngine.evaluate.mockResolvedValue({ unlocked: [] });
+});
+
+const req = () => ({ profile: { userId: USER }, body: { itemId: 101, itemCount: 1 } });
+
+function expectNothingWritten() {
+  expect(InventoryModel.inventory.create).not.toHaveBeenCalled();
+  expect(InventoryModel.inventory.decreaseGodStone).not.toHaveBeenCalled();
+  expect(InventoryModel.deleteItem).not.toHaveBeenCalled();
+  expect(InventoryModel.insertItems).not.toHaveBeenCalled();
+}
+
+describe("itemCount 信任邊界", () => {
+  it.each([
+    [2, "多份"],
+    [5, "多份"],
+    [100, "多份"],
+    [0, "零"],
+    [-1, "負數"],
+    [-100, "大量負數"],
+    [1.5, "小數"],
+    [1.0000001, "近似 1 的小數"],
+    ["1abc", "髒字串"],
+    ["", "空字串"],
+    [null, "null"],
+    [undefined, "缺值"],
+    [true, "布林"],
+    [[1], "陣列"],
+    [{ valueOf: () => 1 }, "偽裝成 1 的物件"],
+    [Number.NaN, "NaN"],
+    [Number.POSITIVE_INFINITY, "Infinity"],
+  ])("itemCount=%p（%s）回 400 且完全不寫入、不扣款", async itemCount => {
+    const res = createRes();
+    stubTrxReads({ balance: 999999 });
+
+    await handler.exchangeItem(
+      { profile: { userId: USER }, body: { itemId: 101, itemCount } },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expectNothingWritten();
+    // 連交易都不該開，錢不可能動
+    expect(mysql.transaction).not.toHaveBeenCalled();
+  });
+
+  it.each([1, "1", " 1 "])("itemCount=%p 是唯一合法值", async itemCount => {
+    stubTrxReads({ balance: 5000 });
+    const res = createRes();
+
+    await handler.exchangeItem(
+      { profile: { userId: USER }, body: { itemId: 101, itemCount } },
+      res
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.itemCount).toBe(1);
+  });
+
+  it("寫入的 itemAmount 用常數 1，不是使用者送來的值", async () => {
+    stubTrxReads({ balance: 5000 });
+
+    await handler.exchangeItem(
+      { profile: { userId: USER }, body: { itemId: 101, itemCount: "1" } },
+      createRes()
+    );
+
+    expect(InventoryModel.inventory.create).toHaveBeenCalledWith(
+      expect.objectContaining({ itemAmount: 1 }),
+      expect.anything()
+    );
+  });
+
+  it("成就的 spend 也只算一份，不會被 itemCount 放大", async () => {
+    stubTrxReads({ balance: 5000 });
+
+    await handler.exchangeItem(
+      { profile: { userId: USER }, body: { itemId: 101, itemCount: "1" } },
+      createRes()
+    );
+
+    expect(AchievementEngine.evaluate).toHaveBeenCalledWith(
+      USER,
+      "shop_exchange",
+      expect.objectContaining({ spend: 3000 })
+    );
+  });
+});
+
+describe("itemId 驗證", () => {
+  it.each([0, -1, 1.5, "abc", null, undefined, true, [101]])(
+    "itemId=%p 回 400，不查商品也不開交易",
+    async itemId => {
+      const res = createRes();
+
+      await handler.exchangeItem(
+        { profile: { userId: USER }, body: { itemId, itemCount: 1 } },
+        res
+      );
+
+      expect(res.statusCode).toBe(400);
+      expect(GodStoneShopModel.findByItemId).not.toHaveBeenCalled();
+      expectNothingWritten();
+    }
+  );
+
+  it("itemId=999（女神石本身）不能拿來兌換", async () => {
+    const res = createRes();
+
+    await handler.exchangeItem(
+      { profile: { userId: USER }, body: { itemId: 999, itemCount: 1 } },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(GodStoneShopModel.findByItemId).not.toHaveBeenCalled();
+    expectNothingWritten();
+  });
+});
+
+describe("商品資料防呆", () => {
+  it.each([null, undefined, "abc", -100])("price=%p 時拒絕兌換，不會反向加錢", async price => {
+    GodStoneShopModel.findByItemId.mockResolvedValue({ itemId: 101, price });
+    stubTrxReads({ balance: 999999 });
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(400);
+    expectNothingWritten();
+  });
+
+  it("商品不存在回 400，不動金流", async () => {
+    GodStoneShopModel.findByItemId.mockResolvedValue(null);
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(400);
+    expectNothingWritten();
+  });
+
+  it("gacha_pool 查無角色時拒絕（否則 attributes 會寫入 undefined 星數）", async () => {
+    GachaModel.model.find.mockResolvedValue(null);
+    stubTrxReads({ balance: 999999 });
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(400);
+    expectNothingWritten();
+  });
+});
+
+describe("重複持有的權威檢查", () => {
+  it("交易外 fast-path 命中就直接擋，省一趟交易", async () => {
+    InventoryModel.fetchUserOwnItems.mockResolvedValue([{ itemId: 101 }]);
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(GodStoneShopModel.findByItemId).not.toHaveBeenCalled();
+    expect(mysql.transaction).not.toHaveBeenCalled();
+  });
+
+  it("fast-path 沒看到（並發第二筆讀到舊快照）時，交易內的 locking read 仍會擋下", async () => {
+    // 這正是兩個並發兌換同角色的情境：兩邊的 fetchUserOwnItems 都回空。
+    InventoryModel.fetchUserOwnItems.mockResolvedValue([]);
+    stubTrxReads({ balance: 999999, owns: true });
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("api.error.gacha.shop.exchanged");
+    expectNothingWritten();
+  });
+
+  it("持有檢查用 FOR UPDATE，後到的並發請求才會排隊", async () => {
+    stubTrxReads({ balance: 5000, owns: false });
+
+    await handler.exchangeItem(req(), createRes());
+
+    // 餘額一次 + 持有一次，兩次都要鎖
+    expect(mysql.forUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("鎖序是 999（餘額）→ itemId（持有），與 PublicMarketService 一致", async () => {
+    const order = stubTrxReads({ balance: 5000, owns: false });
+
+    await handler.exchangeItem(req(), createRes());
+
+    expect(order).toEqual([999, 101]);
+  });
+
+  it("已持有優先於餘額不足：兩者同時成立時回「已兌換過」", async () => {
+    stubTrxReads({ balance: 0, owns: true });
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.body.error).toBe("api.error.gacha.shop.exchanged");
+    expectNothingWritten();
+  });
+});
+
+describe("女神石兌換金流", () => {
+  it("扣款是 append-only：只插一列負數，不刪任何既有帳列", async () => {
+    stubTrxReads({ balance: 5000 });
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ userId: USER, itemId: 101, remainGodStone: 2000 });
+
+    expect(InventoryModel.inventory.decreaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER, amount: 3000 })
+    );
+    // 這兩支就是舊寫法吃掉並發退款的元兇，改完之後不該再被呼叫
+    expect(InventoryModel.deleteItem).not.toHaveBeenCalled();
+    expect(InventoryModel.insertItems).not.toHaveBeenCalled();
+  });
+
+  it("餘額檢查在交易內，並發兌換才會排隊", async () => {
+    stubTrxReads({ balance: 5000 });
+
+    await handler.exchangeItem(req(), createRes());
+
+    expect(mysql.transaction).toHaveBeenCalled();
+    expect(mysql.forUpdate).toHaveBeenCalled();
+  });
+
+  it("餘額不足回 400，且不寫入任何東西", async () => {
+    stubTrxReads({ balance: 100 });
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("api.error.gacha.shop.notEnoughGodStone");
+    expectNothingWritten();
+  });
+
+  it("餘額剛好等於售價可以兌換（邊界不能少一塊）", async () => {
+    stubTrxReads({ balance: 3000 });
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.remainGodStone).toBe(0);
+  });
+
+  it("物品與扣款在同一筆交易內寫入（不會扣了錢拿不到東西）", async () => {
+    stubTrxReads({ balance: 5000 });
+    const order = [];
+    InventoryModel.inventory.create.mockImplementation(async (_data, trx) => {
+      order.push(["create", trx != null]);
+      return 1;
+    });
+    InventoryModel.inventory.decreaseGodStone.mockImplementation(async ({ trx }) => {
+      order.push(["decrease", trx != null]);
+      return [1];
+    });
+
+    await handler.exchangeItem(req(), createRes());
+
+    expect(order).toEqual([
+      ["create", true],
+      ["decrease", true],
+    ]);
+  });
+
+  it("成就在交易之後結算，且爆炸不影響已完成的兌換", async () => {
+    stubTrxReads({ balance: 5000 });
+    AchievementEngine.evaluate.mockRejectedValue(new Error("boom"));
+    const res = createRes();
+
+    await handler.exchangeItem(req(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(AchievementEngine.evaluate).toHaveBeenCalled();
+  });
+});

--- a/app/src/controller/princess/GodStoneShop/api.js
+++ b/app/src/controller/princess/GodStoneShop/api.js
@@ -12,18 +12,32 @@ const {
 } = require("./handler");
 const router = createRouter();
 
-ShopRouter.get("/", async (req, res) => {
-  const itemList = await GodStoneShopModel.all();
-  res.json(itemList);
-});
+/**
+ * Express 4 不會接住 async handler 回傳的 rejected promise —— 沒有這層包裝，
+ * 一次 DB 失敗就是 unhandled rejection：請求永遠掛著直到客戶端逾時，
+ * 而 process 層級的 unhandledRejection 在 Node 上預設會讓整個 bot 行程結束。
+ * 交給 next(err) 由 Express 的預設 error handler 回 500。
+ *
+ * 與 router/race.js、router/PublicMarket 用的是同一個三行寫法，
+ * 刻意各自留在自己的檔案裡 —— 抽成共用模組只是替三行程式碼多開一個 import。
+ */
+const asyncHandler = fn => (req, res, next) => fn(req, res, next).catch(next);
 
-ShopRouter.post("/purchase", verifyToken, exchangeItem);
+ShopRouter.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const itemList = await GodStoneShopModel.all();
+    res.json(itemList);
+  })
+);
 
-ShopRouter.get("/history", verifyToken, history);
+ShopRouter.post("/purchase", verifyToken, asyncHandler(exchangeItem));
 
-AdminRouter.post("/items", addGodStoneShopItem);
-AdminRouter.delete("/items/:id", destroyGodStoneShopItem);
-AdminRouter.put("/items/:id", updateGodStoneShopItem);
+ShopRouter.get("/history", verifyToken, asyncHandler(history));
+
+AdminRouter.post("/items", asyncHandler(addGodStoneShopItem));
+AdminRouter.delete("/items/:id", asyncHandler(destroyGodStoneShopItem));
+AdminRouter.put("/items/:id", asyncHandler(updateGodStoneShopItem));
 
 router.use("/god-stone-shop", ShopRouter);
 router.use("/admin/god-stone-shop", AdminRouter);

--- a/app/src/controller/princess/GodStoneShop/handler.js
+++ b/app/src/controller/princess/GodStoneShop/handler.js
@@ -2,8 +2,55 @@ const InventoryModel = require("../../../model/application/Inventory");
 const GodStoneShopModel = require("../../../model/princess/GodStoneShop");
 const GachaModel = require("../../../model/princess/gacha");
 const gacha = GachaModel.model;
+const mysql = require("../../../util/mysql");
 const i18n = require("../../../util/i18n");
 const AchievementEngine = require("../../../service/AchievementEngine");
+
+const GOD_STONE_ITEM_ID = 999;
+
+// i18n 的 `updateFiles: false` 讓查無的 key 直接回傳 key 字串本身，
+// 而 locales/zh_tw.json 不在這次的改動範圍內，所以這條訊息先寫死。
+// 真正的前端送不出這種請求（寫死 itemCount: 1），會看到它的只有直接打 API 的人。
+const INVALID_ITEM_COUNT_MESSAGE = "兌換數量不正確，一次只能兌換一個";
+
+/**
+ * 兌換數量的信任邊界。
+ *
+ * 商店的商品是角色，角色一人一隻 —— 前端寫死送 1，價格也是「一份」的價格。
+ * 但這是使用者可控的輸入：送 itemCount: 5 進來，舊碼會照 price × 1 扣款卻寫入
+ * itemAmount: 5，等於用一份的錢拿五份；送負數則反而把持有量寫成負的。
+ * 所以這裡不做「夾在合法範圍」而是嚴格只收整數 1，其餘一律擋掉 ——
+ * 商業上本來就沒有第二種合法值，放寬只會多開一條要驗的路。
+ *
+ * 字串 "1" 也接受：JSON body 經過某些客戶端會變成字串，那不是攻擊。
+ * 但 1.0 以外的浮點、"1abc"、true、[1] 全部拒絕。
+ *
+ * @param {*} value
+ * @returns {Boolean}
+ */
+function isValidItemCount(value) {
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") return /^\s*1\s*$/.test(value);
+  return false;
+}
+
+/**
+ * itemId 必須是正整數，且不能是女神石本身（999）——
+ * 拿女神石當商品會走進「用女神石買女神石」的自我扣款路徑。
+ *
+ * 只收 number 或數字字串：`Number(true)` 是 1、`Number([101])` 是 101，
+ * 直接 Number() 會讓 `true` / `[101]` 這種輸入變成合法的商品編號。
+ *
+ * @param {*} value
+ * @returns {Boolean}
+ */
+function isValidItemId(value) {
+  if (typeof value !== "number" && typeof value !== "string") return false;
+  if (typeof value === "string" && !/^\s*\d+\s*$/.test(value)) return false;
+
+  const id = Number(value);
+  return Number.isInteger(id) && id > 0 && id !== GOD_STONE_ITEM_ID;
+}
 
 /**
  * 使用女神石兌換物品
@@ -12,9 +59,26 @@ const AchievementEngine = require("../../../service/AchievementEngine");
  */
 exports.exchangeItem = async function (req, res) {
   const { userId } = req.profile;
-  const { itemId, itemCount } = req.body;
+  const { itemId: rawItemId, itemCount } = req.body;
 
-  // 檢查要兌換的目標物品是否已存在
+  if (!isValidItemId(rawItemId)) {
+    return res.status(400).json({
+      error: i18n.__("api.error.gacha.shop.itemNotFound"),
+    });
+  }
+
+  if (!isValidItemCount(itemCount)) {
+    return res.status(400).json({
+      error: INVALID_ITEM_COUNT_MESSAGE,
+    });
+  }
+
+  const itemId = Number(rawItemId);
+  // 通過驗證後數量恆為 1，後面一律用這個常數，不再碰使用者送來的值。
+  const quantity = 1;
+
+  // 快速失敗：已擁有就不用再往下查商品／開交易。
+  // 這只是省一趟來回，真正說了算的是交易內那次 locking read（見下方）。
   const targetList = await InventoryModel.fetchUserOwnItems(userId, [itemId]);
   if (targetList.length !== 0) {
     return res.status(400).json({
@@ -30,37 +94,89 @@ exports.exchangeItem = async function (req, res) {
     });
   }
 
-  // 檢查是否有足夠的女神石
-  const godStone = await GachaModel.getUserGodStoneCount(userId);
-  if (godStone < itemInfo.price) {
+  const price = parseInt(itemInfo.price, 10);
+  // 商品價格來自 DB，理論上可信，但壞資料（NULL／非數字／負數）會讓扣款變成加錢。
+  if (!Number.isInteger(price) || price < 0) {
     return res.status(400).json({
-      error: i18n.__("api.error.gacha.shop.notEnoughGodStone"),
+      error: i18n.__("api.error.gacha.shop.itemNotFound"),
     });
   }
 
   const character = await gacha.find(itemId);
+  if (!character) {
+    return res.status(400).json({
+      error: i18n.__("api.error.gacha.shop.itemNotFound"),
+    });
+  }
 
-  // 兌換物品
-  // 1. 扣除女神石
-  // 2. 加入物品
-  const remainGodStone = parseInt(godStone) - parseInt(itemInfo.price);
-  console.log("使用女神石兌換物品", itemInfo.price, remainGodStone, godStone);
-  await InventoryModel.deleteItem(userId, 999);
-  await InventoryModel.insertItems([
-    {
+  let outcome;
+
+  // 女神石是 append-only 帳本（餘額 = SUM(itemAmount)）。
+  // 舊寫法是「讀餘額 → 刪掉使用者所有 999 列 → 插一列剩餘額」，等於把整本帳
+  // 壓成單一列：只要在讀跟刪之間有任何一筆入帳（公開市場退款、成交撥款、轉帳），
+  // 那筆錢會連同舊列一起被刪除且不在剩餘額裡 —— 使用者的錢憑空消失。
+  // 改成只 append 一列負數，其他來源的列碰都不碰。
+  //
+  // 鎖序：先鎖 999（餘額）再鎖 itemId（持有），與 PublicMarketService 的
+  // 「999 → itemId」一致，兩邊交錯執行不會反向取鎖。
+  await mysql.transaction(async trx => {
+    const balanceRow = await trx("inventory")
+      .where({ userId, itemId: GOD_STONE_ITEM_ID })
+      .sum({ amount: "itemAmount" })
+      .forUpdate()
+      .first();
+    const godStone = Number((balanceRow && balanceRow.amount) || 0);
+
+    // 權威的重複持有檢查。交易外那次是快取式的 fast-path，讀的是自己交易開始前的
+    // 快照，兩個並發請求會雙雙看到「還沒有」而各寫入一次，同一角色拿到兩隻。
+    // FOR UPDATE 讀最新已提交版本並上鎖，後到的那筆在這裡排隊，醒來就看得到。
+    const ownedRow = await trx("inventory")
+      .where({ userId, itemId })
+      .sum({ amount: "itemAmount" })
+      .forUpdate()
+      .first();
+    if (Number((ownedRow && ownedRow.amount) || 0) > 0) {
+      outcome = { ok: false, code: "exchanged" };
+      return;
+    }
+
+    if (godStone < price) {
+      outcome = { ok: false, code: "notEnoughGodStone" };
+      return;
+    }
+
+    await InventoryModel.inventory.create(
+      {
+        userId,
+        itemId,
+        itemAmount: quantity,
+        attributes: JSON.stringify([{ key: "star", value: character.Star }]),
+        note: `god_stone_shop:exchange:${itemId}`,
+      },
+      trx
+    );
+
+    await InventoryModel.inventory.decreaseGodStone({
       userId,
-      itemId,
-      itemAmount: itemCount,
-      attributes: JSON.stringify([{ key: "star", value: character.Star }]),
-    },
-    { userId, itemId: 999, itemAmount: remainGodStone },
-  ]);
+      amount: price,
+      note: `god_stone_shop:exchange:${itemId}`,
+      trx,
+    });
+
+    outcome = { ok: true, remainGodStone: godStone - price };
+  });
+
+  if (!outcome.ok) {
+    return res.status(400).json({
+      error: i18n.__(`api.error.gacha.shop.${outcome.code}`),
+    });
+  }
 
   await AchievementEngine.evaluate(userId, "shop_exchange", {
-    spend: parseInt(itemInfo.price) * parseInt(itemCount),
+    spend: price * quantity,
   }).catch(() => {});
 
-  res.json({ userId, itemId, itemCount, remainGodStone });
+  res.json({ userId, itemId, itemCount: quantity, remainGodStone: outcome.remainGodStone });
 };
 
 /**

--- a/app/src/model/application/PublicMarket.js
+++ b/app/src/model/application/PublicMarket.js
@@ -1,6 +1,8 @@
 const base = require("../base");
 
 const OPEN = "open";
+const SELL = "sell";
+const BUY = "buy";
 
 class PublicMarket extends base {
   /**
@@ -15,8 +17,8 @@ class PublicMarket extends base {
   }
 
   /**
-   * 同 getById，但加上 `FOR UPDATE` 行鎖 —— 購買流程用，
-   * 兩個買家同時打進來時第二個會卡在這裡直到第一個 commit，
+   * 同 getById，但加上 `FOR UPDATE` 行鎖 —— 購買／履約流程用，
+   * 兩個人同時打進來時第二個會卡在這裡直到第一個 commit，
    * 之後讀到的 status 已是 sold，於是拿到 ALREADY_TAKEN。
    * @param {Number} id
    * @param {import("knex").Knex.Transaction} trx
@@ -30,6 +32,7 @@ class PublicMarket extends base {
       .select([
         { id: `${this.table}.id` },
         { itemId: "item_id" },
+        { orderType: "order_type" },
         { sellerId: "seller_id" },
         { buyerId: "buyer_id" },
         "price",
@@ -46,11 +49,18 @@ class PublicMarket extends base {
   }
 
   /**
-   * 掛單簿：目前有開放掛單的角色，附掛單數與最低價。
+   * 掛單簿：某方向目前有開放掛單的角色，附掛單數與「最佳價」。
+   * 最佳價的定義隨方向翻轉：賣單是最低售價（買方角度最划算），
+   * 收購單是最高收購價（賣方角度最划算）。排序同理。
+   *
    * Star 一併帶出給前端渲染 ★；它跟著 item_id 走（函數相依），
    * 但 MySQL 8 預設 ONLY_FULL_GROUP_BY 不認這層推導，所以必須列進 groupBy。
+   *
+   * @param {"sell"|"buy"} [orderType]
    */
-  getOpenCharacters() {
+  getOpenCharacters(orderType = SELL) {
+    const isBuy = orderType === BUY;
+
     return this.qb()
       .select([
         { itemId: `${this.table}.item_id` },
@@ -58,43 +68,70 @@ class PublicMarket extends base {
         { headImage: "gacha_pool.HeadImage_Url" },
         { star: "gacha_pool.Star" },
         { listingCount: this.connection.raw("COUNT(*)") },
-        { minPrice: this.connection.raw("MIN(`price`)") },
+        {
+          bestPrice: this.connection.raw(isBuy ? "MAX(`price`)" : "MIN(`price`)"),
+        },
       ])
       .leftJoin("gacha_pool", "gacha_pool.ID", `${this.table}.item_id`)
-      .where({ status: OPEN })
+      .where({ status: OPEN, order_type: orderType })
       .groupBy(
         `${this.table}.item_id`,
         "gacha_pool.Name",
         "gacha_pool.HeadImage_Url",
         "gacha_pool.Star"
       )
-      .orderBy("minPrice", "asc");
+      .orderBy("bestPrice", isBuy ? "desc" : "asc");
   }
 
   /**
-   * 某角色的開放掛單，價低優先。
+   * 某角色某方向的開放掛單。賣單價低優先、收購單價高優先。
    * @param {Number} itemId
+   * @param {"sell"|"buy"} [orderType]
    */
-  getOpenListingsByItemId(itemId) {
+  getOpenListingsByItemId(itemId, orderType = SELL) {
     return this.selectWithName()
-      .where({ [`${this.table}.item_id`]: itemId, [`${this.table}.status`]: OPEN })
-      .orderBy("price", "asc")
+      .where({
+        [`${this.table}.item_id`]: itemId,
+        [`${this.table}.status`]: OPEN,
+        [`${this.table}.order_type`]: orderType,
+      })
+      .orderBy("price", orderType === BUY ? "desc" : "asc")
       .orderBy(`${this.table}.id`, "asc");
   }
 
   /**
-   * 賣家的開放掛單。
-   * @param {String} sellerId
+   * 發布者的開放掛單（賣單 + 收購單）。
+   *
+   * 「發布者」欄位隨方向不同：賣單看 seller_id，收購單看 buyer_id
+   * （收購單開著的時候 seller_id 是 NULL，成交才填上履約的人）。
+   *
+   * @param {String} userId
    * @param {import("knex").Knex.Transaction} [trx]
    */
-  getOpenListingsBySeller(sellerId, trx) {
+  getOpenListingsByRequester(userId, trx) {
     return this.selectWithName(trx)
-      .where({ [`${this.table}.seller_id`]: sellerId, [`${this.table}.status`]: OPEN })
+      .where({ [`${this.table}.status`]: OPEN })
+      .where(qb => this.applyRequesterFilter(qb, userId))
       .orderBy(`${this.table}.created_at`, "desc");
   }
 
   /**
-   * 使用者參與過、已結束的掛單（賣家或買家皆算）。
+   * 「這張單是不是 userId 發的」的 where 片段，兩個方向各看各的欄位。
+   * @param {import("knex").Knex.QueryBuilder} qb
+   * @param {String} userId
+   */
+  applyRequesterFilter(qb, userId) {
+    return qb
+      .where(inner =>
+        inner.where(`${this.table}.order_type`, SELL).andWhere(`${this.table}.seller_id`, userId)
+      )
+      .orWhere(inner =>
+        inner.where(`${this.table}.order_type`, BUY).andWhere(`${this.table}.buyer_id`, userId)
+      );
+  }
+
+  /**
+   * 使用者參與過、已結束的掛單（賣家或買家皆算，兩個方向都包含）。
    * @param {String} userId
    * @param {Number} limit
    */
@@ -109,21 +146,29 @@ class PublicMarket extends base {
   }
 
   /**
-   * 賣家目前開放掛單數。
-   * @param {String} sellerId
+   * 發布者目前的開放掛單數 —— 賣單與收購單「合計」，上限是共用的。
+   *
+   * 刻意「不」加 FOR UPDATE。這個 where 是跨兩支索引的 OR，加鎖會變成範圍鎖甚至全表掃描，
+   * 而呼叫端（發收購單）當下正握著自己 inventory 的餘額鎖 —— purchase / fulfill 的鎖序
+   * 卻是「先掛單列、後 inventory」，兩邊相反就有死鎖。
+   * 正確性由呼叫端保證：發單流程的第一個語句是餘額的 locking read，同一使用者的並發
+   * 發單已經在那裡排隊；等它醒來才做這次計數，快照建立在前一筆 commit 之後，數得到。
+   *
+   * @param {String} userId
    * @param {import("knex").Knex.Transaction} [trx]
    * @returns {Promise<Number>}
    */
-  async countOpenBySeller(sellerId, trx) {
+  async countOpenByRequester(userId, trx) {
     const row = await this.qb(trx)
-      .where({ seller_id: sellerId, status: OPEN })
+      .where({ status: OPEN })
+      .where(qb => this.applyRequesterFilter(qb, userId))
       .count({ c: "*" })
       .first();
     return Number(row && row.c ? row.c : 0);
   }
 
   /**
-   * 全站開放掛單數。
+   * 全站開放掛單數（兩個方向合計）。
    * @returns {Promise<Number>}
    */
   async countOpen() {
@@ -132,17 +177,32 @@ class PublicMarket extends base {
   }
 
   /**
-   * 賣家是否已對同一角色掛過單。
+   * 賣家是否已對同一角色掛過賣單。
    * @param {String} sellerId
    * @param {Number} itemId
    * @param {import("knex").Knex.Transaction} [trx]
    */
   findOpenBySellerAndItem(sellerId, itemId, trx) {
-    return this.qb(trx).where({ seller_id: sellerId, item_id: itemId, status: OPEN }).first();
+    return this.qb(trx)
+      .where({ seller_id: sellerId, item_id: itemId, status: OPEN, order_type: SELL })
+      .first();
   }
 
   /**
-   * 條件式成交：只有還在 open 的列會被更新，回傳受影響列數。
+   * 買家是否已對同一角色掛過收購單。同一角色同時只能有一張，
+   * 否則同一個人可以用多張單把自己的餘額重複預扣到不成比例。
+   * @param {String} buyerId
+   * @param {Number} itemId
+   * @param {import("knex").Knex.Transaction} [trx]
+   */
+  findOpenBuyByBuyerAndItem(buyerId, itemId, trx) {
+    return this.qb(trx)
+      .where({ buyer_id: buyerId, item_id: itemId, status: OPEN, order_type: BUY })
+      .first();
+  }
+
+  /**
+   * 條件式成交（賣單）：只有還在 open 的賣單會被更新，回傳受影響列數。
    * 即使沒有 FOR UPDATE 也不可能兩個買家都拿到 1。
    * @param {Number} id
    * @param {String} buyerId
@@ -151,12 +211,27 @@ class PublicMarket extends base {
    */
   markSold(id, buyerId, trx) {
     return this.qb(trx)
-      .where({ id, status: OPEN })
+      .where({ id, status: OPEN, order_type: SELL })
       .update({ status: "sold", buyer_id: buyerId, sold_at: new Date() });
   }
 
   /**
-   * 條件式關閉（取消 / 失效）。
+   * 條件式履約（收購單）：把履約者寫進 seller_id 並結案。
+   * 帶上 order_type 條件，賣單絕不可能走到這條路徑上。
+   * @param {Number} id
+   * @param {String} sellerId 履約者（賣出角色的人）
+   * @param {import("knex").Knex.Transaction} trx
+   * @returns {Promise<Number>}
+   */
+  markFulfilled(id, sellerId, trx) {
+    return this.qb(trx)
+      .where({ id, status: OPEN, order_type: BUY })
+      .update({ status: "sold", seller_id: sellerId, sold_at: new Date() });
+  }
+
+  /**
+   * 條件式關閉（取消 / 失效）。受影響列數為 0 代表別人先關掉了 ——
+   * 收購單的退款一律綁在這個回傳值上，才不會退兩次。
    * @param {Number} id
    * @param {"cancelled"|"invalid"} status
    * @param {import("knex").Knex.Transaction} [trx]
@@ -169,5 +244,15 @@ class PublicMarket extends base {
 
 module.exports = new PublicMarket({
   table: "public_market",
-  fillable: ["seller_id", "buyer_id", "item_id", "price", "fee", "status", "sold_at", "closed_at"],
+  fillable: [
+    "order_type",
+    "seller_id",
+    "buyer_id",
+    "item_id",
+    "price",
+    "fee",
+    "status",
+    "sold_at",
+    "closed_at",
+  ],
 });

--- a/app/src/router/PublicMarket/index.js
+++ b/app/src/router/PublicMarket/index.js
@@ -6,18 +6,25 @@ const { DefaultLogger } = require("../../util/Logger");
 
 const MESSAGES = {
   NOT_FOUND: "找不到這筆委託",
-  FORBIDDEN: "你不是這筆委託的賣家",
+  // 賣單與收購單共用這個碼，文案改成發布者語意才兩邊都說得通。
+  FORBIDDEN: "你不是這筆委託的發布者",
   NOT_OPEN: "這筆委託已結束，無法再操作",
   INVALID_PRICE: `價格必須是 ${PublicMarketService.MIN_PRICE} ～ ${PublicMarketService.MAX_PRICE} 的整數`,
   INVALID_ITEM: "角色 ID 不正確",
-  LISTING_CAP: `最多只能同時掛 ${PublicMarketService.MAX_OPEN_LISTINGS} 筆委託`,
+  INVALID_ORDER_TYPE: "委託方向不正確",
+  WRONG_ORDER_TYPE: "這筆委託不是用這種方式成交的",
+  LISTING_CAP: `最多只能同時掛 ${PublicMarketService.MAX_OPEN_LISTINGS} 筆委託（賣單與收購單合計）`,
   NOT_OWNED: "你沒有這個角色",
   ALREADY_LISTED: "你已經掛過這個角色了",
+  ALREADY_REQUESTED: "你已經有這個角色的收購單了",
   ALREADY_TAKEN: "此委託已被其他玩家買走或取消",
   INSUFFICIENT_FUNDS: "女神石不足",
+  NOT_ENOUGH_TO_RESERVE: "女神石不足，發布收購單時需要先預扣全額",
   ALREADY_OWNED: "你已經擁有這個角色了",
+  ALREADY_OWNED_REQUESTER: "收購方已經有這個角色了，收購單已失效並全額退款",
   SELLER_LOST_ITEM: "賣家已無此角色，系統已自動下架這筆委託",
   IS_SELLER: "不能購買自己的委託",
+  IS_BUYER: "不能賣給自己的收購單",
   INTERNAL: "系統忙碌中，請稍後再試",
 };
 
@@ -52,8 +59,10 @@ router.get(
 router.get(
   "/public-market/characters",
   verifyToken,
-  asyncHandler(async (_req, res) => {
-    res.json(await PublicMarketService.getOpenCharacters());
+  asyncHandler(async (req, res) => {
+    // 讀取端一律寬鬆解析：網址被亂改時退回賣單簿，不要噴 400 讓整頁掛掉。
+    const orderType = PublicMarketService.normalizeOrderType(req.query.orderType);
+    res.json(await PublicMarketService.getOpenCharacters(orderType));
   })
 );
 
@@ -66,7 +75,9 @@ router.get(
     const itemId = parseId(req.query.itemId);
     if (!itemId) return fail(res, 400, "INVALID_ITEM");
 
-    res.json(await PublicMarketService.getListingsByItemId(itemId, req.profile.userId));
+    const orderType = PublicMarketService.normalizeOrderType(req.query.orderType);
+
+    res.json(await PublicMarketService.getListingsByItemId(itemId, req.profile.userId, orderType));
   })
 );
 
@@ -100,13 +111,27 @@ router.post(
     const itemId = Number(req.body.itemId);
     const price = Number(req.body.price);
 
+    // 寫入端嚴格解析：方向拼錯會決定錢往哪個方向流，不能靜靜地當成賣單。
+    const orderType = PublicMarketService.parseOrderType(req.body.orderType);
+    if (orderType === null) return fail(res, 400, "INVALID_ORDER_TYPE");
+
     if (!Number.isInteger(itemId) || itemId <= 0) return fail(res, 400, "INVALID_ITEM");
     if (!PublicMarketService.isValidPrice(price)) return fail(res, 400, "INVALID_PRICE");
 
-    const result = await PublicMarketService.createListing(userId, { itemId, price });
+    const result = await PublicMarketService.createListing(userId, { itemId, price, orderType });
     if (result.ok) return res.status(201).json(result.listing);
 
     if (result.code === "INVALID_PRICE") return fail(res, 400, result.code);
+    if (result.code === "INVALID_ORDER_TYPE") return fail(res, 400, result.code);
+    if (result.code === "INVALID_ITEM") return fail(res, 400, result.code);
+    if (result.code === "NOT_ENOUGH_TO_RESERVE") {
+      return fail(res, 409, result.code, {
+        balance: result.balance,
+        price: result.price,
+        shortfall: result.shortfall,
+      });
+    }
+
     return fail(res, 409, result.code, {
       ...(result.code === "LISTING_CAP"
         ? { myOpenCount: result.myOpenCount, maxOpen: result.maxOpen }
@@ -123,7 +148,14 @@ router.delete(
     if (!id) return fail(res, 404, "NOT_FOUND");
 
     const result = await PublicMarketService.cancelListing(id, req.profile.userId);
-    if (result.ok) return res.json({ listingId: result.listingId, status: "cancelled" });
+    if (result.ok) {
+      return res.json({
+        listingId: result.listingId,
+        status: "cancelled",
+        // 賣單沒有退款這回事，欄位就不出現，前端用 `?? price` 自己處理。
+        ...(result.refundedAmount != null ? { refundedAmount: result.refundedAmount } : {}),
+      });
+    }
 
     if (result.code === "NOT_FOUND") return fail(res, 404, result.code);
     if (result.code === "FORBIDDEN") return fail(res, 403, result.code);
@@ -160,6 +192,38 @@ router.post(
         price: result.price,
         shortfall: result.shortfall,
       });
+    }
+
+    return fail(res, 409, result.code);
+  })
+);
+
+router.post(
+  "/public-market/listings/:id/fulfill",
+  verifyToken,
+  asyncHandler(async (req, res) => {
+    const id = parseId(req.params.id);
+    if (!id) return fail(res, 404, "NOT_FOUND");
+
+    const result = await PublicMarketService.fulfill(id, req.profile.userId);
+
+    if (result.ok) {
+      // 履約者不扣款也不需要餘額快照：service 沒讀他的餘額，回傳 netProceeds 就夠前端算。
+      return res.json({
+        listingId: result.listingId,
+        itemId: result.itemId,
+        name: result.name,
+        price: result.price,
+        fee: result.fee,
+        netProceeds: result.netProceeds,
+      });
+    }
+
+    if (result.code === "NOT_FOUND") return fail(res, 404, result.code);
+    if (result.code === "IS_BUYER") return fail(res, 403, result.code);
+    if (result.code === "ALREADY_OWNED_REQUESTER") {
+      // 前端靠這個碼把畫面降級成「已失效」，refundedAmount 是退給收購方的金額。
+      return fail(res, 409, result.code, { refundedAmount: result.refundedAmount });
     }
 
     return fail(res, 409, result.code);

--- a/app/src/router/__tests__/PublicMarket.test.js
+++ b/app/src/router/__tests__/PublicMarket.test.js
@@ -1,7 +1,15 @@
-// 一次性接線檢查：router 有掛上預期路徑、template 產出的動態欄位正確。
+// 一次性接線檢查：router 有掛上預期路徑、回應欄位白名單、template 產出的動態欄位正確。
 jest.mock("../../service/PublicMarketService", () => {
   const actual = jest.requireActual("../../service/PublicMarketService");
-  return { ...actual, purchase: jest.fn() };
+  return {
+    ...actual,
+    purchase: jest.fn(),
+    fulfill: jest.fn(),
+    createListing: jest.fn(),
+    cancelListing: jest.fn(),
+    getOpenCharacters: jest.fn(),
+    getListingsByItemId: jest.fn(),
+  };
 });
 
 const request = require("supertest");
@@ -10,8 +18,24 @@ const routerModule = require("../../router/PublicMarket");
 const PublicMarketService = require("../../service/PublicMarketService");
 const { generateMarketBubble } = require("../../templates/application/PublicMarket");
 
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", routerModule.router);
+  return app;
+}
+
+const SELLER = "U" + "1".repeat(32);
+const BUYER = "U" + "2".repeat(32);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  PublicMarketService.getOpenCharacters.mockResolvedValue([]);
+  PublicMarketService.getListingsByItemId.mockResolvedValue([]);
+});
+
 describe("PublicMarket 接線", () => {
-  it("router 掛上全部 8 條路徑", () => {
+  it("router 掛上全部 9 條路徑", () => {
     const routes = routerModule.router.stack
       .filter(l => l.route)
       .map(l => `${Object.keys(l.route.methods)[0].toUpperCase()} ${l.route.path}`);
@@ -25,6 +49,7 @@ describe("PublicMarket 接線", () => {
       "POST /public-market/listings",
       "DELETE /public-market/listings/:id",
       "POST /public-market/listings/:id/purchase",
+      "POST /public-market/listings/:id/fulfill",
     ]);
   });
 
@@ -50,7 +75,7 @@ describe("PublicMarket 接線", () => {
     expect(bubble.body.contents[1].contents[0].width).toBe(expected);
   });
 
-  it("footer 兩顆按鈕都是 LIFF 連結，沒有殘留 PLACEHOLDER", () => {
+  it("footer 三顆按鈕都是 LIFF 連結，含發布收購單入口", () => {
     const bubble = generateMarketBubble({
       myOpenCount: 3,
       maxOpen: 10,
@@ -59,13 +84,26 @@ describe("PublicMarket 接線", () => {
     });
     const uris = bubble.footer.contents.map(b => b.action.uri);
 
-    expect(uris).toHaveLength(2);
+    expect(uris).toHaveLength(3);
     uris.forEach(uri => {
       expect(uri).toContain("https://liff.line.me/");
       expect(uri).not.toContain("PLACEHOLDER");
     });
     expect(uris[0]).toContain("/trade/market");
     expect(uris[1]).toContain("/trade/sell");
+    expect(uris[2]).toContain("/trade/buy");
+  });
+
+  it("配額文案講明是買賣合計，玩家才不會以為兩種各 10 筆", () => {
+    const bubble = generateMarketBubble({
+      myOpenCount: 3,
+      maxOpen: 10,
+      totalOpenCount: 128,
+      feePercent: 5,
+    });
+
+    expect(bubble.body.contents[0].contents[0].text).toBe("我的開放委託");
+    expect(bubble.body.contents[2].text).toBe("賣單 + 收購單合計");
   });
 
   it("header 漸層與文案與設計稿一致", () => {
@@ -85,26 +123,198 @@ describe("PublicMarket 接線", () => {
     expect(bubble.header.contents[0].contents[0].text).toBe("公開市場");
     expect(bubble.header.contents[0].contents[1].text).toBe("手續費 5%");
     expect(bubble.body.contents[0].contents[1].text).toBe("3 / 10");
-    expect(bubble.body.contents[3].contents[1].text).toBe("128 筆");
+    expect(bubble.body.contents[4].contents[1].text).toBe("128 筆");
   });
 });
 
-describe("購買回應欄位白名單", () => {
-  function createApp() {
-    const app = express();
-    app.use(express.json());
-    app.use("/api", routerModule.router);
-    return app;
-  }
+describe("讀取端 orderType", () => {
+  it("GET /characters 缺省查賣單簿", async () => {
+    await request(createApp()).get("/api/public-market/characters");
 
-  it("service 回傳的 sellerId 不會外洩到 HTTP 回應", async () => {
+    expect(PublicMarketService.getOpenCharacters).toHaveBeenCalledWith("sell");
+  });
+
+  it("GET /characters?orderType=buy 查收購簿", async () => {
+    await request(createApp()).get("/api/public-market/characters?orderType=buy");
+
+    expect(PublicMarketService.getOpenCharacters).toHaveBeenCalledWith("buy");
+  });
+
+  it("GET /characters?orderType=亂寫 安靜退回賣單簿，不讓整頁掛掉", async () => {
+    const res = await request(createApp()).get("/api/public-market/characters?orderType=nonsense");
+
+    expect(res.status).toBe(200);
+    expect(PublicMarketService.getOpenCharacters).toHaveBeenCalledWith("sell");
+  });
+
+  it("GET /listings 缺省查賣單，帶 buy 查收購單", async () => {
+    const app = createApp();
+
+    await request(app).get("/api/public-market/listings?itemId=101");
+    expect(PublicMarketService.getListingsByItemId).toHaveBeenLastCalledWith(
+      101,
+      expect.any(String),
+      "sell"
+    );
+
+    await request(app).get("/api/public-market/listings?itemId=101&orderType=buy");
+    expect(PublicMarketService.getListingsByItemId).toHaveBeenLastCalledWith(
+      101,
+      expect.any(String),
+      "buy"
+    );
+  });
+
+  it("GET /listings 缺 itemId 回 400 INVALID_ITEM", async () => {
+    const res = await request(createApp()).get("/api/public-market/listings");
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_ITEM");
+    expect(PublicMarketService.getListingsByItemId).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /listings 方向分派", () => {
+  it("缺省 orderType 走賣單", async () => {
+    PublicMarketService.createListing.mockResolvedValue({ ok: true, listing: { id: 1 } });
+
+    const res = await request(createApp())
+      .post("/api/public-market/listings")
+      .send({ itemId: 101, price: 1000 });
+
+    expect(res.status).toBe(201);
+    expect(PublicMarketService.createListing).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ itemId: 101, price: 1000, orderType: "sell" })
+    );
+  });
+
+  it("orderType=buy 帶到 service", async () => {
+    PublicMarketService.createListing.mockResolvedValue({
+      ok: true,
+      listing: { id: 2, orderType: "buy" },
+    });
+
+    const res = await request(createApp())
+      .post("/api/public-market/listings")
+      .send({ itemId: 101, price: 1000, orderType: "buy" });
+
+    expect(res.status).toBe(201);
+    expect(PublicMarketService.createListing).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ orderType: "buy" })
+    );
+  });
+
+  it("方向拼錯回 400 INVALID_ORDER_TYPE，完全不進 service", async () => {
+    const res = await request(createApp())
+      .post("/api/public-market/listings")
+      .send({ itemId: 101, price: 1000, orderType: "sel" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_ORDER_TYPE");
+    expect(PublicMarketService.createListing).not.toHaveBeenCalled();
+  });
+
+  it("NOT_ENOUGH_TO_RESERVE 回 409 並附差額，前端才寫得出還差多少", async () => {
+    PublicMarketService.createListing.mockResolvedValue({
+      ok: false,
+      code: "NOT_ENOUGH_TO_RESERVE",
+      balance: 300,
+      price: 1000,
+      shortfall: 700,
+    });
+
+    const res = await request(createApp())
+      .post("/api/public-market/listings")
+      .send({ itemId: 101, price: 1000, orderType: "buy" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "NOT_ENOUGH_TO_RESERVE",
+      balance: 300,
+      price: 1000,
+      shortfall: 700,
+    });
+  });
+
+  it.each(["ALREADY_REQUESTED", "ALREADY_OWNED", "ALREADY_LISTED"])(
+    "%s 回 409 且訊息不是 undefined",
+    async code => {
+      PublicMarketService.createListing.mockResolvedValue({ ok: false, code });
+
+      const res = await request(createApp())
+        .post("/api/public-market/listings")
+        .send({ itemId: 101, price: 1000, orderType: "buy" });
+
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe(code);
+      expect(typeof res.body.message).toBe("string");
+      expect(res.body.message.length).toBeGreaterThan(0);
+    }
+  );
+
+  it("LISTING_CAP 帶出配額數字", async () => {
+    PublicMarketService.createListing.mockResolvedValue({
+      ok: false,
+      code: "LISTING_CAP",
+      myOpenCount: 10,
+      maxOpen: 10,
+    });
+
+    const res = await request(createApp())
+      .post("/api/public-market/listings")
+      .send({ itemId: 101, price: 1000, orderType: "buy" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "LISTING_CAP", myOpenCount: 10, maxOpen: 10 });
+    expect(res.body.message).toContain("合計");
+  });
+});
+
+describe("DELETE /listings/:id", () => {
+  it("賣單取消不帶 refundedAmount", async () => {
+    PublicMarketService.cancelListing.mockResolvedValue({ ok: true, listingId: 42 });
+
+    const res = await request(createApp()).delete("/api/public-market/listings/42");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ listingId: 42, status: "cancelled" });
+  });
+
+  it("收購單取消回 refundedAmount", async () => {
+    PublicMarketService.cancelListing.mockResolvedValue({
+      ok: true,
+      listingId: 42,
+      refundedAmount: 8600,
+    });
+
+    const res = await request(createApp()).delete("/api/public-market/listings/42");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ listingId: 42, status: "cancelled", refundedAmount: 8600 });
+  });
+
+  it("非發布者回 403，文案是發布者語意（賣單收購單共用這個碼）", async () => {
+    PublicMarketService.cancelListing.mockResolvedValue({ ok: false, code: "FORBIDDEN" });
+
+    const res = await request(createApp()).delete("/api/public-market/listings/42");
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN");
+    expect(res.body.message).toBe("你不是這筆委託的發布者");
+  });
+});
+
+describe("購買 / 履約回應欄位白名單", () => {
+  it("purchase：service 回傳的 sellerId 不會外洩到 HTTP 回應", async () => {
     // service 內部帶 sellerId 只為了 commit 後結算成就，不該讓買家看到賣家的 LINE userId
     PublicMarketService.purchase.mockResolvedValue({
       ok: true,
       listingId: 42,
       itemId: 101,
       name: "佩可莉ーヌ",
-      sellerId: "U" + "1".repeat(32),
+      sellerId: SELLER,
       price: 1000,
       fee: 50,
       netProceeds: 950,
@@ -124,5 +334,88 @@ describe("購買回應欄位白名單", () => {
       balanceAfter: 4000,
     });
     expect(res.body).not.toHaveProperty("sellerId");
+  });
+
+  it("fulfill：service 回傳的 buyerId 不會外洩", async () => {
+    PublicMarketService.fulfill.mockResolvedValue({
+      ok: true,
+      listingId: 55,
+      itemId: 101,
+      name: "佩可莉ーヌ",
+      buyerId: BUYER,
+      price: 8600,
+      fee: 430,
+      netProceeds: 8170,
+    });
+
+    const res = await request(createApp()).post("/api/public-market/listings/55/fulfill");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      listingId: 55,
+      itemId: 101,
+      name: "佩可莉ーヌ",
+      price: 8600,
+      fee: 430,
+      netProceeds: 8170,
+    });
+    expect(res.body).not.toHaveProperty("buyerId");
+    expect(res.body).not.toHaveProperty("sellerId");
+  });
+
+  it("fulfill 的 ALREADY_OWNED_REQUESTER 回 409 + refundedAmount，前端靠這個碼降級畫面", async () => {
+    PublicMarketService.fulfill.mockResolvedValue({
+      ok: false,
+      code: "ALREADY_OWNED_REQUESTER",
+      refundedAmount: 8600,
+    });
+
+    const res = await request(createApp()).post("/api/public-market/listings/55/fulfill");
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "ALREADY_OWNED_REQUESTER",
+      refundedAmount: 8600,
+    });
+  });
+
+  it("fulfill 的 NOT_OWNED 回 409，且不帶任何退款欄位（單子還開著）", async () => {
+    PublicMarketService.fulfill.mockResolvedValue({ ok: false, code: "NOT_OWNED" });
+
+    const res = await request(createApp()).post("/api/public-market/listings/55/fulfill");
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("NOT_OWNED");
+    expect(res.body).not.toHaveProperty("refundedAmount");
+  });
+
+  it("fulfill 自己的收購單回 403 IS_BUYER", async () => {
+    PublicMarketService.fulfill.mockResolvedValue({ ok: false, code: "IS_BUYER" });
+
+    const res = await request(createApp()).post("/api/public-market/listings/55/fulfill");
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("IS_BUYER");
+  });
+
+  it.each([
+    ["purchase", "purchase"],
+    ["fulfill", "fulfill"],
+  ])("%s 的 WRONG_ORDER_TYPE 回 409 且有可讀訊息", async (path, method) => {
+    PublicMarketService[method].mockResolvedValue({ ok: false, code: "WRONG_ORDER_TYPE" });
+
+    const res = await request(createApp()).post(`/api/public-market/listings/55/${path}`);
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("WRONG_ORDER_TYPE");
+    expect(res.body.message).not.toBe(undefined);
+  });
+
+  it.each(["purchase", "fulfill"])("%s 的 id 不合法回 404，不進 service", async path => {
+    const res = await request(createApp()).post(`/api/public-market/listings/abc/${path}`);
+
+    expect(res.status).toBe(404);
+    expect(PublicMarketService.purchase).not.toHaveBeenCalled();
+    expect(PublicMarketService.fulfill).not.toHaveBeenCalled();
   });
 });

--- a/app/src/service/PublicMarketService.js
+++ b/app/src/service/PublicMarketService.js
@@ -12,9 +12,34 @@ const MIN_PRICE = 1;
 const MAX_PRICE = 10000000;
 const GOD_STONE_ITEM_ID = 999;
 
+const SELL = "sell";
+const BUY = "buy";
+
+/**
+ * 委託方向。缺值一律當賣單 —— 第一階段的資料與連結全部沒有這個欄位。
+ * @param {*} value
+ * @returns {"sell"|"buy"}
+ */
+function normalizeOrderType(value) {
+  return String(value == null ? SELL : value).toLowerCase() === BUY ? BUY : SELL;
+}
+
+/**
+ * 嚴格版：只接受 sell / buy / 缺省，其餘回 null 讓呼叫端擋下來。
+ * 發布委託是會動到錢的動作，方向拼錯不能靜靜地當成賣單。
+ * @param {*} value
+ * @returns {?("sell"|"buy")}
+ */
+function parseOrderType(value) {
+  if (value === undefined || value === null || value === "") return SELL;
+  const normalized = String(value).toLowerCase();
+  return normalized === SELL || normalized === BUY ? normalized : null;
+}
+
 /**
  * 手續費：成交價的 5%，無條件進位。手續費是「銷毀」的 —— 買家付 price，
  * 賣家收 price - fee，沒有第三方入帳，差額直接從流通量消失。
+ * 兩個方向的算法完全一樣，只是誰先付錢不同。
  * @param {Number} price
  * @returns {Number}
  */
@@ -63,7 +88,7 @@ function baseAttributes(character) {
 
 async function getBalance(userId, trx) {
   // 女神石是 append-only 帳本，餘額 = SUM(itemAmount)。
-  // 帶 trx 時加上 FOR UPDATE，讓同一買家的並發購買排隊，避免用同一筆餘額買兩單。
+  // 帶 trx 時加上 FOR UPDATE，讓同一使用者的並發扣款排隊，避免用同一筆餘額付兩次。
   let query = (trx || mysql)("inventory")
     .where({ userId, itemId: GOD_STONE_ITEM_ID })
     .sum({ amount: "itemAmount" });
@@ -74,12 +99,25 @@ async function getBalance(userId, trx) {
   return Number((row && row.amount) || 0);
 }
 
+/**
+ * 持有判定。
+ *
+ * 帶 trx 時是 locking read：REPEATABLE READ 下的普通 SELECT 讀的是交易開始時的快照，
+ * 「檢查完到寫入之間」對方剛拿到角色的話這裡會看不到（賣單購買的既有破口 —— 買家
+ * 在同一瞬間抽到同一隻角色，仍會成交而變成重複持有）。FOR UPDATE 讀最新已提交版本
+ * 並鎖住，把那個空窗關掉。
+ *
+ * @param {String} userId
+ * @param {Number} itemId
+ * @param {import("knex").Knex.Transaction} [trx]
+ * @returns {Promise<Boolean>}
+ */
 async function ownsCharacter(userId, itemId, trx) {
-  const row = await (trx || mysql)("inventory")
-    .where({ userId, itemId })
-    .sum({ amount: "itemAmount" })
-    .first();
+  let query = (trx || mysql)("inventory").where({ userId, itemId }).sum({ amount: "itemAmount" });
 
+  if (trx) query = query.forUpdate();
+
+  const row = await query.first();
   return Number((row && row.amount) || 0) > 0;
 }
 
@@ -95,6 +133,16 @@ async function resolveNames(userIds) {
 }
 
 /**
+ * 發布這張單的人：賣單是賣家，收購單是買家。
+ * 收購單開放期間 seller_id 是 NULL（還沒人履約），所以不能一律看 seller_id。
+ * @param {Object} row model 的 API 形狀資料列（camelCase）
+ * @returns {?String}
+ */
+function requesterIdOf(row) {
+  return normalizeOrderType(row.orderType) === BUY ? row.buyerId || null : row.sellerId || null;
+}
+
+/**
  * 把 model 的資料列整成 API 形狀。
  * star 一律取 gacha_pool 的基礎星數（升星不隨交易轉移），
  * baseStarOf 讀得懂 Star / star 兩種鍵，查無值退回 1。
@@ -105,34 +153,48 @@ async function resolveNames(userIds) {
  * @returns {Object}
  */
 function shapeListing(row, { viewerId, names = {} } = {}) {
-  return {
+  const orderType = normalizeOrderType(row.orderType);
+  const price = Number(row.price);
+  const requesterId = requesterIdOf({ ...row, orderType });
+
+  const listing = {
     id: Number(row.id),
     itemId: Number(row.itemId),
+    orderType,
     name: row.name,
     star: baseStarOf(row),
-    price: Number(row.price),
+    price,
     fee: Number(row.fee),
-    netProceeds: Number(row.price) - Number(row.fee),
+    netProceeds: price - Number(row.fee),
     status: row.status,
-    sellerId: row.sellerId,
-    sellerName: names[row.sellerId] || null,
+    sellerId: row.sellerId || null,
+    sellerName: row.sellerId ? names[row.sellerId] || null : null,
     buyerId: row.buyerId || null,
     buyerName: row.buyerId ? names[row.buyerId] || null : null,
-    mine: viewerId ? row.sellerId === viewerId : undefined,
+    mine: viewerId ? requesterId === viewerId : undefined,
     createdAt: row.createdAt,
     soldAt: row.soldAt || null,
     closedAt: row.closedAt || null,
   };
+
+  // 收購單一旦取消／失效，預扣的女神石一定已全額退回（退款與狀態變更同一筆交易）。
+  // 前端要寫出實際金額，這裡直接給，省得它自己猜。
+  if (orderType === BUY && (row.status === "cancelled" || row.status === "invalid")) {
+    listing.refundedAmount = price;
+  }
+
+  return listing;
 }
 
 /**
  * 首頁／Flex 用的總覽數字。
+ * myOpenCount 是賣單 + 收購單「合計」，上限兩者共用。
  * @param {String} userId
  */
 async function getSummary(userId) {
   const [balance, myOpenCount, totalOpenCount] = await Promise.all([
     getBalance(userId),
-    PublicMarketModel.countOpenBySeller(userId),
+    PublicMarketModel.countOpenByRequester(userId),
     PublicMarketModel.countOpen(),
   ]);
 
@@ -146,35 +208,49 @@ async function getSummary(userId) {
 }
 
 /**
- * 掛單簿：目前有開放掛單的角色。
+ * 掛單簿：某方向目前有開放掛單的角色。
+ * bestPrice 的語意隨方向翻轉：賣單是最低售價，收購單是最高收購價。
+ * @param {"sell"|"buy"} [orderType]
  * @returns {Promise<Array<Object>>}
  */
-async function getOpenCharacters() {
-  const rows = await PublicMarketModel.getOpenCharacters();
+async function getOpenCharacters(orderType = SELL) {
+  const type = normalizeOrderType(orderType);
+  const rows = await PublicMarketModel.getOpenCharacters(type);
+
   return rows.map(row => ({
     itemId: Number(row.itemId),
+    orderType: type,
     name: row.name,
     star: baseStarOf(row),
     headImage: row.headImage,
     listingCount: Number(row.listingCount),
-    minPrice: Number(row.minPrice),
+    bestPrice: Number(row.bestPrice),
   }));
 }
 
 /**
- * 某角色的開放掛單，價低優先。
+ * 某角色某方向的開放掛單。賣單價低優先、收購單價高優先。
  * @param {Number} itemId
  * @param {String} viewerId
+ * @param {"sell"|"buy"} [orderType]
  */
-async function getListingsByItemId(itemId, viewerId) {
-  const rows = await PublicMarketModel.getOpenListingsByItemId(itemId);
-  const names = await resolveNames(rows.map(r => r.sellerId));
+async function getListingsByItemId(itemId, viewerId, orderType = SELL) {
+  const type = normalizeOrderType(orderType);
+  const rows = await PublicMarketModel.getOpenListingsByItemId(itemId, type);
+  const names = await resolveNames(rows.map(r => (type === BUY ? r.buyerId : r.sellerId)));
 
   return rows.map(row => {
-    const listing = shapeListing(row, { viewerId, names });
-    // 掛單簿列表不需要買家欄位（open 掛單本來就沒買家）
-    delete listing.buyerId;
-    delete listing.buyerName;
+    const listing = shapeListing({ ...row, orderType: type }, { viewerId, names });
+
+    // open 掛單沒有對手方，把還沒有意義的欄位剪掉：
+    // 賣單沒有買家、收購單沒有賣家。
+    if (type === BUY) {
+      delete listing.sellerId;
+      delete listing.sellerName;
+    } else {
+      delete listing.buyerId;
+      delete listing.buyerName;
+    }
     delete listing.soldAt;
     delete listing.closedAt;
     delete listing.status;
@@ -183,12 +259,28 @@ async function getListingsByItemId(itemId, viewerId) {
 }
 
 /**
- * 判斷觀看者能不能買這張單，以及不能買的原因。
+ * 判斷觀看者能不能操作這張單，以及不能的原因。
  * 前端會依 blockReason 換整頁畫面，所以順序不能亂：
  * 單子本身不是 open 最優先，其次才是觀看者身分。
+ *
+ * 兩個方向的守門條件不同：
+ *   sell —— 我要付錢買，所以看「是不是自己掛的 / 已經有了 / 錢夠不夠」
+ *   buy  —— 我要交出角色換錢，所以看「是不是自己發的 / 有沒有那隻角色」。
+ *            買家的錢在發單時就預扣了，履約時不需要再驗餘額。
+ *
+ * @param {Object} param0
+ * @param {"sell"|"buy"} [param0.orderType]
+ * @returns {?String}
  */
-function resolveBlockReason({ status, isSeller, owns, balance, price }) {
+function resolveBlockReason({ orderType, status, isSeller, isRequester, owns, balance, price }) {
   if (status !== "open") return "NOT_OPEN";
+
+  if (normalizeOrderType(orderType) === BUY) {
+    if (isRequester) return "IS_BUYER";
+    if (!owns) return "NOT_OWNED";
+    return null;
+  }
+
   if (isSeller) return "IS_SELLER";
   if (owns) return "ALREADY_OWNED";
   if (balance < price) return "INSUFFICIENT_FUNDS";
@@ -211,10 +303,15 @@ async function getListingDetail(id, viewerId) {
   ]);
 
   const listing = shapeListing(row, { viewerId, names });
-  const isSeller = row.sellerId === viewerId;
+  const isBuyOrder = listing.orderType === BUY;
+  const isSeller = !isBuyOrder && row.sellerId === viewerId;
+  const isRequester = isBuyOrder && row.buyerId === viewerId;
+
   const blockReason = resolveBlockReason({
+    orderType: listing.orderType,
     status: row.status,
     isSeller,
+    isRequester,
     owns,
     balance,
     price: listing.price,
@@ -228,14 +325,18 @@ async function getListingDetail(id, viewerId) {
       balance,
       ownsCharacter: owns,
       isSeller,
-      canBuy: blockReason === null,
+      // 收購單的發布者是買家；前端兩個名字都認，兩邊都給省得它猜。
+      isBuyer: isRequester,
+      isRequester,
+      canBuy: !isBuyOrder && blockReason === null,
+      canFulfill: isBuyOrder && blockReason === null,
       blockReason,
     },
   };
 }
 
 /**
- * 建立掛單。
+ * 建立賣出委託。
  *
  * ponytail: 掛單「不」把角色從 inventory 移走 —— 純狀態列，取消就是把 status 翻成
  * cancelled，賣家的升星強化自始至終沒被動過（對應文案「解除鎖定，不收手續費，
@@ -248,16 +349,9 @@ async function getListingDetail(id, viewerId) {
  * @param {Number} param1.itemId
  * @param {Number} param1.price
  */
-async function createListing(sellerId, { itemId, price }) {
-  if (!isValidPrice(price)) {
-    return { ok: false, code: "INVALID_PRICE" };
-  }
-
-  if (!Number.isInteger(itemId) || itemId <= 0 || itemId === GOD_STONE_ITEM_ID) {
-    return { ok: false, code: "NOT_OWNED" };
-  }
-
-  const openCount = await PublicMarketModel.countOpenBySeller(sellerId);
+async function createSellListing(sellerId, { itemId, price }) {
+  // 上限是賣單 + 收購單合計，兩種單都佔同一個配額。
+  const openCount = await PublicMarketModel.countOpenByRequester(sellerId);
   if (openCount >= MAX_OPEN_LISTINGS) {
     return { ok: false, code: "LISTING_CAP", myOpenCount: openCount, maxOpen: MAX_OPEN_LISTINGS };
   }
@@ -272,6 +366,7 @@ async function createListing(sellerId, { itemId, price }) {
   }
 
   const id = await PublicMarketModel.create({
+    order_type: SELL,
     seller_id: sellerId,
     item_id: itemId,
     price,
@@ -281,30 +376,212 @@ async function createListing(sellerId, { itemId, price }) {
 
   const row = await PublicMarketModel.getById(id);
   const names = await resolveNames([sellerId]);
-  const listing = shapeListing(row, { viewerId: sellerId, names });
 
-  return { ok: true, listing };
+  return { ok: true, listing: shapeListing(row, { viewerId: sellerId, names }) };
 }
 
 /**
- * 賣家取消掛單。不收手續費，角色本來就沒離開過賣家身上。
+ * 建立收購委託。
+ *
+ * 與賣單最大的差別：收購單「先付錢」。發布當下就把全額從買家帳上扣走（預扣／escrow），
+ * 履約時買家不再扣款。理由是履約的人交出的是不可逆的資產（角色離開 box），
+ * 不能讓他成交後才發現對方沒錢 —— 那筆角色收不回來。
+ *
+ * 交易內的順序固定為：
+ *   1. 餘額 locking read —— 同一買家的並發發單在這裡排隊，這是本流程唯一的序列化點。
+ *      因為它先跑，之後的計數／重複檢查讀到的都是前一筆 commit 之後的狀態，
+ *      掛單上限與「同角色一張」不需要再各自加鎖（在 public_market 上加範圍鎖會與
+ *      purchase / fulfill 的「掛單列 → inventory」鎖序相反，換來死鎖）。
+ *   2. 掛單數合計檢查
+ *   3. 持有／重複單檢查
+ *   4. 寫入掛單列
+ *   5. 預扣
+ * 先鎖錢再做其他檢查，是因為之後才鎖的話，兩張同時進來的單會各自讀到扣款前的餘額，
+ * 兩張都通過檢查而把餘額扣成負的。
+ *
+ * @param {String} buyerId
+ * @param {Object} param1
+ * @param {Number} param1.itemId
+ * @param {Number} param1.price
+ */
+async function createBuyOrder(buyerId, { itemId, price }) {
+  let result;
+
+  await mysql.transaction(async trx => {
+    const balance = await getBalance(buyerId, trx);
+
+    const openCount = await PublicMarketModel.countOpenByRequester(buyerId, trx);
+    if (openCount >= MAX_OPEN_LISTINGS) {
+      result = {
+        ok: false,
+        code: "LISTING_CAP",
+        myOpenCount: openCount,
+        maxOpen: MAX_OPEN_LISTINGS,
+      };
+      return;
+    }
+
+    // 角色一人一隻：已經有的角色收購回來也不會生效，等於白鎖一筆錢。
+    if (await ownsCharacter(buyerId, itemId, trx)) {
+      result = { ok: false, code: "ALREADY_OWNED" };
+      return;
+    }
+
+    const duplicated = await PublicMarketModel.findOpenBuyByBuyerAndItem(buyerId, itemId, trx);
+    if (duplicated) {
+      result = { ok: false, code: "ALREADY_REQUESTED" };
+      return;
+    }
+
+    if (balance < price) {
+      result = {
+        ok: false,
+        code: "NOT_ENOUGH_TO_RESERVE",
+        balance,
+        price,
+        shortfall: price - balance,
+      };
+      return;
+    }
+
+    const id = await PublicMarketModel.create(
+      {
+        order_type: BUY,
+        buyer_id: buyerId,
+        // 收購單開著的時候還不知道誰會賣，成交才寫入履約者。
+        seller_id: null,
+        item_id: itemId,
+        price,
+        fee: calcFee(price),
+        status: "open",
+      },
+      trx
+    );
+
+    await InventoryModel.decreaseGodStone({
+      userId: buyerId,
+      amount: price,
+      note: `public_market:buy_order:reserve:${id}`,
+      trx,
+    });
+
+    const row = await PublicMarketModel.getById(id, trx);
+    result = { ok: true, id, row, balanceAfter: balance - price };
+  });
+
+  if (!result.ok) return result;
+
+  const names = await resolveNames([buyerId]);
+
+  return {
+    ok: true,
+    listing: {
+      ...shapeListing(result.row, { viewerId: buyerId, names }),
+      // 前端要立刻寫出「已預扣」後的錢包數字，不用再打一次 summary。
+      balanceAfter: result.balanceAfter,
+    },
+  };
+}
+
+/**
+ * 建立委託。缺省或 sell 走賣單，buy 走收購單。
+ * @param {String} userId
+ * @param {Object} param1
+ * @param {Number} param1.itemId
+ * @param {Number} param1.price
+ * @param {"sell"|"buy"} [param1.orderType]
+ */
+async function createListing(userId, { itemId, price, orderType }) {
+  const type = parseOrderType(orderType);
+  if (type === null) {
+    return { ok: false, code: "INVALID_ORDER_TYPE" };
+  }
+
+  if (!isValidPrice(price)) {
+    return { ok: false, code: "INVALID_PRICE" };
+  }
+
+  // itemId 999 是女神石本身，不是角色，兩個方向都不准拿來掛單。
+  if (!Number.isInteger(itemId) || itemId <= 0 || itemId === GOD_STONE_ITEM_ID) {
+    return { ok: false, code: type === BUY ? "INVALID_ITEM" : "NOT_OWNED" };
+  }
+
+  try {
+    return type === BUY
+      ? await createBuyOrder(userId, { itemId, price })
+      : await createSellListing(userId, { itemId, price });
+  } catch (e) {
+    DefaultLogger.error(e);
+    throw e;
+  }
+}
+
+/**
+ * 發布者取消自己的委託。
+ *
+ * 賣單：不收手續費，角色本來就沒離開過賣家身上。
+ * 收購單：預扣的女神石全額退回，且只能退一次 —— 退款綁在「條件式關閉真的改到那一列」
+ * 這件事上（markClosed 回傳受影響列數）。兩個請求同時打進來時只有一個會拿到 1，
+ * 另一個看到 0 就當作已結束處理，不會再退第二次。
+ *
  * @param {Number} id
  * @param {String} userId
  */
 async function cancelListing(id, userId) {
-  const row = await PublicMarketModel.find(id);
-  if (!row) return { ok: false, code: "NOT_FOUND" };
-  if (row.seller_id !== userId) return { ok: false, code: "FORBIDDEN" };
-  if (row.status !== "open") return { ok: false, code: "NOT_OPEN" };
+  let result;
 
-  const affected = await PublicMarketModel.markClosed(id, "cancelled");
-  if (!affected) return { ok: false, code: "NOT_OPEN" };
+  try {
+    await mysql.transaction(async trx => {
+      const listing = await PublicMarketModel.lockById(id, trx);
+      if (!listing) {
+        result = { ok: false, code: "NOT_FOUND" };
+        return;
+      }
 
-  return { ok: true, listingId: Number(id) };
+      const orderType = normalizeOrderType(listing.order_type);
+      const requesterId = orderType === BUY ? listing.buyer_id : listing.seller_id;
+
+      if (requesterId !== userId) {
+        result = { ok: false, code: "FORBIDDEN" };
+        return;
+      }
+
+      if (listing.status !== "open") {
+        result = { ok: false, code: "NOT_OPEN" };
+        return;
+      }
+
+      const affected = await PublicMarketModel.markClosed(id, "cancelled", trx);
+      if (!affected) {
+        result = { ok: false, code: "NOT_OPEN" };
+        return;
+      }
+
+      if (orderType !== BUY) {
+        result = { ok: true, listingId: Number(id) };
+        return;
+      }
+
+      const price = Number(listing.price);
+      await InventoryModel.increaseGodStone({
+        userId,
+        amount: price,
+        note: `public_market:buy_order:refund:cancel:${id}`,
+        trx,
+      });
+
+      result = { ok: true, listingId: Number(id), refundedAmount: price };
+    });
+  } catch (e) {
+    DefaultLogger.error(e);
+    throw e;
+  }
+
+  return result;
 }
 
 /**
- * 執行購買。整段包在單一 mysql.transaction 內。
+ * 買下一張賣單。整段包在單一 mysql.transaction 內。
  *
  * 競態安全靠兩層：
  * 1. 進交易先 `SELECT ... FOR UPDATE` 鎖住掛單列，後到的買家會卡住直到前一筆
@@ -312,7 +589,12 @@ async function cancelListing(id, userId) {
  * 2. 收尾的 UPDATE 帶 `WHERE status = 'open'`，受影響列數為 0 就整筆 rollback。
  *    即使 1 因故失效也不可能兩個買家都成功。
  *
- * 成交後（交易外）替買賣雙方結算 trade_complete 成就，與 1 對 1 交易的做法一致。
+ * 鎖序固定為「掛單列 → 買方 999（餘額）→ 買方 itemId（持有）→ 賣方 itemId」。
+ * 同一使用者的 inventory 內部也照 itemId 由小到大：999 這個 itemId 比任何角色 ID 都大，
+ * 但重點不是數值大小，而是每條路徑都用同一個順序 —— fulfill 沒有買方餘額鎖，
+ * 其餘步驟落在同一條序列上，所以兩條路徑交錯執行不會形成環。
+ *
+ * 成就結算在 commit 之後（交易外）替買賣雙方結算 trade_complete，與 1 對 1 交易的做法一致。
  *
  * @param {Number} id
  * @param {String} buyerId
@@ -326,6 +608,12 @@ async function purchase(id, buyerId) {
       const listing = await PublicMarketModel.lockById(id, trx);
       if (!listing) {
         result = { ok: false, code: "NOT_FOUND" };
+        return;
+      }
+
+      // 收購單要用 fulfill 履約，這條路徑只處理賣單。
+      if (normalizeOrderType(listing.order_type) === BUY) {
+        result = { ok: false, code: "WRONG_ORDER_TYPE" };
         return;
       }
 
@@ -344,12 +632,17 @@ async function purchase(id, buyerId) {
         return;
       }
 
+      // 鎖序：先鎖買方的 999（餘額），再鎖買方持有的 itemId，最後才動賣方的 itemId。
+      // 這與 createBuyOrder / fulfill 走的是同一條序列 —— 先前是 itemId 先於 999，
+      // 兩條路徑對同一個買家反向取鎖就有死鎖。讀的順序改了，但「檢查」的先後不變：
+      // 已持有仍優先於餘額不足回報，錯誤碼與既有行為完全一致。
+      const balance = await getBalance(buyerId, trx);
+
       if (await ownsCharacter(buyerId, itemId, trx)) {
         result = { ok: false, code: "ALREADY_OWNED" };
         return;
       }
 
-      const balance = await getBalance(buyerId, trx);
       if (balance < price) {
         result = {
           ok: false,
@@ -439,30 +732,173 @@ async function purchase(id, buyerId) {
 }
 
 /**
- * 我的掛單：開放中 + 已結束。
+ * 履約一張收購單：把自己的角色賣給發單的買家。
+ *
+ * 金流與賣單相反 —— 錢在發單時就預扣了，這裡只做「撥款 + 交付角色」，
+ * 買家不會被再扣一次。手續費一樣是銷毀，履約者實收 price - fee。
+ *
+ * 三種不成交的情形，處理方式刻意不同：
+ * 1. 履約者手上沒有這隻角色（NOT_OWNED）—— 收購單「保持 open」。
+ *    如果這裡順手把單子作廢，任何人都能用一個沒有角色的帳號把別人的收購單掃光，
+ *    那是免費的惡意下架管道。所以不動狀態、不退款、什麼都不寫。
+ * 2. 買家自己已經拿到角色了（ALREADY_OWNED_REQUESTER）—— 這張單再也不可能成交，
+ *    同一筆交易內作廢並把預扣全額退回買家，回傳讓前端能認的碼與退款金額。
+ * 3. 其他人先成交／先取消（ALREADY_TAKEN）—— 不退款，錢在那條路徑上已經處理過。
+ *
+ * 鎖序與 purchase 相同：掛單列 → 買方 inventory → 賣方 inventory。
+ *
+ * @param {Number} id
+ * @param {String} sellerId 履約者（交出角色的人）
+ */
+async function fulfill(id, sellerId) {
+  let result;
+
+  try {
+    await mysql.transaction(async trx => {
+      const listing = await PublicMarketModel.lockById(id, trx);
+      if (!listing) {
+        result = { ok: false, code: "NOT_FOUND" };
+        return;
+      }
+
+      if (normalizeOrderType(listing.order_type) !== BUY) {
+        result = { ok: false, code: "WRONG_ORDER_TYPE" };
+        return;
+      }
+
+      if (listing.status !== "open") {
+        result = { ok: false, code: "ALREADY_TAKEN" };
+        return;
+      }
+
+      const buyerId = listing.buyer_id;
+      const itemId = Number(listing.item_id);
+      const price = Number(listing.price);
+      const fee = Number(listing.fee);
+
+      if (buyerId === sellerId) {
+        result = { ok: false, code: "IS_BUYER" };
+        return;
+      }
+
+      // 買家在發單後自己抽到了：這張單已無意義，作廢並退款。
+      if (await ownsCharacter(buyerId, itemId, trx)) {
+        const closed = await PublicMarketModel.markClosed(id, "invalid", trx);
+        if (!closed) {
+          // 別人先關掉了，退款由那條路徑負責，這裡再退就是退第二次。
+          result = { ok: false, code: "ALREADY_TAKEN" };
+          return;
+        }
+
+        await InventoryModel.increaseGodStone({
+          userId: buyerId,
+          amount: price,
+          note: `public_market:buy_order:refund:buyer_owned:${id}`,
+          trx,
+        });
+
+        result = { ok: false, code: "ALREADY_OWNED_REQUESTER", refundedAmount: price };
+        return;
+      }
+
+      // 履約者手上沒有角色：單子原樣留著，不寫任何東西。
+      const removed = await InventoryModel.deleteUserItem(sellerId, itemId, trx);
+      if (!removed) {
+        result = { ok: false, code: "NOT_OWNED" };
+        return;
+      }
+
+      const character = await GachaPoolModel.find(itemId, trx);
+
+      // 升星強化不轉移：買家拿到的是基礎星數。
+      await InventoryModel.create(
+        {
+          userId: buyerId,
+          itemId,
+          itemAmount: 1,
+          attributes: baseAttributes(character),
+          note: `public_market:buy_order:fulfill:${id}`,
+        },
+        trx
+      );
+
+      // 買家不再扣款 —— 發單時已經預扣過，這裡再扣一次就是收兩次錢。
+      await InventoryModel.increaseGodStone({
+        userId: sellerId,
+        amount: price - fee,
+        note: `public_market:buy_order:payout:${id}`,
+        trx,
+      });
+
+      const fulfilled = await PublicMarketModel.markFulfilled(id, sellerId, trx);
+      if (!fulfilled) {
+        throw new Error("PUBLIC_MARKET_RACE");
+      }
+
+      result = {
+        ok: true,
+        listingId: Number(id),
+        itemId,
+        name: character ? character.Name : null,
+        // buyerId 只給 commit 後的成就結算用；router 的回應欄位是白名單，不會外流
+        buyerId,
+        price,
+        fee,
+        netProceeds: price - fee,
+      };
+    });
+  } catch (e) {
+    if (e && e.message === "PUBLIC_MARKET_RACE") {
+      return { ok: false, code: "ALREADY_TAKEN" };
+    }
+    DefaultLogger.error(e);
+    throw e;
+  }
+
+  if (result && result.ok) {
+    await Promise.all([
+      AchievementEngine.evaluate(sellerId, "trade_complete", {}).catch(() => {}),
+      AchievementEngine.evaluate(result.buyerId, "trade_complete", {}).catch(() => {}),
+    ]);
+  }
+
+  return result;
+}
+
+/**
+ * 我的掛單：開放中（賣單 + 收購單）+ 已結束。
  * @param {String} userId
  */
 async function getMyListings(userId) {
   const [openRows, closedRows] = await Promise.all([
-    PublicMarketModel.getOpenListingsBySeller(userId),
+    PublicMarketModel.getOpenListingsByRequester(userId),
     PublicMarketModel.getClosedListingsByUser(userId),
   ]);
 
   const names = await resolveNames([
     ...openRows.map(r => r.sellerId),
+    ...openRows.map(r => r.buyerId),
     ...closedRows.map(r => r.sellerId),
     ...closedRows.map(r => r.buyerId),
   ]);
 
   const open = openRows.map(row => {
     const listing = shapeListing(row, { viewerId: userId, names });
-    delete listing.buyerId;
-    delete listing.buyerName;
+
+    // 開放中的單沒有對手方，剪掉還沒有意義的欄位（收購單的 buyerId 就是我自己，留著）。
+    if (listing.orderType === BUY) {
+      delete listing.sellerId;
+      delete listing.sellerName;
+    } else {
+      delete listing.buyerId;
+      delete listing.buyerName;
+    }
     return listing;
   });
 
   const closed = closedRows.map(row => {
     const listing = shapeListing(row, { viewerId: userId, names });
+    // 角色的流向決定 role，與方向無關：交出角色的是 seller，拿到角色的是 buyer。
     const role = row.sellerId === userId ? "seller" : "buyer";
     const counterpartyId = role === "seller" ? row.buyerId : row.sellerId;
 
@@ -482,11 +918,16 @@ module.exports = {
   MAX_OPEN_LISTINGS,
   MIN_PRICE,
   MAX_PRICE,
+  SELL,
+  BUY,
+  normalizeOrderType,
+  parseOrderType,
   calcFee,
   calcNetProceeds,
   isValidPrice,
   baseStarOf,
   baseAttributes,
+  requesterIdOf,
   resolveBlockReason,
   getBalance,
   ownsCharacter,
@@ -497,5 +938,6 @@ module.exports = {
   createListing,
   cancelListing,
   purchase,
+  fulfill,
   getMyListings,
 };

--- a/app/src/service/__tests__/PublicMarketService.test.js
+++ b/app/src/service/__tests__/PublicMarketService.test.js
@@ -1,4 +1,4 @@
-// PublicMarketService 的純邏輯與購買競態測試。
+// PublicMarketService 的純邏輯、購買競態、收購單金流測試。
 // 全域 setup（app/__tests__/setup.js）已把 util/mysql 換成 mock query builder，
 // 其 `transaction(cb)` 會直接執行 cb，因此不需要實體 MySQL。
 // model 層一律 mock，測的是 service 的決策而非 SQL。
@@ -8,12 +8,16 @@ jest.mock("../../model/application/PublicMarket", () => ({
   getById: jest.fn(),
   lockById: jest.fn(),
   create: jest.fn(),
-  countOpenBySeller: jest.fn(),
+  countOpenByRequester: jest.fn(),
   countOpen: jest.fn(),
   findOpenBySellerAndItem: jest.fn(),
-  getOpenListingsBySeller: jest.fn(),
+  findOpenBuyByBuyerAndItem: jest.fn(),
+  getOpenListingsByRequester: jest.fn(),
+  getOpenListingsByItemId: jest.fn(),
+  getOpenCharacters: jest.fn(),
   getClosedListingsByUser: jest.fn(),
   markSold: jest.fn(),
+  markFulfilled: jest.fn(),
   markClosed: jest.fn(),
 }));
 
@@ -50,9 +54,13 @@ const BUYER = "U" + "2".repeat(32);
 /**
  * getBalance / ownsCharacter 都是直接打 mysql("inventory")，
  * 這裡改寫 mock builder 的 first()，依查詢條件回不同 sum。
+ *
+ * owner 可以是布林（單一使用者情境）或 `{ [userId]: bool }`（收購單有兩造）。
+ * 回傳值是被讀取到的 itemId 順序，測試靠它斷言鎖序。
  */
-function stubInventoryReads({ balance = 0, buyerOwns = false } = {}) {
+function stubInventoryReads({ balance = 0, buyerOwns = false, owns = null } = {}) {
   const mysql = require("../../util/mysql");
+  const readOrder = [];
   let lastWhere = {};
 
   mysql.where.mockImplementation(cond => {
@@ -61,9 +69,15 @@ function stubInventoryReads({ balance = 0, buyerOwns = false } = {}) {
   });
 
   mysql.first.mockImplementation(async () => {
+    readOrder.push(lastWhere.itemId);
     if (lastWhere.itemId === 999) return { amount: balance };
+    if (owns && typeof owns === "object") {
+      return { amount: owns[lastWhere.userId] ? 1 : 0 };
+    }
     return { amount: buyerOwns ? 1 : 0 };
   });
+
+  return readOrder;
 }
 
 beforeEach(() => {
@@ -80,7 +94,11 @@ beforeEach(() => {
   InventoryModel.increaseGodStone.mockResolvedValue([1]);
   InventoryModel.decreaseGodStone.mockResolvedValue([1]);
   GachaPoolModel.find.mockResolvedValue({ ID: 101, Name: "佩可莉ーヌ", Star: "3" });
+  PublicMarketModel.countOpenByRequester.mockResolvedValue(0);
+  PublicMarketModel.findOpenBySellerAndItem.mockResolvedValue(null);
+  PublicMarketModel.findOpenBuyByBuyerAndItem.mockResolvedValue(null);
   PublicMarketModel.markSold.mockResolvedValue(1);
+  PublicMarketModel.markFulfilled.mockResolvedValue(1);
   PublicMarketModel.markClosed.mockResolvedValue(1);
   AchievementEngine.evaluate.mockResolvedValue({ unlocked: [] });
 });
@@ -114,6 +132,40 @@ describe("價格驗證", () => {
   );
 });
 
+describe("委託方向解析", () => {
+  it.each([
+    [undefined, "sell"],
+    [null, "sell"],
+    ["", "sell"],
+    ["sell", "sell"],
+    ["buy", "buy"],
+    ["BUY", "buy"],
+    ["Sell", "sell"],
+    ["nonsense", "sell"],
+    [123, "sell"],
+  ])("normalizeOrderType(%p) -> %s（讀取端寬鬆，缺值當賣單）", (input, expected) => {
+    expect(Service.normalizeOrderType(input)).toBe(expected);
+  });
+
+  it.each([
+    [undefined, "sell"],
+    [null, "sell"],
+    ["", "sell"],
+    ["sell", "sell"],
+    ["buy", "buy"],
+    ["BUY", "buy"],
+  ])("parseOrderType(%p) -> %s", (input, expected) => {
+    expect(Service.parseOrderType(input)).toBe(expected);
+  });
+
+  it.each(["nonsense", "SELL_", 0, 1, [], {}])(
+    "parseOrderType(%p) -> null（寫入端嚴格，方向拼錯不能當賣單）",
+    input => {
+      expect(Service.parseOrderType(input)).toBeNull();
+    }
+  );
+});
+
 describe("升星不轉移", () => {
   it("attributes 用 gacha_pool 的基礎星數，不是賣家的升星值", () => {
     expect(Service.baseAttributes({ Star: "3" })).toBe(JSON.stringify([{ key: "star", value: 3 }]));
@@ -125,14 +177,45 @@ describe("升星不轉移", () => {
   });
 });
 
-describe("blockReason 判定順序", () => {
-  const ctx = { status: "open", isSeller: false, owns: false, balance: 100, price: 50 };
+describe("發布者判定", () => {
+  it("賣單的發布者是賣家", () => {
+    expect(Service.requesterIdOf({ orderType: "sell", sellerId: SELLER, buyerId: BUYER })).toBe(
+      SELLER
+    );
+  });
 
-  it("可買時為 null", () => expect(Service.resolveBlockReason(ctx)).toBeNull());
+  it("收購單的發布者是買家，即使已經有履約的賣家", () => {
+    expect(Service.requesterIdOf({ orderType: "buy", sellerId: SELLER, buyerId: BUYER })).toBe(
+      BUYER
+    );
+  });
+
+  it("缺 orderType 時當賣單處理（第一階段資料）", () => {
+    expect(Service.requesterIdOf({ sellerId: SELLER, buyerId: null })).toBe(SELLER);
+  });
+});
+
+describe("blockReason 判定順序", () => {
+  const sellCtx = {
+    orderType: "sell",
+    status: "open",
+    isSeller: false,
+    owns: false,
+    balance: 100,
+    price: 50,
+  };
+
+  it("賣單可買時為 null", () => expect(Service.resolveBlockReason(sellCtx)).toBeNull());
 
   it("非 open 一律 NOT_OPEN，優先於身分判定", () => {
     expect(
-      Service.resolveBlockReason({ ...ctx, status: "sold", isSeller: true, owns: true, balance: 0 })
+      Service.resolveBlockReason({
+        ...sellCtx,
+        status: "sold",
+        isSeller: true,
+        owns: true,
+        balance: 0,
+      })
     ).toBe("NOT_OPEN");
   });
 
@@ -140,14 +223,38 @@ describe("blockReason 判定順序", () => {
     [{ isSeller: true }, "IS_SELLER"],
     [{ owns: true }, "ALREADY_OWNED"],
     [{ balance: 10 }, "INSUFFICIENT_FUNDS"],
-  ])("%p -> %s", (patch, expected) => {
-    expect(Service.resolveBlockReason({ ...ctx, ...patch })).toBe(expected);
+  ])("賣單 %p -> %s", (patch, expected) => {
+    expect(Service.resolveBlockReason({ ...sellCtx, ...patch })).toBe(expected);
+  });
+
+  const buyCtx = {
+    orderType: "buy",
+    status: "open",
+    isRequester: false,
+    owns: true,
+    balance: 0,
+    price: 5000,
+  };
+
+  it("收購單：持有角色就能履約，餘額為 0 也不擋（錢在發單時已預扣）", () => {
+    expect(Service.resolveBlockReason(buyCtx)).toBeNull();
+  });
+
+  it.each([
+    [{ isRequester: true }, "IS_BUYER"],
+    [{ owns: false }, "NOT_OWNED"],
+  ])("收購單 %p -> %s", (patch, expected) => {
+    expect(Service.resolveBlockReason({ ...buyCtx, ...patch })).toBe(expected);
+  });
+
+  it("收購單非 open 仍優先 NOT_OPEN", () => {
+    expect(Service.resolveBlockReason({ ...buyCtx, status: "invalid" })).toBe("NOT_OPEN");
   });
 });
 
-describe("掛單上限", () => {
-  it("已有 10 筆開放掛單時回 LISTING_CAP，且不寫入", async () => {
-    PublicMarketModel.countOpenBySeller.mockResolvedValue(10);
+describe("掛賣單", () => {
+  it("已有 10 筆開放委託時回 LISTING_CAP，且不寫入", async () => {
+    PublicMarketModel.countOpenByRequester.mockResolvedValue(10);
 
     const res = await Service.createListing(SELLER, { itemId: 101, price: 1000 });
 
@@ -155,13 +262,13 @@ describe("掛單上限", () => {
     expect(PublicMarketModel.create).not.toHaveBeenCalled();
   });
 
-  it("第 10 筆（已有 9 筆）可以掛", async () => {
-    PublicMarketModel.countOpenBySeller.mockResolvedValue(9);
-    PublicMarketModel.findOpenBySellerAndItem.mockResolvedValue(null);
+  it("第 10 筆（已有 9 筆）可以掛，且寫入 order_type=sell", async () => {
+    PublicMarketModel.countOpenByRequester.mockResolvedValue(9);
     PublicMarketModel.create.mockResolvedValue(77);
     PublicMarketModel.getById.mockResolvedValue({
       id: 77,
       itemId: 101,
+      orderType: "sell",
       sellerId: SELLER,
       price: 1000,
       fee: 50,
@@ -174,23 +281,335 @@ describe("掛單上限", () => {
     const res = await Service.createListing(SELLER, { itemId: 101, price: 1000 });
 
     expect(res.ok).toBe(true);
-    expect(res.listing).toMatchObject({ fee: 50, netProceeds: 950, star: 3 });
+    expect(res.listing).toMatchObject({ fee: 50, netProceeds: 950, star: 3, orderType: "sell" });
     expect(PublicMarketModel.create).toHaveBeenCalledWith(
-      expect.objectContaining({ price: 1000, fee: 50, status: "open" })
+      expect.objectContaining({ order_type: "sell", price: 1000, fee: 50, status: "open" })
     );
   });
 
   it("價格不合法時連上限都不查", async () => {
     const res = await Service.createListing(SELLER, { itemId: 101, price: 0 });
     expect(res).toEqual({ ok: false, code: "INVALID_PRICE" });
-    expect(PublicMarketModel.countOpenBySeller).not.toHaveBeenCalled();
+    expect(PublicMarketModel.countOpenByRequester).not.toHaveBeenCalled();
+  });
+
+  it("同一角色重複掛賣單回 ALREADY_LISTED", async () => {
+    PublicMarketModel.findOpenBySellerAndItem.mockResolvedValue({ id: 5 });
+    stubInventoryReads({ balance: 0, buyerOwns: true });
+
+    const res = await Service.createListing(SELLER, { itemId: 101, price: 1000 });
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_LISTED" });
+    expect(PublicMarketModel.create).not.toHaveBeenCalled();
+  });
+
+  it("方向拼錯直接擋下，不會誤走賣單流程", async () => {
+    const res = await Service.createListing(SELLER, {
+      itemId: 101,
+      price: 1000,
+      orderType: "sel",
+    });
+
+    expect(res).toEqual({ ok: false, code: "INVALID_ORDER_TYPE" });
+    expect(PublicMarketModel.create).not.toHaveBeenCalled();
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
   });
 });
 
-describe("購買競態", () => {
+describe("發布收購單", () => {
+  function stubCreated(id = 88, overrides = {}) {
+    PublicMarketModel.create.mockResolvedValue(id);
+    PublicMarketModel.getById.mockResolvedValue({
+      id,
+      itemId: 101,
+      orderType: "buy",
+      sellerId: null,
+      buyerId: BUYER,
+      price: 1000,
+      fee: 50,
+      status: "open",
+      name: "佩可莉ーヌ",
+      star: "3",
+      ...overrides,
+    });
+  }
+
+  it("成功：寫入 buy 單（buyer_id=發單者、seller_id=null）並在同交易預扣全額", async () => {
+    stubInventoryReads({ balance: 5000, buyerOwns: false });
+    stubCreated(88);
+
+    const res = await Service.createListing(BUYER, {
+      itemId: 101,
+      price: 1000,
+      orderType: "buy",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.listing).toMatchObject({
+      id: 88,
+      orderType: "buy",
+      buyerId: BUYER,
+      sellerId: null,
+      price: 1000,
+      balanceAfter: 4000,
+      mine: true,
+    });
+
+    expect(PublicMarketModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        order_type: "buy",
+        buyer_id: BUYER,
+        seller_id: null,
+        item_id: 101,
+        price: 1000,
+        fee: 50,
+        status: "open",
+      }),
+      expect.anything()
+    );
+
+    expect(InventoryModel.decreaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: BUYER,
+        amount: 1000,
+        note: "public_market:buy_order:reserve:88",
+      })
+    );
+    expect(InventoryModel.decreaseGodStone).toHaveBeenCalledTimes(1);
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("餘額不足回 NOT_ENOUGH_TO_RESERVE，不建單也不扣款", async () => {
+    stubInventoryReads({ balance: 300, buyerOwns: false });
+
+    const res = await Service.createListing(BUYER, {
+      itemId: 101,
+      price: 1000,
+      orderType: "buy",
+    });
+
+    expect(res).toEqual({
+      ok: false,
+      code: "NOT_ENOUGH_TO_RESERVE",
+      balance: 300,
+      price: 1000,
+      shortfall: 700,
+    });
+    expect(PublicMarketModel.create).not.toHaveBeenCalled();
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("餘額剛好等於出價可以發布（邊界不能少一塊）", async () => {
+    stubInventoryReads({ balance: 1000, buyerOwns: false });
+    stubCreated(89);
+
+    const res = await Service.createListing(BUYER, {
+      itemId: 101,
+      price: 1000,
+      orderType: "buy",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.listing.balanceAfter).toBe(0);
+  });
+
+  it("已持有該角色回 ALREADY_OWNED，不預扣", async () => {
+    stubInventoryReads({ balance: 5000, buyerOwns: true });
+
+    const res = await Service.createListing(BUYER, {
+      itemId: 101,
+      price: 1000,
+      orderType: "buy",
+    });
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_OWNED" });
+    expect(PublicMarketModel.create).not.toHaveBeenCalled();
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("同一角色已有開放收購單回 ALREADY_REQUESTED，不重複預扣", async () => {
+    stubInventoryReads({ balance: 5000, buyerOwns: false });
+    PublicMarketModel.findOpenBuyByBuyerAndItem.mockResolvedValue({ id: 12 });
+
+    const res = await Service.createListing(BUYER, {
+      itemId: 101,
+      price: 1000,
+      orderType: "buy",
+    });
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_REQUESTED" });
+    expect(PublicMarketModel.create).not.toHaveBeenCalled();
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("上限是賣單 + 收購單合計：已有 10 筆（含賣單）就不能再發收購單", async () => {
+    stubInventoryReads({ balance: 999999, buyerOwns: false });
+    PublicMarketModel.countOpenByRequester.mockResolvedValue(10);
+
+    const res = await Service.createListing(BUYER, {
+      itemId: 101,
+      price: 1000,
+      orderType: "buy",
+    });
+
+    expect(res).toMatchObject({ ok: false, code: "LISTING_CAP", myOpenCount: 10, maxOpen: 10 });
+    expect(PublicMarketModel.create).not.toHaveBeenCalled();
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("上限查的是合計計數（countOpenByRequester），不是只看賣單", async () => {
+    stubInventoryReads({ balance: 5000, buyerOwns: false });
+    stubCreated(90);
+
+    await Service.createListing(BUYER, { itemId: 101, price: 1000, orderType: "buy" });
+
+    expect(PublicMarketModel.countOpenByRequester).toHaveBeenCalledWith(BUYER, expect.anything());
+  });
+
+  it("女神石本身（999）不能拿來發收購單", async () => {
+    const res = await Service.createListing(BUYER, {
+      itemId: 999,
+      price: 1000,
+      orderType: "buy",
+    });
+
+    expect(res).toEqual({ ok: false, code: "INVALID_ITEM" });
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("預扣發生在建單之後，note 帶得到掛單 id（對帳靠這個字串）", async () => {
+    stubInventoryReads({ balance: 5000, buyerOwns: false });
+    stubCreated(4242);
+
+    const order = [];
+    PublicMarketModel.create.mockImplementation(async () => {
+      order.push("create");
+      return 4242;
+    });
+    InventoryModel.decreaseGodStone.mockImplementation(async () => {
+      order.push("reserve");
+      return [1];
+    });
+
+    await Service.createListing(BUYER, { itemId: 101, price: 1000, orderType: "buy" });
+
+    expect(order).toEqual(["create", "reserve"]);
+    expect(InventoryModel.decreaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({ note: "public_market:buy_order:reserve:4242" })
+    );
+  });
+
+  it("鎖序是 999（餘額）→ itemId（持有），與 purchase 一致", async () => {
+    const readOrder = stubInventoryReads({ balance: 5000, buyerOwns: false });
+    stubCreated(91);
+
+    await Service.createListing(BUYER, { itemId: 101, price: 1000, orderType: "buy" });
+
+    expect(readOrder).toEqual([999, 101]);
+  });
+});
+
+describe("取消委託", () => {
+  function openRow(overrides = {}) {
+    return {
+      id: 42,
+      order_type: "sell",
+      seller_id: SELLER,
+      buyer_id: null,
+      item_id: 101,
+      price: 1000,
+      fee: 50,
+      status: "open",
+      ...overrides,
+    };
+  }
+
+  it("賣家取消賣單：不退款、不收費", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openRow());
+
+    const res = await Service.cancelListing(42, SELLER);
+
+    expect(res).toEqual({ ok: true, listingId: 42 });
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("收購方取消收購單：同交易內全額退款一次，回 refundedAmount", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(
+      openRow({ order_type: "buy", seller_id: null, buyer_id: BUYER, price: 8600, fee: 430 })
+    );
+
+    const res = await Service.cancelListing(42, BUYER);
+
+    expect(res).toEqual({ ok: true, listingId: 42, refundedAmount: 8600 });
+    // 退全額，不扣手續費 —— 沒成交就不該收費
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: BUYER,
+        amount: 8600,
+        note: "public_market:buy_order:refund:cancel:42",
+      })
+    );
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledTimes(1);
+  });
+
+  it("收購單的賣方欄位（NULL）不能拿來當發布者：非發布者一律 FORBIDDEN", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(
+      openRow({ order_type: "buy", seller_id: null, buyer_id: BUYER })
+    );
+
+    const res = await Service.cancelListing(42, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "FORBIDDEN" });
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+    expect(PublicMarketModel.markClosed).not.toHaveBeenCalled();
+  });
+
+  it("賣單的買家欄位不能拿來取消（只有發布者可以）", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openRow({ buyer_id: BUYER }));
+
+    const res = await Service.cancelListing(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "FORBIDDEN" });
+  });
+
+  it.each(["sold", "cancelled", "invalid"])("終態 %s 不可再取消，也不退款", async status => {
+    PublicMarketModel.lockById.mockResolvedValue(
+      openRow({ order_type: "buy", seller_id: null, buyer_id: BUYER, status })
+    );
+
+    const res = await Service.cancelListing(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "NOT_OPEN" });
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+    expect(PublicMarketModel.markClosed).not.toHaveBeenCalled();
+  });
+
+  it("條件式關閉影響 0 列（別人先關掉）時不退第二次款", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(
+      openRow({ order_type: "buy", seller_id: null, buyer_id: BUYER })
+    );
+    PublicMarketModel.markClosed.mockResolvedValue(0);
+
+    const res = await Service.cancelListing(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "NOT_OPEN" });
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("查無此單回 NOT_FOUND", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(undefined);
+
+    const res = await Service.cancelListing(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "NOT_FOUND" });
+  });
+});
+
+describe("購買競態（賣單）", () => {
   function openListing(overrides = {}) {
     return {
       id: 42,
+      order_type: "sell",
       seller_id: SELLER,
       buyer_id: null,
       item_id: 101,
@@ -222,6 +641,20 @@ describe("購買競態", () => {
     }
   );
 
+  it("拿收購單走 purchase 會被擋成 WRONG_ORDER_TYPE，不動任何金流", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(
+      openListing({ order_type: "buy", seller_id: null, buyer_id: BUYER })
+    );
+    stubInventoryReads({ balance: 999999 });
+
+    const res = await Service.purchase(42, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "WRONG_ORDER_TYPE" });
+    expectNoMoneyMoved();
+    expect(PublicMarketModel.markSold).not.toHaveBeenCalled();
+    expect(PublicMarketModel.markClosed).not.toHaveBeenCalled();
+  });
+
   it("鎖失效導致 markSold 影響 0 列時整筆回滾成 ALREADY_TAKEN", async () => {
     PublicMarketModel.lockById.mockResolvedValue(openListing());
     PublicMarketModel.markSold.mockResolvedValue(0);
@@ -251,6 +684,38 @@ describe("購買競態", () => {
   it("已擁有該角色回 ALREADY_OWNED，不扣款", async () => {
     PublicMarketModel.lockById.mockResolvedValue(openListing());
     stubInventoryReads({ balance: 5000, buyerOwns: true });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_OWNED" });
+    expectNoMoneyMoved();
+  });
+
+  it("交易內的持有檢查是 locking read（FOR UPDATE），關掉快照空窗", async () => {
+    const mysql = require("../../util/mysql");
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    stubInventoryReads({ balance: 5000 });
+
+    await Service.purchase(42, BUYER);
+
+    // 餘額與持有各一次，兩次都要鎖；只鎖餘額的話買家仍可能在檢查後才拿到角色。
+    expect(mysql.forUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("鎖序是 999（餘額）→ itemId（持有），與 createBuyOrder / GodStoneShop 一致", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    const readOrder = stubInventoryReads({ balance: 5000 });
+
+    await Service.purchase(42, BUYER);
+
+    // 反過來（itemId 先於 999）會與其他路徑對同一個買家反向取鎖，形成死鎖。
+    expect(readOrder).toEqual([999, 101]);
+  });
+
+  it("鎖序調整不改行為：已持有仍優先於餘額不足回報", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing());
+    // 兩個條件同時成立：錢不夠，而且已經有角色了
+    stubInventoryReads({ balance: 0, buyerOwns: true });
 
     const res = await Service.purchase(42, BUYER);
 
@@ -324,12 +789,235 @@ describe("購買競態", () => {
       expect.anything()
     );
   });
+
+  it("缺 order_type 的舊資料仍走賣單流程（相容第一階段）", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(openListing({ order_type: undefined }));
+    stubInventoryReads({ balance: 10000 });
+
+    const res = await Service.purchase(42, BUYER);
+
+    expect(res.ok).toBe(true);
+    expect(PublicMarketModel.markSold).toHaveBeenCalledWith(42, BUYER, expect.anything());
+  });
+});
+
+describe("履約收購單（fulfill）", () => {
+  function buyOrder(overrides = {}) {
+    return {
+      id: 55,
+      order_type: "buy",
+      seller_id: null,
+      buyer_id: BUYER,
+      item_id: 101,
+      price: 8600,
+      fee: 430,
+      status: "open",
+      ...overrides,
+    };
+  }
+
+  it("成功：角色轉給收購方、履約者實收 price-fee、收購方不再被扣款", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    // 收購方沒有角色、履約者有
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+
+    const res = await Service.fulfill(55, SELLER);
+
+    expect(res).toMatchObject({
+      ok: true,
+      listingId: 55,
+      itemId: 101,
+      price: 8600,
+      fee: 430,
+      netProceeds: 8170,
+    });
+
+    // 角色從履約者移到收購方
+    expect(InventoryModel.deleteUserItem).toHaveBeenCalledWith(SELLER, 101, expect.anything());
+    expect(InventoryModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: BUYER, itemId: 101, itemAmount: 1 }),
+      expect.anything()
+    );
+
+    // 錢：只有履約者入帳，收購方一毛都不再扣（發單時已預扣）
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: SELLER,
+        amount: 8170,
+        note: "public_market:buy_order:payout:55",
+      })
+    );
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledTimes(1);
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+
+    // 成交要把履約者寫進 seller_id，否則「我的掛單」對不出賣方
+    expect(PublicMarketModel.markFulfilled).toHaveBeenCalledWith(55, SELLER, expect.anything());
+  });
+
+  it("手續費銷毀：收購方付出 price，履約者只收 price-fee，差額沒有第三方入帳", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder({ price: 1000, fee: 50 }));
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+
+    const res = await Service.fulfill(55, SELLER);
+
+    const credited = InventoryModel.increaseGodStone.mock.calls.reduce(
+      (sum, [args]) => sum + args.amount,
+      0
+    );
+    expect(res.netProceeds).toBe(950);
+    expect(credited).toBe(950);
+  });
+
+  it("履約者拿到的角色是基礎星數，升星不隨交易轉移", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    GachaPoolModel.find.mockResolvedValue({ ID: 101, Name: "佩可莉ーヌ", Star: "3" });
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+
+    await Service.fulfill(55, SELLER);
+
+    expect(InventoryModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: BUYER,
+        attributes: JSON.stringify([{ key: "star", value: 3 }]),
+        note: "public_market:buy_order:fulfill:55",
+      }),
+      expect.anything()
+    );
+  });
+
+  it("自己履約自己的收購單回 IS_BUYER，什麼都不動", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: true } });
+
+    const res = await Service.fulfill(55, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "IS_BUYER" });
+    expect(InventoryModel.deleteUserItem).not.toHaveBeenCalled();
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+    expect(PublicMarketModel.markClosed).not.toHaveBeenCalled();
+    expect(PublicMarketModel.markFulfilled).not.toHaveBeenCalled();
+  });
+
+  it("履約者沒有角色：只回 NOT_OWNED，收購單保持 open、不退款（否則等於免費下架別人的單）", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: false } });
+    InventoryModel.deleteUserItem.mockResolvedValue(0);
+
+    const res = await Service.fulfill(55, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "NOT_OWNED" });
+    expect(PublicMarketModel.markClosed).not.toHaveBeenCalled();
+    expect(PublicMarketModel.markFulfilled).not.toHaveBeenCalled();
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+    expect(InventoryModel.decreaseGodStone).not.toHaveBeenCalled();
+    expect(InventoryModel.create).not.toHaveBeenCalled();
+  });
+
+  it("收購方在期間內自己拿到角色：作廢 + 全額退款一次，回可辨識的碼與金額", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: true, [SELLER]: true } });
+
+    const res = await Service.fulfill(55, SELLER);
+
+    expect(res).toEqual({
+      ok: false,
+      code: "ALREADY_OWNED_REQUESTER",
+      refundedAmount: 8600,
+    });
+    expect(PublicMarketModel.markClosed).toHaveBeenCalledWith(55, "invalid", expect.anything());
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: BUYER,
+        amount: 8600,
+        note: "public_market:buy_order:refund:buyer_owned:55",
+      })
+    );
+    expect(InventoryModel.increaseGodStone).toHaveBeenCalledTimes(1);
+    // 履約者的角色不能被吃掉
+    expect(InventoryModel.deleteUserItem).not.toHaveBeenCalled();
+  });
+
+  it("收購方已持有 + 條件式作廢影響 0 列（別人先關）：改回 ALREADY_TAKEN，不退第二次", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: true, [SELLER]: true } });
+    PublicMarketModel.markClosed.mockResolvedValue(0);
+
+    const res = await Service.fulfill(55, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_TAKEN" });
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it.each(["sold", "cancelled", "invalid"])("終態 %s 回 ALREADY_TAKEN，不動金流", async status => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder({ status }));
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+
+    const res = await Service.fulfill(55, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_TAKEN" });
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+    expect(InventoryModel.deleteUserItem).not.toHaveBeenCalled();
+  });
+
+  it("拿賣單走 fulfill 被擋成 WRONG_ORDER_TYPE", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(
+      buyOrder({ order_type: "sell", seller_id: SELLER, buyer_id: null })
+    );
+    stubInventoryReads({ balance: 0, owns: { [SELLER]: true } });
+
+    const res = await Service.fulfill(55, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "WRONG_ORDER_TYPE" });
+    expect(InventoryModel.deleteUserItem).not.toHaveBeenCalled();
+    expect(InventoryModel.increaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("缺 order_type 的舊資料不會被誤當收購單履約", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(
+      buyOrder({ order_type: undefined, seller_id: SELLER, buyer_id: null })
+    );
+    stubInventoryReads({ balance: 0, owns: { [SELLER]: true } });
+
+    const res = await Service.fulfill(55, BUYER);
+
+    expect(res).toEqual({ ok: false, code: "WRONG_ORDER_TYPE" });
+  });
+
+  it("條件式履約影響 0 列（有人繞過行鎖）時整筆回滾成 ALREADY_TAKEN", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+    PublicMarketModel.markFulfilled.mockResolvedValue(0);
+
+    const res = await Service.fulfill(55, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "ALREADY_TAKEN" });
+  });
+
+  it("查無此單回 NOT_FOUND", async () => {
+    PublicMarketModel.lockById.mockResolvedValue(undefined);
+
+    const res = await Service.fulfill(55, SELLER);
+
+    expect(res).toEqual({ ok: false, code: "NOT_FOUND" });
+  });
+
+  it("持有檢查全程 locking read：收購方與履約者各鎖一次", async () => {
+    const mysql = require("../../util/mysql");
+    PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+    stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+
+    await Service.fulfill(55, SELLER);
+
+    // fulfill 不讀餘額（買家已預扣），所以這一次就是收購方的持有檢查
+    expect(mysql.forUpdate).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("star 欄位輸出", () => {
   const baseRow = {
     id: 7,
     itemId: 101,
+    orderType: "sell",
     sellerId: SELLER,
     buyerId: null,
     price: 1000,
@@ -339,9 +1027,7 @@ describe("star 欄位輸出", () => {
   };
 
   it("掛單簿列表帶出 star，且沒被 delete 剪掉", async () => {
-    PublicMarketModel.getOpenListingsByItemId = jest
-      .fn()
-      .mockResolvedValue([{ ...baseRow, star: "3" }]);
+    PublicMarketModel.getOpenListingsByItemId.mockResolvedValue([{ ...baseRow, star: "3" }]);
 
     const [listing] = await Service.getListingsByItemId(101, BUYER);
 
@@ -359,7 +1045,7 @@ describe("star 欄位輸出", () => {
   });
 
   it("我的掛單 open / closed 兩個陣列都有 star", async () => {
-    PublicMarketModel.getOpenListingsBySeller.mockResolvedValue([{ ...baseRow, star: "1" }]);
+    PublicMarketModel.getOpenListingsByRequester.mockResolvedValue([{ ...baseRow, star: "1" }]);
     PublicMarketModel.getClosedListingsByUser.mockResolvedValue([
       { ...baseRow, id: 8, status: "sold", buyerId: BUYER, star: "3" },
     ]);
@@ -371,15 +1057,13 @@ describe("star 欄位輸出", () => {
   });
 
   it("角色清單（GROUP BY 查詢）也帶出 star", async () => {
-    PublicMarketModel.getOpenCharacters = jest
-      .fn()
-      .mockResolvedValue([
-        { itemId: 770, name: "可可蘿", star: "3", headImage: null, listingCount: 2, minPrice: 500 },
-      ]);
+    PublicMarketModel.getOpenCharacters.mockResolvedValue([
+      { itemId: 770, name: "可可蘿", star: "3", headImage: null, listingCount: 2, bestPrice: 500 },
+    ]);
 
     const [character] = await Service.getOpenCharacters();
 
-    expect(character).toMatchObject({ itemId: 770, star: 3, listingCount: 2, minPrice: 500 });
+    expect(character).toMatchObject({ itemId: 770, star: 3, listingCount: 2, bestPrice: 500 });
   });
 
   it.each([
@@ -392,9 +1076,7 @@ describe("star 欄位輸出", () => {
     ["2", 2],
     [3, 3],
   ])("Star=%p 時 star 輸出 %i（baseStarOf 既有 fallback 契約）", async (rawStar, expected) => {
-    PublicMarketModel.getOpenListingsByItemId = jest
-      .fn()
-      .mockResolvedValue([{ ...baseRow, star: rawStar }]);
+    PublicMarketModel.getOpenListingsByItemId.mockResolvedValue([{ ...baseRow, star: rawStar }]);
 
     const [listing] = await Service.getListingsByItemId(101, BUYER);
 
@@ -402,10 +1084,293 @@ describe("star 欄位輸出", () => {
   });
 });
 
+describe("掛單簿形狀與方向", () => {
+  const sellRow = {
+    id: 7,
+    itemId: 101,
+    orderType: "sell",
+    sellerId: SELLER,
+    buyerId: null,
+    price: 1000,
+    fee: 50,
+    status: "open",
+    name: "佩可莉ーヌ",
+    star: "3",
+  };
+
+  const buyRow = { ...sellRow, id: 9, orderType: "buy", sellerId: null, buyerId: BUYER };
+
+  it("缺省方向查賣單簿", async () => {
+    PublicMarketModel.getOpenListingsByItemId.mockResolvedValue([sellRow]);
+
+    await Service.getListingsByItemId(101, BUYER);
+
+    expect(PublicMarketModel.getOpenListingsByItemId).toHaveBeenCalledWith(101, "sell");
+  });
+
+  it("orderType=buy 查收購簿，並把還沒有意義的賣方欄位剪掉", async () => {
+    PublicMarketModel.getOpenListingsByItemId.mockResolvedValue([buyRow]);
+
+    const [listing] = await Service.getListingsByItemId(101, SELLER, "buy");
+
+    expect(PublicMarketModel.getOpenListingsByItemId).toHaveBeenCalledWith(101, "buy");
+    expect(listing).toMatchObject({ orderType: "buy", buyerId: BUYER, netProceeds: 950 });
+    expect(listing).not.toHaveProperty("sellerId");
+    expect(listing).not.toHaveProperty("sellerName");
+    expect(listing).not.toHaveProperty("status");
+  });
+
+  it("賣單簿剪掉買方欄位", async () => {
+    PublicMarketModel.getOpenListingsByItemId.mockResolvedValue([sellRow]);
+
+    const [listing] = await Service.getListingsByItemId(101, BUYER);
+
+    expect(listing).toMatchObject({ orderType: "sell", sellerId: SELLER });
+    expect(listing).not.toHaveProperty("buyerId");
+  });
+
+  it("mine 依方向認發布者：收購單看 buyerId", async () => {
+    PublicMarketModel.getOpenListingsByItemId.mockResolvedValue([buyRow]);
+
+    const [asRequester] = await Service.getListingsByItemId(101, BUYER, "buy");
+    const [asOther] = await Service.getListingsByItemId(101, SELLER, "buy");
+
+    expect(asRequester.mine).toBe(true);
+    expect(asOther.mine).toBe(false);
+  });
+
+  it("角色清單依方向查，bestPrice 語意由 model 決定", async () => {
+    PublicMarketModel.getOpenCharacters.mockResolvedValue([
+      { itemId: 770, name: "可可蘿", star: "3", headImage: null, listingCount: 2, bestPrice: 9000 },
+    ]);
+
+    const [character] = await Service.getOpenCharacters("buy");
+
+    expect(PublicMarketModel.getOpenCharacters).toHaveBeenCalledWith("buy");
+    expect(character).toMatchObject({ orderType: "buy", bestPrice: 9000 });
+  });
+
+  it("角色清單缺省查賣單簿", async () => {
+    PublicMarketModel.getOpenCharacters.mockResolvedValue([]);
+
+    await Service.getOpenCharacters();
+
+    expect(PublicMarketModel.getOpenCharacters).toHaveBeenCalledWith("sell");
+  });
+});
+
+describe("詳情 viewer 形狀", () => {
+  const buyRow = {
+    id: 9,
+    itemId: 101,
+    orderType: "buy",
+    sellerId: null,
+    buyerId: BUYER,
+    price: 1000,
+    fee: 50,
+    status: "open",
+    name: "佩可莉ーヌ",
+    star: "3",
+  };
+
+  it("收購單 + 我持有角色：canFulfill=true、canBuy=false", async () => {
+    PublicMarketModel.getById.mockResolvedValue(buyRow);
+    stubInventoryReads({ balance: 0, buyerOwns: true });
+
+    const detail = await Service.getListingDetail(9, SELLER);
+
+    expect(detail).toMatchObject({ orderType: "buy", buyerId: BUYER, buyerName: `Name-${BUYER}` });
+    expect(detail.viewer).toMatchObject({
+      ownsCharacter: true,
+      isSeller: false,
+      isBuyer: false,
+      isRequester: false,
+      canFulfill: true,
+      canBuy: false,
+      blockReason: null,
+    });
+  });
+
+  it("收購單 + 我沒有角色：blockReason=NOT_OWNED、canFulfill=false", async () => {
+    PublicMarketModel.getById.mockResolvedValue(buyRow);
+    stubInventoryReads({ balance: 0, buyerOwns: false });
+
+    const detail = await Service.getListingDetail(9, SELLER);
+
+    expect(detail.viewer).toMatchObject({ canFulfill: false, blockReason: "NOT_OWNED" });
+  });
+
+  it("收購單 + 我就是發單者：isRequester / isBuyer 皆為 true，blockReason=IS_BUYER", async () => {
+    PublicMarketModel.getById.mockResolvedValue(buyRow);
+    stubInventoryReads({ balance: 0, buyerOwns: false });
+
+    const detail = await Service.getListingDetail(9, BUYER);
+
+    expect(detail.viewer).toMatchObject({
+      isRequester: true,
+      isBuyer: true,
+      canFulfill: false,
+      blockReason: "IS_BUYER",
+    });
+  });
+
+  it("已取消的收購單帶 refundedAmount = price，前端才寫得出實際退款金額", async () => {
+    PublicMarketModel.getById.mockResolvedValue({
+      ...buyRow,
+      status: "cancelled",
+      closedAt: "2026-08-10T00:00:00Z",
+    });
+    stubInventoryReads({ balance: 0 });
+
+    const detail = await Service.getListingDetail(9, BUYER);
+
+    expect(detail.refundedAmount).toBe(1000);
+  });
+
+  it("已成交的收購單沒有 refundedAmount（錢撥給履約者了，不是退款）", async () => {
+    PublicMarketModel.getById.mockResolvedValue({ ...buyRow, status: "sold", sellerId: SELLER });
+    stubInventoryReads({ balance: 0 });
+
+    const detail = await Service.getListingDetail(9, BUYER);
+
+    expect(detail).not.toHaveProperty("refundedAmount");
+  });
+
+  it("賣單保留原本的 canBuy / IS_SELLER 語意", async () => {
+    PublicMarketModel.getById.mockResolvedValue({
+      ...buyRow,
+      orderType: "sell",
+      sellerId: SELLER,
+      buyerId: null,
+    });
+    stubInventoryReads({ balance: 5000, buyerOwns: false });
+
+    const detail = await Service.getListingDetail(9, SELLER);
+
+    expect(detail.viewer).toMatchObject({
+      isSeller: true,
+      canBuy: false,
+      canFulfill: false,
+      blockReason: "IS_SELLER",
+    });
+  });
+});
+
+describe("我的掛單（兩種方向合併）", () => {
+  it("open 同時含賣單與收購單，各自剪掉沒意義的對手方欄位", async () => {
+    PublicMarketModel.getOpenListingsByRequester.mockResolvedValue([
+      {
+        id: 1,
+        itemId: 101,
+        orderType: "sell",
+        sellerId: SELLER,
+        buyerId: null,
+        price: 1000,
+        fee: 50,
+        status: "open",
+        star: "3",
+      },
+      {
+        id: 2,
+        itemId: 102,
+        orderType: "buy",
+        sellerId: null,
+        buyerId: SELLER,
+        price: 2000,
+        fee: 100,
+        status: "open",
+        star: "3",
+      },
+    ]);
+    PublicMarketModel.getClosedListingsByUser.mockResolvedValue([]);
+
+    const { open } = await Service.getMyListings(SELLER);
+
+    expect(open[0]).toMatchObject({ orderType: "sell", sellerId: SELLER, mine: true });
+    expect(open[0]).not.toHaveProperty("buyerId");
+    expect(open[1]).toMatchObject({ orderType: "buy", buyerId: SELLER, mine: true });
+    expect(open[1]).not.toHaveProperty("sellerId");
+  });
+
+  it("closed 收購單取消時帶 refundedAmount，成交時 role 依角色流向判定", async () => {
+    PublicMarketModel.getOpenListingsByRequester.mockResolvedValue([]);
+    PublicMarketModel.getClosedListingsByUser.mockResolvedValue([
+      {
+        id: 3,
+        itemId: 101,
+        orderType: "buy",
+        sellerId: null,
+        buyerId: BUYER,
+        price: 3000,
+        fee: 150,
+        status: "cancelled",
+        star: "3",
+      },
+      {
+        id: 4,
+        itemId: 102,
+        orderType: "buy",
+        sellerId: SELLER,
+        buyerId: BUYER,
+        price: 4000,
+        fee: 200,
+        status: "sold",
+        star: "3",
+      },
+    ]);
+
+    const { closed } = await Service.getMyListings(BUYER);
+
+    expect(closed[0]).toMatchObject({ status: "cancelled", refundedAmount: 3000, role: "buyer" });
+    // 成交：角色流向 BUYER，所以他是 buyer，對手方是履約的 SELLER
+    expect(closed[1]).toMatchObject({
+      status: "sold",
+      role: "buyer",
+      counterpartyId: SELLER,
+    });
+    expect(closed[1]).not.toHaveProperty("refundedAmount");
+  });
+
+  it("履約者視角：同一張收購單的 role 是 seller", async () => {
+    PublicMarketModel.getOpenListingsByRequester.mockResolvedValue([]);
+    PublicMarketModel.getClosedListingsByUser.mockResolvedValue([
+      {
+        id: 4,
+        itemId: 102,
+        orderType: "buy",
+        sellerId: SELLER,
+        buyerId: BUYER,
+        price: 4000,
+        fee: 200,
+        status: "sold",
+        star: "3",
+      },
+    ]);
+
+    const { closed } = await Service.getMyListings(SELLER);
+
+    expect(closed[0]).toMatchObject({ role: "seller", counterpartyId: BUYER, netProceeds: 3800 });
+  });
+});
+
+describe("總覽數字", () => {
+  it("myOpenCount 用合計計數（賣單 + 收購單共用上限）", async () => {
+    PublicMarketModel.countOpenByRequester.mockResolvedValue(7);
+    PublicMarketModel.countOpen.mockResolvedValue(128);
+    stubInventoryReads({ balance: 5000 });
+
+    const summary = await Service.getSummary(SELLER);
+
+    expect(PublicMarketModel.countOpenByRequester).toHaveBeenCalledWith(SELLER);
+    expect(summary).toMatchObject({ myOpenCount: 7, maxOpen: 10, totalOpenCount: 128 });
+  });
+});
+
 describe("trade_complete 成就結算", () => {
   function openListing(overrides = {}) {
     return {
       id: 42,
+      order_type: "sell",
       seller_id: SELLER,
       buyer_id: null,
       item_id: 101,
@@ -506,5 +1471,86 @@ describe("trade_complete 成就結算", () => {
     const res = await Service.purchase(42, BUYER);
 
     expect(res.sellerId).toBe(SELLER);
+  });
+
+  describe("收購單履約", () => {
+    function buyOrder(overrides = {}) {
+      return {
+        id: 55,
+        order_type: "buy",
+        seller_id: null,
+        buyer_id: BUYER,
+        item_id: 101,
+        price: 1000,
+        fee: 50,
+        status: "open",
+        ...overrides,
+      };
+    }
+
+    it("履約成功後雙方各結算一次", async () => {
+      PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+      stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+
+      await Service.fulfill(55, SELLER);
+
+      expect(AchievementEngine.evaluate).toHaveBeenCalledTimes(2);
+      expect(AchievementEngine.evaluate).toHaveBeenCalledWith(SELLER, "trade_complete", {});
+      expect(AchievementEngine.evaluate).toHaveBeenCalledWith(BUYER, "trade_complete", {});
+    });
+
+    it("結算在 commit 之後：markFulfilled 先跑完", async () => {
+      PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+      stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+
+      const callOrder = [];
+      PublicMarketModel.markFulfilled.mockImplementation(async () => {
+        callOrder.push("markFulfilled");
+        return 1;
+      });
+      AchievementEngine.evaluate.mockImplementation(async () => {
+        callOrder.push("evaluate");
+        return { unlocked: [] };
+      });
+
+      await Service.fulfill(55, SELLER);
+
+      expect(callOrder).toEqual(["markFulfilled", "evaluate", "evaluate"]);
+    });
+
+    it("成就爆炸不會回滾已完成的履約", async () => {
+      PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+      stubInventoryReads({ balance: 0, owns: { [BUYER]: false, [SELLER]: true } });
+      AchievementEngine.evaluate.mockRejectedValue(new Error("achievement exploded"));
+
+      const res = await Service.fulfill(55, SELLER);
+
+      expect(res).toMatchObject({ ok: true, listingId: 55, netProceeds: 950 });
+    });
+
+    it.each(["NOT_OWNED", "ALREADY_OWNED_REQUESTER", "IS_BUYER"])("%s 不結算成就", async code => {
+      PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+      stubInventoryReads({
+        balance: 0,
+        owns: {
+          [BUYER]: code === "ALREADY_OWNED_REQUESTER",
+          [SELLER]: code !== "NOT_OWNED",
+        },
+      });
+      if (code === "NOT_OWNED") InventoryModel.deleteUserItem.mockResolvedValue(0);
+
+      const res = await Service.fulfill(55, code === "IS_BUYER" ? BUYER : SELLER);
+
+      expect(res.code).toBe(code);
+      expect(AchievementEngine.evaluate).not.toHaveBeenCalled();
+    });
+
+    it("取消收購單不算一次交易成就", async () => {
+      PublicMarketModel.lockById.mockResolvedValue(buyOrder());
+
+      await Service.cancelListing(55, BUYER);
+
+      expect(AchievementEngine.evaluate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/src/templates/application/PublicMarket.js
+++ b/app/src/templates/application/PublicMarket.js
@@ -5,8 +5,8 @@ const { getLiffUri } = require("../common");
  * 版型來自設計稿 line-flex-market.json，數字改為由 service 帶入。
  *
  * @param {Object} param0
- * @param {Number} param0.myOpenCount 我的開放掛單數
- * @param {Number} param0.maxOpen 掛單上限
+ * @param {Number} param0.myOpenCount 我的開放掛單數（賣單 + 收購單合計）
+ * @param {Number} param0.maxOpen 掛單上限（兩種方向共用）
  * @param {Number} param0.totalOpenCount 全站開放掛單數
  * @param {Number} param0.feePercent 手續費百分比
  * @returns {Object} Flex bubble
@@ -55,7 +55,7 @@ exports.generateMarketBubble = ({ myOpenCount, maxOpen, totalOpenCount, feePerce
         },
         {
           type: "text",
-          text: "角色掛單簿 · 最低價優先",
+          text: "賣單最低價 · 收購單最高價",
           size: "xs",
           color: "#CDEFF3",
           margin: "sm",
@@ -74,7 +74,7 @@ exports.generateMarketBubble = ({ myOpenCount, maxOpen, totalOpenCount, feePerce
           contents: [
             {
               type: "text",
-              text: "我的開放掛單",
+              text: "我的開放委託",
               size: "sm",
               color: "#5A6B7F",
               flex: 0,
@@ -108,6 +108,13 @@ exports.generateMarketBubble = ({ myOpenCount, maxOpen, totalOpenCount, feePerce
           ],
         },
         {
+          type: "text",
+          text: "賣單 + 收購單合計",
+          size: "xxs",
+          color: "#5A6B7F",
+          margin: "sm",
+        },
+        {
           type: "separator",
           margin: "lg",
           color: "#E8EEF0",
@@ -119,7 +126,7 @@ exports.generateMarketBubble = ({ myOpenCount, maxOpen, totalOpenCount, feePerce
           contents: [
             {
               type: "text",
-              text: "全站開放掛單",
+              text: "全站開放委託",
               size: "sm",
               color: "#5A6B7F",
               flex: 0,
@@ -211,6 +218,16 @@ exports.generateMarketBubble = ({ myOpenCount, maxOpen, totalOpenCount, feePerce
             type: "uri",
             label: "我要掛賣單",
             uri: getLiffUri("full", "/trade/sell"),
+          },
+        },
+        {
+          type: "button",
+          style: "link",
+          height: "sm",
+          action: {
+            type: "uri",
+            label: "我要發收購單",
+            uri: getLiffUri("full", "/trade/buy"),
           },
         },
       ],

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import TradeDetail from "./pages/Trade/TradeDetail";
 import Market from "./pages/Trade/Market";
 import MarketListing from "./pages/Trade/MarketListing";
 import MarketSell from "./pages/Trade/Sell";
+import MarketBuy from "./pages/Trade/Buy";
 import MyListings from "./pages/Trade/MyListings";
 import GroupList from "./pages/Group";
 import GroupRecord from "./pages/Group/Record";
@@ -80,9 +81,10 @@ export default function App() {
 
           {/* Trade */}
           {/* 公開市場 / 角色委託所 —— 必須排在 trade/:marketId 之前，
-              否則 "market" / "sell" / "my-listings" 會被當成 marketId 吃掉。 */}
+              否則 "market" / "sell" / "buy" / "my-listings" 會被當成 marketId 吃掉。 */}
           <Route path="trade/market" element={<Market />} />
           <Route path="trade/sell" element={<MarketSell />} />
+          <Route path="trade/buy" element={<MarketBuy />} />
           <Route path="trade/my-listings" element={<MyListings />} />
           <Route path="trade/listings/:id" element={<MarketListing />} />
           <Route path="trade/order" element={<TradeOrder />} />

--- a/frontend/src/pages/Trade/Buy.jsx
+++ b/frontend/src/pages/Trade/Buy.jsx
@@ -41,9 +41,15 @@ import {
 import { CharAvatar, GradientPanel } from "./_marketUi";
 
 /* ---------------------------------------------------------------- banner */
-function SummaryBanner({ balance, openCount, maxOpen, capped, loading }) {
+/**
+ * 收購單的 banner 多一格「本次預扣」：發布當下錢就離開錢包，
+ * 這是跟賣單最大的差別，所以放在最顯眼的位置，不是塞在下面的明細裡。
+ */
+function SummaryBanner({ balance, openCount, maxOpen, capped, reserve, loading }) {
+  const after = Math.max(0, Number(balance ?? 0) - Number(reserve ?? 0));
+
   return (
-    <GradientPanel tone="sell">
+    <GradientPanel tone="buy">
       <Box sx={{ display: "flex", alignItems: "flex-end", gap: 1.5 }}>
         <Box>
           <Typography sx={{ fontSize: 11.5, opacity: 0.88, letterSpacing: ".4px" }}>
@@ -97,9 +103,31 @@ function SummaryBanner({ balance, openCount, maxOpen, capped, loading }) {
         )}
       </Box>
 
-      <Typography sx={{ fontSize: 11, opacity: 0.85, lineHeight: 1.6, mt: 1.25 }}>
-        賣單與收購單合計上限 {maxOpen} 筆。
-      </Typography>
+      {reserve > 0 && !capped && (
+        <Box
+          aria-live="polite"
+          sx={{
+            mt: 1.5,
+            pt: 1.25,
+            borderTop: "1px solid rgba(255,255,255,.24)",
+            display: "flex",
+            alignItems: "baseline",
+            gap: 0.75,
+            fontSize: 12.5,
+            ...NUMS,
+          }}
+        >
+          <Box component="span" sx={{ opacity: 0.88 }}>
+            發布後預扣
+          </Box>
+          <Box component="b" sx={{ fontSize: 15, fontWeight: 700 }}>
+            −{fmtStone(reserve)}
+          </Box>
+          <Box component="span" sx={{ ml: "auto", opacity: 0.88 }}>
+            餘額剩 {fmtStone(after)}
+          </Box>
+        </Box>
+      )}
     </GradientPanel>
   );
 }
@@ -122,42 +150,53 @@ function Label({ children }) {
   );
 }
 
-/* ---------------------------------------------------------------- 費用明細 */
-function FeeBreakdown({ price, feeLabel = "手續費（5%）", netLabel = "實收", showBurnNote }) {
+/* ---------------------------------------------------------------- 金流明細 */
+/**
+ * 收購單有兩條線：你付出的全額，跟賣家真正拿到的數字。
+ * 兩個都要寫出來，不然賣家會以為出價 1000 就能拿滿 1000。
+ */
+function BuyBreakdown({ price }) {
   const fee = calcFee(price);
   const net = calcNet(price);
-  const line = (label, value, sx) => (
-    <Box
-      sx={{
-        display: "flex",
-        alignItems: "baseline",
-        justifyContent: "space-between",
-        py: 0.75,
-        ...sx,
-      }}
-    >
-      <Typography component="span" sx={{ fontSize: 13, color: "text.secondary" }}>
-        {label}
-      </Typography>
-      {value}
+
+  const line = (label, value, hint) => (
+    <Box sx={{ py: 0.75 }}>
+      <Box sx={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
+        <Typography component="span" sx={{ fontSize: 13, color: "text.secondary" }}>
+          {label}
+        </Typography>
+        {value}
+      </Box>
+      {hint && (
+        <Typography sx={{ fontSize: 11, color: "text.secondary", lineHeight: 1.6, mt: 0.25 }}>
+          {hint}
+        </Typography>
+      )}
     </Box>
   );
 
   return (
     <Box aria-live="polite">
       {line(
-        "售價",
+        "你的出價",
         <Box component="b" sx={{ fontSize: 15, fontWeight: 600, ...NUMS }}>
           {fmtStone(price)}
         </Box>
       )}
       {line(
-        feeLabel,
+        "發布時預扣",
         <Box component="b" sx={{ fontSize: 15, fontWeight: 600, color: "error.main", ...NUMS }}>
-          −{fmtStone(fee)}
-        </Box>
+          −{fmtStone(price)}
+        </Box>,
+        "全額先從錢包扣起來鎖住，成交前不能動用。"
       )}
       <Divider sx={{ my: 1 }} />
+      {line(
+        "手續費（5%，銷毀）",
+        <Box component="b" sx={{ fontSize: 14, fontWeight: 600, color: "text.secondary", ...NUMS }}>
+          {fmtStone(fee)}
+        </Box>
+      )}
       <Box
         sx={{
           display: "flex",
@@ -167,33 +206,31 @@ function FeeBreakdown({ price, feeLabel = "手續費（5%）", netLabel = "實�
         }}
       >
         <Typography component="span" sx={{ fontSize: 13.5, fontWeight: 600 }}>
-          {netLabel}
+          成交時賣家實收
         </Typography>
-        <Box component="b" sx={{ fontSize: 22, fontWeight: 600, color: "primary.main", ...NUMS }}>
+        <Box component="b" sx={{ fontSize: 22, fontWeight: 600, color: "secondary.main", ...NUMS }}>
           {fmtStone(net)}
         </Box>
       </Box>
-      {showBurnNote && (
-        <Typography
-          sx={{
-            mt: 1.25,
-            pt: 1.25,
-            borderTop: "1px dashed",
-            borderColor: "divider",
-            fontSize: 11.5,
-            color: "text.secondary",
-            lineHeight: 1.65,
-          }}
-        >
-          手續費的女神石會直接銷毀，不會進到任何人的口袋。
-        </Typography>
-      )}
+      <Typography
+        sx={{
+          mt: 1.25,
+          pt: 1.25,
+          borderTop: "1px dashed",
+          borderColor: "divider",
+          fontSize: 11.5,
+          color: "text.secondary",
+          lineHeight: 1.65,
+        }}
+      >
+        取消或失效時，預扣的 {fmtStone(price)} 女神石會原數退回，不收任何費用。
+      </Typography>
     </Box>
   );
 }
 
 /* ---------------------------------------------------------------- 主頁面 */
-export default function Sell() {
+export default function Buy() {
   const { loggedIn: isLoggedIn } = useLiff();
   const navigate = useNavigate();
 
@@ -204,7 +241,11 @@ export default function Sell() {
 
   const [{ data: summary, loading: summaryLoading, error: summaryError }, refetchSummary] =
     useAxios("/api/public-market/summary", { manual: true });
-  const [{ data: inventoryItems = [], loading: invLoading }, fetchItems] = useAxios(
+  const [{ data: pool, loading: poolLoading, error: poolError }, fetchPool] = useAxios(
+    "/api/inventory/pool",
+    { manual: true }
+  );
+  const [{ data: inventoryItems, loading: invLoading, error: invError }, fetchItems] = useAxios(
     "/api/inventory",
     { manual: true }
   );
@@ -215,24 +256,41 @@ export default function Sell() {
   const [{ message, severity, open: snackOpen }, { handleOpen, handleClose }] = useHintBar();
 
   useEffect(() => {
-    document.title = "掛賣單";
+    document.title = "發布收購單";
   }, []);
 
   useEffect(() => {
     if (!isLoggedIn) return;
     refetchSummary();
-    fetchItems();
-  }, [isLoggedIn, refetchSummary, fetchItems]);
+    fetchPool().catch(() => {});
+    fetchItems().catch(() => {});
+  }, [isLoggedIn, refetchSummary, fetchPool, fetchItems]);
 
-  // 石頭本身是背包裡的 itemId 999，不是可以掛賣的角色。
-  const characters = useMemo(
-    () => (Array.isArray(inventoryItems) ? inventoryItems : []).filter(i => i.itemId !== 999),
+  // 背包裡的 itemId 999 是女神石本身，不是角色。
+  const ownedIds = useMemo(
+    () =>
+      new Set(
+        (Array.isArray(inventoryItems) ? inventoryItems : [])
+          .filter(i => i.itemId !== 999)
+          .map(i => String(i.itemId))
+      ),
     [inventoryItems]
   );
 
+  // 收購單只能掛「自己沒有的」角色：角色一人一隻，收到手也不會生效。
+  // 背包還沒回來就不能過濾，否則會把已持有的角色一起放進選單。
+  const ownedKnown = Array.isArray(inventoryItems) && !invError;
+  const candidates = useMemo(() => {
+    if (!Array.isArray(pool) || !ownedKnown) return [];
+    return pool.filter(c => !ownedIds.has(String(c.itemId)));
+  }, [pool, ownedIds, ownedKnown]);
+
+  // selected 只從 candidates 裡查。背包晚一步回來、或使用者中途自己抽到同一隻角色時，
+  // 那位角色會直接從 candidates 消失，selected 自然變回 null —— 不用另外寫一個
+  // effect 去清 state，也就不會有「畫面還顯示著、送出卻被拒」的空窗。
   const selected = useMemo(
-    () => characters.find(c => c.itemId === selectedId) || null,
-    [characters, selectedId]
+    () => candidates.find(c => c.itemId === selectedId) || null,
+    [candidates, selectedId]
   );
 
   const maxOpen = summary?.maxOpen ?? MAX_OPEN_FALLBACK;
@@ -241,26 +299,48 @@ export default function Sell() {
 
   const priceNum = Number(price);
   const priceValid = Number.isInteger(priceNum) && priceNum >= PRICE_MIN && priceNum <= PRICE_MAX;
-  const submittable = !capped && selectedId != null && priceValid && !creating;
+
+  const balance = summary?.balance;
+  // 餘額還沒讀到就不預先擋人：真正的判斷在後端，前端先擋只是省一次來回。
+  const balanceKnown = Number.isFinite(Number(balance));
+  const short = priceValid && balanceKnown && Number(balance) < priceNum;
+
+  const listLoading = poolLoading || invLoading;
+  const listBroken = Boolean(poolError) || Boolean(invError);
+
+  const submittable =
+    !capped && !short && !listBroken && selected != null && priceValid && !creating;
 
   const handleSubmit = async () => {
     setConfirmOpen(false);
+    if (!selected) return;
     try {
-      const { data } = await createListing({ data: { itemId: selectedId, price: priceNum } });
+      const { data } = await createListing({
+        data: { orderType: "buy", itemId: selected.itemId, price: priceNum },
+      });
       handleOpen(
-        `已建立委託：${data.name ?? selected?.name ?? "角色"} ${fmtStone(data.price ?? priceNum)} 女神石`,
+        `已發布收購單：${data.name ?? selected?.name ?? "角色"} ${fmtStone(data.price ?? priceNum)} 女神石（已預扣）`,
         "success"
       );
       refetchSummary();
       setTimeout(() => navigate("/trade/my-listings"), 1200);
     } catch (err) {
-      const { title, detail } = errorInfo(err, "掛單失敗，請稍後再試");
+      const { title, detail } = errorInfo(err, "發布收購單失敗，請稍後再試");
       handleOpen(detail ? `${title}，${detail}` : title, "error");
       refetchSummary();
+      fetchItems().catch(() => {});
     }
   };
 
   if (!isLoggedIn) return <AlertLogin />;
+
+  const pickerHint = listLoading
+    ? "載入角色清單中…"
+    : listBroken
+      ? "角色清單載入失敗"
+      : candidates.length === 0
+        ? "沒有可收購的角色"
+        : "點此選擇角色";
 
   return (
     <Box
@@ -272,7 +352,7 @@ export default function Sell() {
     >
       <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.75 }}>
         <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: "1 1 auto" }}>
-          掛賣單
+          發布收購單
         </Typography>
         <IconButton aria-label="我的掛單" onClick={() => navigate("/trade/my-listings")}>
           <ReceiptLongIcon />
@@ -283,10 +363,11 @@ export default function Sell() {
         <Skeleton variant="rounded" height={92} animation="wave" />
       ) : (
         <SummaryBanner
-          balance={summary?.balance}
+          balance={balance}
           openCount={openCount}
           maxOpen={maxOpen}
           capped={capped}
+          reserve={priceValid ? priceNum : 0}
           loading={summaryLoading && !summary}
         />
       )}
@@ -294,6 +375,25 @@ export default function Sell() {
       {summaryError && (
         <Alert severity="error" sx={{ borderRadius: 3, mt: 1.75 }}>
           載入掛單狀態失敗，請稍後再試
+        </Alert>
+      )}
+
+      {listBroken && (
+        <Alert severity="error" sx={{ borderRadius: 3, mt: 1.75 }}>
+          <AlertTitle sx={{ fontSize: 13.5, fontWeight: 700, mb: 0.25 }}>讀不到角色清單</AlertTitle>
+          <Typography sx={{ fontSize: 12, lineHeight: 1.7, color: "text.secondary" }}>
+            沒辦法確認你已經擁有哪些角色，先不開放發布，以免掛到已持有的角色。
+          </Typography>
+          <Button
+            size="small"
+            sx={{ mt: 0.75 }}
+            onClick={() => {
+              fetchPool().catch(() => {});
+              fetchItems().catch(() => {});
+            }}
+          >
+            重試
+          </Button>
         </Alert>
       )}
 
@@ -309,7 +409,7 @@ export default function Sell() {
       )}
 
       <Box sx={{ opacity: capped ? 0.55 : 1, pointerEvents: capped ? "none" : "auto" }}>
-        <Label>要賣的角色</Label>
+        <Label>想收購的角色</Label>
         <Paper
           component="button"
           type="button"
@@ -317,7 +417,7 @@ export default function Sell() {
           onClick={() => setPickerOpen(true)}
           aria-haspopup="dialog"
           aria-disabled={capped || undefined}
-          disabled={capped || invLoading}
+          disabled={capped || listLoading || listBroken || candidates.length === 0}
           sx={theme => ({
             width: "100%",
             display: "flex",
@@ -333,9 +433,10 @@ export default function Sell() {
             color: "text.primary",
             font: "inherit",
             "&:hover": {
-              borderColor: "primary.light",
-              bgcolor: alpha(theme.palette.primary.main, 0.06),
+              borderColor: "secondary.light",
+              bgcolor: alpha(theme.palette.secondary.main, 0.06),
             },
+            "&:disabled": { cursor: "default" },
           })}
         >
           {selected ? (
@@ -356,22 +457,38 @@ export default function Sell() {
             </>
           ) : (
             <Typography sx={{ fontSize: 15, color: "text.secondary", py: 0.75 }}>
-              {invLoading ? "載入背包中…" : "點此選擇角色"}
+              {pickerHint}
             </Typography>
           )}
           <ChevronRightIcon sx={{ ml: "auto", color: "text.secondary" }} />
         </Paper>
+        <Typography
+          sx={{ fontSize: 11.5, color: "text.secondary", lineHeight: 1.6, mt: 0.75, mx: 0.25 }}
+        >
+          只列出你還沒有的角色。角色一人一隻，已持有的收到也不會生效。
+        </Typography>
 
-        <Label>售價</Label>
+        {!listLoading && !listBroken && candidates.length === 0 && (
+          <Alert severity="info" sx={{ borderRadius: 3, mt: 1.25 }}>
+            你已經蒐集完所有角色了，沒有可以收購的對象。
+          </Alert>
+        )}
+
+        <Label>收購價</Label>
         <TextField
           fullWidth
-          id="priceInput"
-          label="單價（女神石）"
+          id="buyPriceInput"
+          label="出價（女神石）"
           value={price}
           onChange={e => setPrice(e.target.value.replace(/[^0-9]/g, ""))}
           disabled={capped}
-          error={price !== "" && !priceValid}
-          helperText="可填 1 ～ 10,000,000。買家付的就是這個價。"
+          color="secondary"
+          error={(price !== "" && !priceValid) || short}
+          helperText={
+            short
+              ? `女神石不足，餘額 ${fmtStone(balance)}，還差 ${fmtStone(priceNum - Number(balance))}`
+              : "可填 1 ～ 10,000,000。發布時就會先預扣這個金額。"
+          }
           slotProps={{
             input: {
               endAdornment: (
@@ -383,8 +500,7 @@ export default function Sell() {
               ),
               sx: { "& input": { fontSize: 19, fontWeight: 600, ...NUMS } },
             },
-
-            htmlInput: { inputMode: "numeric", pattern: "[0-9]*", "aria-describedby": "priceHelp" },
+            htmlInput: { inputMode: "numeric", pattern: "[0-9]*" },
           }}
         />
         <Box
@@ -401,24 +517,24 @@ export default function Sell() {
               aria-pressed={String(p) === price}
               onClick={() => setPrice(String(p))}
               variant={String(p) === price ? "filled" : "outlined"}
-              color={String(p) === price ? "primary" : "default"}
+              color={String(p) === price ? "secondary" : "default"}
               sx={{ fontWeight: 600, ...NUMS }}
             />
           ))}
         </Box>
 
-        <Label>成交後的金額</Label>
+        <Label>金額怎麼走</Label>
         <Paper
           elevation={0}
           sx={{ px: 1.75, py: 1.5, borderRadius: 3, border: "1px solid", borderColor: "divider" }}
         >
-          <FeeBreakdown price={priceValid ? priceNum : 0} showBurnNote />
+          <BuyBreakdown price={priceValid ? priceNum : 0} />
         </Paper>
       </Box>
 
       {capped ? (
         <>
-          <Button variant="contained" disabled sx={{ mt: 2, py: 1.625 }}>
+          <Button variant="contained" color="secondary" disabled sx={{ mt: 2, py: 1.625 }}>
             掛單數已達上限
           </Button>
           <Button variant="text" onClick={() => navigate("/trade/my-listings")} sx={{ mt: 0.75 }}>
@@ -428,21 +544,22 @@ export default function Sell() {
       ) : (
         <Button
           variant="contained"
+          color="secondary"
           disabled={!submittable}
           onClick={() => setConfirmOpen(true)}
           sx={{ mt: 2, py: 1.625 }}
         >
-          送出掛單
+          {short ? "女神石不足" : "發布收購單"}
         </Button>
       )}
 
       <CharacterPickerDrawer
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        items={characters}
+        items={candidates}
         initialId={selectedId}
         onConfirm={id => setSelectedId(id)}
-        title="選擇角色"
+        title="選擇想收購的角色"
       />
 
       <Dialog
@@ -450,20 +567,36 @@ export default function Sell() {
         onClose={() => setConfirmOpen(false)}
         fullWidth
         maxWidth="xs"
-        aria-labelledby="sell-confirm-title"
+        aria-labelledby="buy-order-confirm-title"
       >
-        <DialogTitle id="sell-confirm-title" sx={{ fontWeight: 600 }}>
-          確認掛單？
+        <DialogTitle id="buy-order-confirm-title" sx={{ fontWeight: 600 }}>
+          確認發布收購單？
         </DialogTitle>
         <DialogContent>
           <Alert severity="warning" sx={{ borderRadius: 3, mb: 1.5 }}>
             <AlertTitle sx={{ fontSize: 13.5, fontWeight: 700, mb: 0.5 }}>
-              你的升星強化不會轉移
+              發布當下就會預扣全額
             </AlertTitle>
-            <Typography sx={{ fontSize: 12, lineHeight: 1.7, color: "text.secondary" }}>
-              賣掉後，買家拿到的是<strong>初始星數</strong>
-              的角色。你之前用女神石升上去的星等會直接消失，也不會退錢。
-            </Typography>
+            <Box
+              component="ul"
+              sx={{
+                m: 0,
+                pl: 2.25,
+                fontSize: 12,
+                lineHeight: 1.8,
+                color: "text.secondary",
+              }}
+            >
+              <li>
+                現在扣 <strong>{fmtStone(priceValid ? priceNum : 0)}</strong>{" "}
+                女神石，掛單期間這筆錢不能動用。
+              </li>
+              <li>取消或失效時，全額退還，不收任何費用。</li>
+              <li>
+                成交時賣家實收 <strong>{fmtStone(calcNet(priceValid ? priceNum : 0))}</strong>
+                ，手續費 5%（{fmtStone(calcFee(priceValid ? priceNum : 0))}）銷毀。
+              </li>
+            </Box>
           </Alert>
 
           {selected && (
@@ -496,18 +629,28 @@ export default function Sell() {
             </Box>
           )}
 
-          <FeeBreakdown
-            price={priceValid ? priceNum : 0}
-            feeLabel="手續費（5%，銷毀）"
-            netLabel="成交後實收"
-          />
+          <BuyBreakdown price={priceValid ? priceNum : 0} />
+
+          {balanceKnown && priceValid && (
+            <Typography
+              sx={{ mt: 1.25, fontSize: 11.5, color: "text.secondary", lineHeight: 1.6, ...NUMS }}
+            >
+              餘額 {fmtStone(balance)} → {fmtStone(Number(balance) - priceNum)} 女神石。
+            </Typography>
+          )}
         </DialogContent>
         <DialogActions>
           <Button color="inherit" onClick={() => setConfirmOpen(false)} disabled={creating}>
             取消
           </Button>
-          <Button variant="contained" onClick={handleSubmit} disabled={creating} autoFocus>
-            確認掛單
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={handleSubmit}
+            disabled={creating}
+            autoFocus
+          >
+            確認發布
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/pages/Trade/Market.jsx
+++ b/frontend/src/pages/Trade/Market.jsx
@@ -25,8 +25,18 @@ import AlertLogin from "../../components/AlertLogin";
 import HintSnackBar from "../../components/HintSnackBar";
 import useHintBar from "../../hooks/useHintBar";
 import useLiff from "../../context/useLiff";
-import { NUMS, calcFee, displayName, errorText, fmtStone } from "./_market";
-import { CharAvatar, BaseStar, GradientPanel, Row, Tag } from "./_marketUi";
+import {
+  NUMS,
+  ORDER_COPY,
+  calcFee,
+  calcNet,
+  displayName,
+  errorText,
+  fmtStone,
+  normalizeOrderType,
+  posterNameOf,
+} from "./_market";
+import { CharAvatar, BaseStar, GradientPanel, OrderTypeSwitch, Row, Tag } from "./_marketUi";
 
 /* ---------------------------------------------------------------- 錢包 chip */
 function WalletChip({ balance, loading }) {
@@ -81,7 +91,8 @@ function PageHeader({ balance, loading }) {
 }
 
 /* ---------------------------------------------------------------- 角色 chip */
-function CharacterChip({ char, selected, onClick }) {
+function CharacterChip({ char, selected, onClick, buy }) {
+  const accent = buy ? "secondary" : "primary";
   return (
     <Box
       component="button"
@@ -102,13 +113,13 @@ function CharacterChip({ char, selected, onClick }) {
         fontWeight: 600,
         color: selected
           ? theme.palette.mode === "dark"
-            ? theme.palette.primary.light
-            : theme.palette.primary.dark
+            ? theme.palette[accent].light
+            : theme.palette[accent].dark
           : theme.palette.text.primary,
         border: "1px solid",
-        borderColor: selected ? "primary.main" : "divider",
+        borderColor: selected ? `${accent}.main` : "divider",
         bgcolor: selected
-          ? alpha(theme.palette.primary.main, 0.14)
+          ? alpha(theme.palette[accent].main, 0.14)
           : theme.palette.background.paper,
         transition: "transform .16s ease, box-shadow .16s ease, background .16s ease",
         "&:hover": { transform: "translateY(-1px)", boxShadow: theme.shadows[2] },
@@ -142,9 +153,28 @@ function CharacterChip({ char, selected, onClick }) {
 }
 
 /* ---------------------------------------------------------------- 掛單一列 */
-function OrderCard({ listing, lowest, onBuy }) {
+/**
+ * 一列同時服務兩本簿子。差別只有三處，其餘版面刻意保持一致：
+ *   1. 副標的角色（賣家 / 收購方）
+ *   2. 價格底下多一行「你實收」——收購單看的是拿到手的數字
+ *   3. 主按鈕（立即購買 / 賣給他）與它被擋下來的理由
+ */
+function OrderCard({ listing, orderType, best, onAct, blockReason }) {
+  const buy = orderType === "buy";
+  const copy = ORDER_COPY[orderType];
   const mine = Boolean(listing.mine);
   const navigate = useNavigate();
+  const accent = buy ? "secondary" : "primary";
+
+  const disabledLabel = mine
+    ? buy
+      ? "這是你自己發的收購單，無法賣給自己"
+      : "這是你自己的掛單，無法購買"
+    : blockReason === "NOT_OWNED"
+      ? `你沒有${listing.name}，無法賣出`
+      : null;
+  const disabled = Boolean(disabledLabel);
+
   return (
     <Paper
       component="li"
@@ -163,13 +193,15 @@ function OrderCard({ listing, lowest, onBuy }) {
           boxShadow: theme.shadows[4],
           borderColor: mine
             ? alpha(theme.palette.secondary.main, 0.6)
-            : alpha(theme.palette.primary.main, 0.4),
+            : alpha(theme.palette[accent].main, 0.4),
         },
       })}
     >
       <CharAvatar itemId={listing.itemId} name={listing.name} headImage={listing.headImage} />
       <Box
-        onClick={() => navigate(`/trade/listings/${listing.id}`, { state: { fromMarket: true } })}
+        onClick={() =>
+          navigate(`/trade/listings/${listing.id}`, { state: { fromMarket: true, orderType } })
+        }
         sx={{ flex: "1 1 auto", minWidth: 0, cursor: "pointer" }}
       >
         <Box
@@ -184,8 +216,8 @@ function OrderCard({ listing, lowest, onBuy }) {
         >
           {listing.name}
           <BaseStar star={listing.star} />
-          {lowest && !mine && <Tag label="最低價" color="success" />}
-          {mine && <Tag label="你的掛單" color="secondary" />}
+          {best && !mine && <Tag label={copy.best} color="success" />}
+          {mine && <Tag label={buy ? "你的收購單" : "你的掛單"} color="secondary" />}
         </Box>
         <Typography
           variant="caption"
@@ -193,7 +225,7 @@ function OrderCard({ listing, lowest, onBuy }) {
           noWrap
           sx={{ display: "block", mt: "3px" }}
         >
-          賣家 {displayName(listing.sellerName)} ・ {listing.itemId}
+          {copy.poster} {displayName(posterNameOf(listing))} ・ {listing.itemId}
         </Typography>
         <Box
           sx={theme => ({
@@ -203,7 +235,7 @@ function OrderCard({ listing, lowest, onBuy }) {
             mt: 0.625,
             fontSize: 15,
             fontWeight: 600,
-            color: theme.palette.mode === "dark" ? "primary.light" : "primary.dark",
+            color: theme.palette.mode === "dark" ? `${accent}.light` : `${accent}.dark`,
             ...NUMS,
           })}
         >
@@ -213,9 +245,14 @@ function OrderCard({ listing, lowest, onBuy }) {
             女神石
           </Box>
         </Box>
+        {buy && (
+          <Typography sx={{ fontSize: 11.5, color: "text.secondary", mt: "2px", ...NUMS }}>
+            你實收 {fmtStone(listing.netProceeds ?? calcNet(listing.price))}（扣 5% 手續費）
+          </Typography>
+        )}
       </Box>
-      {mine ? (
-        // 依設計稿：自己的掛單保留按鈕但停用。用 aria-disabled 而非 disabled，
+      {disabled ? (
+        // 依設計稿：不能操作時保留按鈕但停用。用 aria-disabled 而非 disabled，
         // 讀屏會唸出來；同時不掛 onClick，按下去真的不會發生任何事。
         <Button
           size="small"
@@ -224,7 +261,7 @@ function OrderCard({ listing, lowest, onBuy }) {
           role="button"
           tabIndex={0}
           aria-disabled="true"
-          aria-label="這是你自己的掛單，無法購買"
+          aria-label={disabledLabel}
           sx={{
             flex: "0 0 auto",
             color: "text.secondary",
@@ -237,16 +274,17 @@ function OrderCard({ listing, lowest, onBuy }) {
             },
           }}
         >
-          立即購買
+          {copy.action}
         </Button>
       ) : (
         <Button
           size="small"
           variant="contained"
-          onClick={() => onBuy(listing)}
+          color={accent}
+          onClick={() => onAct(listing)}
           sx={{ flex: "0 0 auto" }}
         >
-          立即購買
+          {copy.action}
         </Button>
       )}
     </Paper>
@@ -254,7 +292,8 @@ function OrderCard({ listing, lowest, onBuy }) {
 }
 
 /* ---------------------------------------------------------------- 空狀態 */
-function EmptyBook({ onBackToAll }) {
+function EmptyBook({ orderType, onBackToAll }) {
+  const buy = orderType === "buy";
   return (
     <Paper
       elevation={0}
@@ -278,22 +317,32 @@ function EmptyBook({ onBackToAll }) {
           height: 72,
           borderRadius: "50%",
           border: "2px dashed",
-          borderColor: alpha(theme.palette.primary.main, 0.45),
+          borderColor: alpha(theme.palette[buy ? "secondary" : "primary"].main, 0.45),
           display: "grid",
           placeItems: "center",
-          color: "primary.main",
+          color: buy ? "secondary.main" : "primary.main",
           fontSize: 26,
         })}
       >
         ◌
       </Box>
       <Typography variant="subtitle1" sx={{ fontWeight: 600, mt: 0.5 }}>
-        該角色目前沒有掛單
+        {buy ? "目前沒有人收購這個角色" : "該角色目前沒有掛單"}
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.7 }}>
-        等其他玩家上架，或改看別的角色。
-        <br />
-        你也可以自己掛一張。
+        {buy ? (
+          <>
+            等其他玩家發收購單，或改看別的角色。
+            <br />
+            你也可以自己掛一張賣單等人來買。
+          </>
+        ) : (
+          <>
+            等其他玩家上架，或改看別的角色。
+            <br />
+            你也可以自己掛一張。
+          </>
+        )}
       </Typography>
       <Button variant="outlined" onClick={onBackToAll} sx={{ mt: 0.75 }}>
         看其他角色
@@ -329,6 +378,9 @@ export default function Market() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [keyword, setKeyword] = useState("");
+  // 一個 state 服務兩本簿子：all 是全部，filtered 的意思隨方向改變
+  //（賣單＝我沒有的，收購單＝我持有的）。兩本的「另一半」在概念上是同一件事：
+  // 只留下我真的能操作的角色。
   const [view, setView] = useState("all");
   const [pending, setPending] = useState(null);
 
@@ -336,83 +388,133 @@ export default function Market() {
     "/api/public-market/summary",
     { manual: true }
   );
-  const [{ data: characters, loading: charsLoading, error: charsError }, refetchChars] = useAxios(
-    "/api/public-market/characters",
-    { manual: true }
-  );
+  const [{ loading: charsLoading }, fetchChars] = useAxios("/api/public-market/characters", {
+    manual: true,
+  });
   const [{ data: inventory, error: invError }, refetchInventory] = useAxios("/api/inventory", {
     manual: true,
   });
   const [{ loading: listingsLoading }, fetchListings] = useAxios("/api/public-market/listings", {
     manual: true,
   });
-  const [{ loading: buying }, purchase] = useAxios({ method: "POST" }, { manual: true });
+  const [{ loading: acting }, submitAction] = useAxios({ method: "POST" }, { manual: true });
   const [{ message, severity, open: snackOpen }, { handleOpen, handleClose }] = useHintBar();
 
   useEffect(() => {
     document.title = "角色交易所";
   }, []);
 
+  /* ---- 網址是唯一的真相 ------------------------------------------------ */
+  // 方向與選了誰都只存在 query 裡，不再另外開一份 state，免得兩邊互相覆寫。
+  // 上一頁／下一頁、重新整理、分享連結因此自然可用。
+  const rawOrderType = searchParams.get("orderType");
+  const orderType = normalizeOrderType(rawOrderType);
+  const buy = orderType === "buy";
+  const copy = ORDER_COPY[orderType];
+  const queryId = searchParams.get("characterId");
+
+  // 網址被亂改成 ?orderType=xxx 時安靜正規化，不然分享出去的連結會一直帶著噪音。
+  useEffect(() => {
+    if (rawOrderType == null || rawOrderType === "buy" || rawOrderType === "sell") return;
+    const next = {};
+    if (queryId) next.characterId = queryId;
+    setSearchParams(next, { replace: true });
+  }, [rawOrderType, queryId, setSearchParams]);
+
+  const buildParams = useCallback((type, characterId) => {
+    const next = {};
+    // sell 是預設值，不寫進網址，第一階段留下來的連結才不會突然多一段參數。
+    if (type === "buy") next.orderType = "buy";
+    if (characterId) next.characterId = String(characterId);
+    return next;
+  }, []);
+
+  /* ---- 角色清單：跟著方向走 -------------------------------------------- */
+  // 兩本簿子的角色清單完全不同，所以資料要記住「這份是誰的」，
+  // 換方向的那一幀才不會拿舊清單去驗新網址（會把合法的 characterId 誤刪）。
+  const [chars, setChars] = useState({ type: null, ok: false, rows: [] });
+  const charSeq = useRef(0);
+
+  const loadCharacters = useCallback(
+    async type => {
+      const seq = ++charSeq.current;
+      try {
+        const { data } = await fetchChars({ params: { orderType: type } });
+        if (seq !== charSeq.current) return;
+        setChars({ type, ok: true, rows: Array.isArray(data) ? data : [] });
+      } catch {
+        if (seq !== charSeq.current) return;
+        setChars({ type, ok: false, rows: [] });
+      }
+    },
+    [fetchChars]
+  );
+
   useEffect(() => {
     if (!isLoggedIn) return;
     refetchSummary();
-    refetchChars();
     refetchInventory().catch(() => {});
-  }, [isLoggedIn, refetchSummary, refetchChars, refetchInventory]);
+  }, [isLoggedIn, refetchSummary, refetchInventory]);
 
-  const charList = useMemo(() => (Array.isArray(characters) ? characters : []), [characters]);
-  const charsLoaded = Array.isArray(characters);
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    loadCharacters(orderType);
+  }, [isLoggedIn, orderType, loadCharacters]);
 
-  // 網址是唯一的真相：選了誰只存在 query 裡，不再另外開一份 state，
-  // 免得兩邊互相覆寫。上一頁/下一頁因此自然可用。
-  const queryId = searchParams.get("characterId");
+  const charsCurrent = chars.type === orderType ? chars : null;
+  const charList = useMemo(() => (charsCurrent?.ok ? charsCurrent.rows : []), [charsCurrent]);
+  const charsLoaded = Boolean(charsCurrent?.ok);
+  const charsError = Boolean(charsCurrent) && !charsCurrent.ok;
+
   const selected = useMemo(
     () => (queryId ? charList.find(c => String(c.itemId) === queryId) || null : null),
     [charList, queryId]
   );
   const selectedId = selected ? String(selected.itemId) : null;
 
-  // 角色清單還沒回來就先不要退回選角畫面，不然重新整理會閃一下。
+  // 角色清單還沒回來就先不要退回選角畫面，不然重新整理／換方向會閃一下。
   // 清單真的抓失敗時要放行，否則畫面會卡在骨架上，連錯誤訊息都看不到。
   const resolvingQuery = Boolean(queryId) && !charsLoaded && !charsError;
 
-  // query 指到不存在的角色（角色被下架、網址被亂改），等資料到齊再安靜清掉。
+  // query 指到這本簿子裡不存在的角色（換方向、角色被下架、網址被亂改），
+  // 等這本的資料到齊再安靜清掉，方向本身保留。
   useEffect(() => {
     if (!charsLoaded || !queryId || selected) return;
-    setSearchParams({}, { replace: true });
-  }, [charsLoaded, queryId, selected, setSearchParams]);
+    setSearchParams(buildParams(orderType, null), { replace: true });
+  }, [charsLoaded, queryId, selected, orderType, buildParams, setSearchParams]);
 
-  // 掛單讀取只有這一條路：effect、購買後刷新、錯誤重試都呼叫它。
-  // book 只存「已經有結果」的那份資料（成功或失敗），in-flight 交給 axios-hooks 的
-  // loading 去講，所以這裡不用在 effect 裡同步寫 state。
-  // book.id 綁住這份資料屬於誰，換角色的那一幀就不會閃到上一位的價格。
-  const [book, setBook] = useState({ id: null, ok: false, rows: [] });
+  /* ---- 掛單本體 -------------------------------------------------------- */
+  // book.key 綁住這份資料屬於「哪本簿子的哪位角色」，換角色或換方向的那一幀
+  // 就不會閃到上一份的價格。
+  const [book, setBook] = useState({ key: null, ok: false, rows: [] });
   const reqSeq = useRef(0);
 
   const loadListings = useCallback(
-    async itemId => {
-      const id = String(itemId);
+    async (itemId, type) => {
+      const key = `${type}:${itemId}`;
       const seq = ++reqSeq.current;
       try {
-        const { data } = await fetchListings({ params: { itemId: id } });
-        // 慢回來的舊請求直接丟掉，不能蓋掉新角色的資料。
+        const { data } = await fetchListings({
+          params: { itemId: String(itemId), orderType: type },
+        });
+        // 慢回來的舊請求直接丟掉，不能蓋掉新資料。
         if (seq !== reqSeq.current) return;
-        setBook({ id, ok: true, rows: Array.isArray(data) ? data : [] });
+        setBook({ key, ok: true, rows: Array.isArray(data) ? data : [] });
       } catch {
         if (seq !== reqSeq.current) return;
-        setBook({ id, ok: false, rows: [] });
+        setBook({ key, ok: false, rows: [] });
       }
     },
     [fetchListings]
   );
 
-  // 只跟著 selectedId 走。charList 重抓會換新物件，但 id 是字串比對，不會多打一次。
+  // 只跟著 selectedId + orderType 走。charList 重抓會換新物件，但這裡比對的是字串。
   // （react-hooks/set-state-in-effect 會警告這裡：抓資料本來就得寫回 state，
   //   跟 repo 內其他 fetch-on-mount effect 同一類，eslint 設定刻意留成 warn。）
   useEffect(() => {
     if (!isLoggedIn || !selectedId) return;
-    loadListings(selectedId);
-  }, [isLoggedIn, selectedId, loadListings]);
+    loadListings(selectedId, orderType);
+  }, [isLoggedIn, selectedId, orderType, loadListings]);
 
   // 背包裡的 itemId 999 是女神石本身，不是角色。
   const ownedIds = useMemo(
@@ -424,54 +526,85 @@ export default function Market() {
       ),
     [inventory]
   );
-  // 背包沒載完就不能判斷「沒有的」，否則會把全部角色都說成未持有。
+  // 背包沒載完就不能判斷持有與否，否則會把全部角色都說成未持有。
   const ownedKnown = Array.isArray(inventory) && !invError;
-  const missingCount = useMemo(
-    () => (ownedKnown ? charList.filter(c => !ownedIds.has(String(c.itemId))).length : null),
-    [ownedKnown, charList, ownedIds]
-  );
-  const missingActive = view === "missing" && ownedKnown;
 
-  // 畫面永遠只看「這份資料是不是這位角色的」，避免顯示別人的價格。
-  // 結果還沒回來（換角色、第一次載入）就是 pending；重讀同一位角色時沿用既有列表，
-  // 購買後刷新才不會先閃成空的。
-  const current = book.id === selectedId ? book : null;
+  const matchesView = useCallback(
+    c => (buy ? ownedIds.has(String(c.itemId)) : !ownedIds.has(String(c.itemId))),
+    [buy, ownedIds]
+  );
+  const filteredCount = useMemo(
+    () => (ownedKnown ? charList.filter(matchesView).length : null),
+    [ownedKnown, charList, matchesView]
+  );
+  const filterActive = view === "filtered" && ownedKnown;
+
+  // 畫面永遠只看「這份資料是不是這本簿子這位角色的」。
+  const bookKey = selectedId ? `${orderType}:${selectedId}` : null;
+  const current = bookKey && book.key === bookKey ? book : null;
   const rows = current?.ok ? current.rows : [];
   const rowsPending = Boolean(selectedId) && (!current || listingsLoading);
   const rowsFailed = Boolean(current) && !current.ok && !listingsLoading;
   const showSkeleton = Boolean(selectedId) && !current;
 
+  // 收購單只有持有該角色的人能履約。背包讀不到就先不擋，交給後端把關，
+  // 免得把真的持有的人也一起關在門外。
+  const ownsSelected = selectedId ? ownedIds.has(selectedId) : false;
+  const blockReason = buy && ownedKnown && !ownsSelected ? "NOT_OWNED" : null;
+
   const filtered = useMemo(() => {
-    const base = missingActive ? charList.filter(c => !ownedIds.has(String(c.itemId))) : charList;
+    const base = filterActive ? charList.filter(matchesView) : charList;
     const q = keyword.trim().toLowerCase();
     if (!q) return base;
     return base.filter(c => c.name?.toLowerCase().includes(q) || String(c.itemId).includes(q));
-  }, [charList, keyword, missingActive, ownedIds]);
+  }, [charList, keyword, filterActive, matchesView]);
 
   const handleSelect = itemId => {
-    // push 一筆，讓詳情頁返回時回到同一位角色。
-    setSearchParams({ characterId: String(itemId) });
+    // push 一筆，讓詳情頁返回時回到同一本簿子的同一位角色。
+    setSearchParams(buildParams(orderType, itemId));
   };
 
-  const handleBackToAll = () => setSearchParams({});
+  const handleBackToAll = () => setSearchParams(buildParams(orderType, null));
 
-  const handleConfirmBuy = async () => {
+  const handleSwitchBook = next => {
+    if (next === orderType) return;
+    // 帶著 characterId 一起換：多數時候同一位角色兩本都有，換過去還能接著看。
+    // 真的沒有時，上面那個「清掉不存在的 characterId」的 effect 會在新清單到齊後收尾，
+    // 所以這裡不需要先猜。搜尋字保留，視角回到「全部」——filtered 在兩本的語意相反，
+    // 沿用會讓人以為看到的是同一批角色。
+    setView("all");
+    setSearchParams(buildParams(next, queryId));
+  };
+
+  const handleConfirmAction = async () => {
     if (!pending) return;
+    const isBuyBook = orderType === "buy";
     try {
-      const { data } = await purchase({
-        url: `/api/public-market/listings/${pending.id}/purchase`,
+      const { data } = await submitAction({
+        url: isBuyBook
+          ? `/api/public-market/listings/${pending.id}/fulfill`
+          : `/api/public-market/listings/${pending.id}/purchase`,
       });
       setPending(null);
-      handleOpen(`已購買 ${data.name}，花費 ${fmtStone(data.price)} 女神石`, "success");
+      handleOpen(
+        isBuyBook
+          ? `已賣出 ${data.name ?? pending.name}，實收 ${fmtStone(data.netProceeds ?? calcNet(pending.price))} 女神石`
+          : `已購買 ${data.name ?? pending.name}，花費 ${fmtStone(data.price ?? pending.price)} 女神石`,
+        "success"
+      );
       refetchSummary();
-      refetchChars();
+      loadCharacters(orderType);
       refetchInventory().catch(() => {});
-      if (selectedId) loadListings(selectedId);
+      if (selectedId) loadListings(selectedId, orderType);
     } catch (err) {
       setPending(null);
-      handleOpen(errorText(err, "購買失敗，請稍後再試"), "error");
+      handleOpen(
+        errorText(err, isBuyBook ? "賣出失敗，請稍後再試" : "購買失敗，請稍後再試"),
+        "error"
+      );
       refetchSummary();
-      if (selectedId) loadListings(selectedId);
+      refetchInventory().catch(() => {});
+      if (selectedId) loadListings(selectedId, orderType);
     }
   };
 
@@ -479,9 +612,13 @@ export default function Market() {
 
   const hasMine = rows.some(r => r.mine);
   const balance = summary?.balance;
-  // 切到「我沒有的」但背包還沒回來：先擋住清單，不能把全部角色都當成未持有。
-  const waitingInventory = view === "missing" && !ownedKnown && !invError;
+  // 切到會用到背包的視角但背包還沒回來：先擋住清單，不能亂猜持有狀態。
+  const waitingInventory = view === "filtered" && !ownedKnown && !invError;
   const showPicker = !selected && !resolvingQuery;
+
+  const filteredLabel = buy ? "我持有的" : "我沒有的";
+  const pendingNet = pending ? (pending.netProceeds ?? calcNet(pending.price)) : 0;
+  const pendingFee = pending ? (pending.fee ?? calcFee(pending.price)) : 0;
 
   return (
     <Box
@@ -494,19 +631,39 @@ export default function Market() {
     >
       <PageHeader balance={balance} loading={summaryLoading} />
 
-      <GradientPanel>
+      <OrderTypeSwitch value={orderType} onChange={handleSwitchBook} />
+
+      <GradientPanel tone={orderType}>
         <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.75 }}>
-          公開掛單簿
+          {buy ? "公開收購簿" : "公開掛單簿"}
         </Typography>
         <Box component="ul" sx={{ m: 0, pl: 2, fontSize: 12, lineHeight: 1.7, opacity: 0.92 }}>
-          <li>成交時抽取 5% 手續費，該部分女神石直接銷毀</li>
-          <li>每位玩家同一角色只能持有一張，已擁有的角色無法購買</li>
+          {buy ? (
+            <>
+              <li>這裡是別人想買的角色，你有的話可以直接賣給他</li>
+              <li>成交時抽取 5% 手續費，你拿到的是扣完手續費的金額</li>
+              <li>收購方發單時就已預扣全額，成交當下不會反悔</li>
+            </>
+          ) : (
+            <>
+              <li>成交時抽取 5% 手續費，該部分女神石直接銷毀</li>
+              <li>每位玩家同一角色只能持有一張，已擁有的角色無法購買</li>
+            </>
+          )}
         </Box>
       </GradientPanel>
 
       {charsError && (
-        <Alert severity="error" sx={{ borderRadius: 3 }}>
-          載入掛單簿失敗，請稍後再試
+        <Alert
+          severity="error"
+          sx={{ borderRadius: 3 }}
+          action={
+            <Button color="inherit" size="small" onClick={() => loadCharacters(orderType)}>
+              重試
+            </Button>
+          }
+        >
+          載入{buy ? "收購簿" : "掛單簿"}失敗，請稍後再試
         </Alert>
       )}
 
@@ -540,10 +697,10 @@ export default function Market() {
                 <Typography variant="caption" color="text.secondary" sx={{ ...NUMS }}>
                   {selected.itemId} ・{" "}
                   {rowsPending
-                    ? "讀取掛單中…"
+                    ? `讀取${copy.noun}中…`
                     : rowsFailed
-                      ? "掛單讀取失敗"
-                      : `目前 ${rows.length} 張掛單`}
+                      ? `${copy.noun}讀取失敗`
+                      : `目前 ${rows.length} 張${copy.noun}`}
                 </Typography>
               </Box>
               <Button
@@ -602,15 +759,19 @@ export default function Market() {
                 },
               }}
             >
-              <ToggleButton value="all" aria-label="顯示全部有掛單的角色">
+              <ToggleButton
+                value="all"
+                aria-label={buy ? "顯示全部有人收購的角色" : "顯示全部有掛單的角色"}
+              >
                 全部角色{charsLoaded ? ` (${charList.length})` : ""}
               </ToggleButton>
               <ToggleButton
-                value="missing"
+                value="filtered"
                 disabled={Boolean(invError)}
-                aria-label="只顯示我還沒有的角色"
+                aria-label={buy ? "只顯示我持有、可以賣出的角色" : "只顯示我還沒有的角色"}
               >
-                我沒有的{missingCount === null ? "" : ` (${missingCount})`}
+                {filteredLabel}
+                {filteredCount === null ? "" : ` (${filteredCount})`}
               </ToggleButton>
             </ToggleButtonGroup>
           </Box>
@@ -648,7 +809,7 @@ export default function Market() {
           ) : (
             <Box
               role="group"
-              aria-label={missingActive ? "我還沒有的角色列表" : "角色列表"}
+              aria-label={filterActive ? `${filteredLabel}的角色列表` : "角色列表"}
               sx={{
                 display: "flex",
                 flexWrap: "wrap",
@@ -662,6 +823,7 @@ export default function Market() {
                 <CharacterChip
                   key={c.itemId}
                   char={c}
+                  buy={buy}
                   selected={String(c.itemId) === selectedId}
                   onClick={() => handleSelect(c.itemId)}
                 />
@@ -675,11 +837,17 @@ export default function Market() {
           )}
           {!charsLoading && !waitingInventory && filtered.length === 0 && (
             <Typography variant="body2" color="text.secondary" sx={{ px: 0.25, py: 0.75 }}>
-              {missingActive
+              {filterActive
                 ? keyword.trim()
-                  ? "你沒有的角色裡找不到符合的。"
-                  : "目前有掛單的角色你都已經擁有了。"
-                : "找不到符合的角色。"}
+                  ? `${filteredLabel}角色裡找不到符合的。`
+                  : buy
+                    ? "目前有人收購的角色，你都還沒有。"
+                    : "目前有掛單的角色你都已經擁有了。"
+                : charsLoaded && charList.length === 0
+                  ? buy
+                    ? "目前沒有任何收購單。"
+                    : "目前沒有任何掛單。"
+                  : "找不到符合的角色。"}
             </Typography>
           )}
         </>
@@ -690,17 +858,17 @@ export default function Market() {
           variant="caption"
           sx={{ fontWeight: 600, letterSpacing: ".06em", color: "text.secondary" }}
         >
-          {selected ? `${selected.name} 的掛單` : "掛單"}
+          {selected ? `${selected.name} 的${copy.noun}` : copy.noun}
         </Typography>
         <Typography variant="caption" color="text.secondary">
           {!selected
-            ? "價格由低到高"
+            ? copy.sortNote
             : rowsPending
               ? "載入中…"
               : rowsFailed
                 ? "讀取失敗"
                 : rows.length
-                  ? `${rows.length} 張 ・ 價格由低到高`
+                  ? `${rows.length} 張 ・ ${copy.sortNote}`
                   : "0 張"}
         </Typography>
       </Box>
@@ -710,16 +878,25 @@ export default function Market() {
           severity="error"
           sx={{ borderRadius: 3 }}
           action={
-            <Button color="inherit" size="small" onClick={() => loadListings(selectedId)}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => loadListings(selectedId, orderType)}
+            >
               重試
             </Button>
           }
         >
-          載入掛單失敗，請稍後再試
+          載入{copy.noun}失敗，請稍後再試
         </Alert>
       )}
 
-      {!selected && !resolvingQuery && <Note>先從上面挑一個角色，就會看到目前的掛單。</Note>}
+      {!selected && !resolvingQuery && (
+        <Note>
+          先從上面挑一個角色，就會看到目前的{copy.noun}。
+          {buy && "收購單是別人出價想買，你有那隻角色就能直接賣。"}
+        </Note>
+      )}
 
       {showSkeleton || resolvingQuery ? (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }} aria-busy="true">
@@ -728,34 +905,52 @@ export default function Market() {
           ))}
         </Box>
       ) : selected && rowsFailed ? null : selected && rows.length === 0 ? (
-        <EmptyBook onBackToAll={handleBackToAll} />
+        <EmptyBook orderType={orderType} onBackToAll={handleBackToAll} />
       ) : (
         selected &&
         rows.length > 0 && (
-          <Box
-            component="ul"
-            sx={{
-              listStyle: "none",
-              m: 0,
-              p: 0,
-              display: "flex",
-              flexDirection: "column",
-              gap: 1.25,
-            }}
-          >
-            {rows.map((listing, i) => (
-              <OrderCard key={listing.id} listing={listing} lowest={i === 0} onBuy={setPending} />
-            ))}
-          </Box>
+          <>
+            {buy && ownedKnown && !ownsSelected && (
+              <Alert severity="info" sx={{ borderRadius: 3 }}>
+                你目前沒有 {selected.name}，只能看價格，沒辦法賣出。
+              </Alert>
+            )}
+            <Box
+              component="ul"
+              sx={{
+                listStyle: "none",
+                m: 0,
+                p: 0,
+                display: "flex",
+                flexDirection: "column",
+                gap: 1.25,
+              }}
+            >
+              {rows.map((listing, i) => (
+                <OrderCard
+                  key={listing.id}
+                  listing={listing}
+                  orderType={orderType}
+                  best={i === 0}
+                  blockReason={blockReason}
+                  onAct={setPending}
+                />
+              ))}
+            </Box>
+          </>
         )
       )}
 
       {selected && !rowsPending && !rowsFailed && rows.length === 0 && (
-        <Note>掛單簿只顯示目前還沒成交的賣單，成交或撤單後會立刻從這裡消失。</Note>
+        <Note>
+          {buy
+            ? "收購簿只顯示還沒成交的收購單，成交或撤單後會立刻從這裡消失。"
+            : "掛單簿只顯示目前還沒成交的賣單，成交或撤單後會立刻從這裡消失。"}
+        </Note>
       )}
       {hasMine && (
         <Note>
-          你自己的掛單會一起顯示，方便對照別人的價格。要撤單請到
+          你自己的{copy.noun}會一起顯示，方便對照別人的價格。要撤單請到
           <Box
             component={RouterLink}
             to="/trade/my-listings"
@@ -773,41 +968,81 @@ export default function Market() {
         </Button>
       )}
 
-      <Button variant="outlined" onClick={() => navigate("/trade/sell")}>
-        我要掛賣單
-      </Button>
+      <Box sx={{ display: "flex", gap: 1.25, flexWrap: "wrap" }}>
+        <Button variant="outlined" onClick={() => navigate("/trade/sell")} sx={{ flex: "1 1 45%" }}>
+          我要掛賣單
+        </Button>
+        <Button
+          variant="outlined"
+          color="secondary"
+          onClick={() => navigate("/trade/buy")}
+          sx={{ flex: "1 1 45%" }}
+        >
+          我要發收購單
+        </Button>
+      </Box>
 
-      <Dialog open={Boolean(pending)} onClose={() => setPending(null)} fullWidth maxWidth="xs">
-        <DialogTitle sx={{ fontWeight: 600 }}>確認購買</DialogTitle>
+      <Dialog
+        open={Boolean(pending)}
+        onClose={() => setPending(null)}
+        fullWidth
+        maxWidth="xs"
+        aria-labelledby="market-action-title"
+      >
+        <DialogTitle id="market-action-title" sx={{ fontWeight: 600 }}>
+          {buy ? "確認賣出" : "確認購買"}
+        </DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.7 }}>
-            購買後角色直接進入你的box，此操作無法取消。
+            {buy
+              ? "賣出後角色立刻離開你的box，升星強化不會轉移也不會退錢，此操作無法取消。"
+              : "購買後角色直接進入你的box，此操作無法取消。"}
           </Typography>
           {pending && (
             <Box sx={{ mt: 1.5 }}>
               <Row label="角色" value={`${pending.name}（${pending.itemId}）`} />
               {Number(pending.star) >= 1 && (
-                <Row label="你會取得" value={`基礎 ${Number(pending.star)} 星`} />
+                <Row
+                  label={buy ? "對方會取得" : "你會取得"}
+                  value={`基礎 ${Number(pending.star)} 星`}
+                />
               )}
-              <Row label="賣家" value={displayName(pending.sellerName)} />
-              <Row label="售價" value={`${fmtStone(pending.price)} 女神石`} />
-              <Row
-                label="手續費（5%，銷毀）"
-                value={`${fmtStone(pending.fee ?? calcFee(pending.price))} 女神石`}
-              />
-              <Row
-                label="你的餘額"
-                value={`${fmtStone(balance)} → ${fmtStone((balance ?? 0) - pending.price)} 女神石`}
-              />
+              <Row label={copy.poster} value={displayName(posterNameOf(pending))} />
+              <Row label={buy ? "收購價" : "售價"} value={`${fmtStone(pending.price)} 女神石`} />
+              <Row label="手續費（5%，銷毀）" value={`${fmtStone(pendingFee)} 女神石`} />
+              {buy ? (
+                <>
+                  <Row
+                    label="你實收"
+                    value={`${fmtStone(pendingNet)} 女神石`}
+                    valueColor="secondary.main"
+                  />
+                  <Row
+                    label="你的餘額"
+                    value={`${fmtStone(balance)} → ${fmtStone((balance ?? 0) + pendingNet)} 女神石`}
+                  />
+                </>
+              ) : (
+                <Row
+                  label="你的餘額"
+                  value={`${fmtStone(balance)} → ${fmtStone((balance ?? 0) - pending.price)} 女神石`}
+                />
+              )}
             </Box>
           )}
         </DialogContent>
         <DialogActions>
-          <Button color="inherit" onClick={() => setPending(null)} disabled={buying}>
+          <Button color="inherit" onClick={() => setPending(null)} disabled={acting}>
             取消
           </Button>
-          <Button variant="contained" onClick={handleConfirmBuy} disabled={buying} autoFocus>
-            確認購買
+          <Button
+            variant="contained"
+            color={buy ? "secondary" : "primary"}
+            onClick={handleConfirmAction}
+            disabled={acting}
+            autoFocus
+          >
+            {buy ? "確認賣出" : "確認購買"}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/pages/Trade/Market.jsx
+++ b/frontend/src/pages/Trade/Market.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useAxios from "axios-hooks";
-import { Link as RouterLink, useNavigate } from "react-router-dom";
+import { Link as RouterLink, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Alert,
   Box,
@@ -9,11 +9,12 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  IconButton,
   InputAdornment,
   Paper,
   Skeleton,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
@@ -168,7 +169,7 @@ function OrderCard({ listing, lowest, onBuy }) {
     >
       <CharAvatar itemId={listing.itemId} name={listing.name} headImage={listing.headImage} />
       <Box
-        onClick={() => navigate(`/trade/listings/${listing.id}`)}
+        onClick={() => navigate(`/trade/listings/${listing.id}`, { state: { fromMarket: true } })}
         sx={{ flex: "1 1 auto", minWidth: 0, cursor: "pointer" }}
       >
         <Box
@@ -253,7 +254,7 @@ function OrderCard({ listing, lowest, onBuy }) {
 }
 
 /* ---------------------------------------------------------------- 空狀態 */
-function EmptyBook({ onPickOther }) {
+function EmptyBook({ onBackToAll }) {
   return (
     <Paper
       elevation={0}
@@ -294,7 +295,7 @@ function EmptyBook({ onPickOther }) {
         <br />
         你也可以自己掛一張。
       </Typography>
-      <Button variant="outlined" onClick={onPickOther} sx={{ mt: 0.75 }}>
+      <Button variant="outlined" onClick={onBackToAll} sx={{ mt: 0.75 }}>
         看其他角色
       </Button>
     </Paper>
@@ -325,10 +326,10 @@ function Note({ children }) {
 export default function Market() {
   const { loggedIn: isLoggedIn } = useLiff();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [keyword, setKeyword] = useState("");
-  const [selectedId, setSelectedId] = useState(null);
-  const [pickerOpen, setPickerOpen] = useState(true);
+  const [view, setView] = useState("all");
   const [pending, setPending] = useState(null);
 
   const [{ data: summary, loading: summaryLoading }, refetchSummary] = useAxios(
@@ -339,8 +340,12 @@ export default function Market() {
     "/api/public-market/characters",
     { manual: true }
   );
-  const [{ data: listings, loading: listingsLoading, error: listingsError }, fetchListings] =
-    useAxios("/api/public-market/listings", { manual: true });
+  const [{ data: inventory, error: invError }, refetchInventory] = useAxios("/api/inventory", {
+    manual: true,
+  });
+  const [{ loading: listingsLoading }, fetchListings] = useAxios("/api/public-market/listings", {
+    manual: true,
+  });
   const [{ loading: buying }, purchase] = useAxios({ method: "POST" }, { manual: true });
   const [{ message, severity, open: snackOpen }, { handleOpen, handleClose }] = useHintBar();
 
@@ -352,29 +357,103 @@ export default function Market() {
     if (!isLoggedIn) return;
     refetchSummary();
     refetchChars();
-  }, [isLoggedIn, refetchSummary, refetchChars]);
+    refetchInventory().catch(() => {});
+  }, [isLoggedIn, refetchSummary, refetchChars, refetchInventory]);
 
   const charList = useMemo(() => (Array.isArray(characters) ? characters : []), [characters]);
-  const rows = useMemo(() => (Array.isArray(listings) ? listings : []), [listings]);
+  const charsLoaded = Array.isArray(characters);
 
+  // 網址是唯一的真相：選了誰只存在 query 裡，不再另外開一份 state，
+  // 免得兩邊互相覆寫。上一頁/下一頁因此自然可用。
+  const queryId = searchParams.get("characterId");
   const selected = useMemo(
-    () => charList.find(c => String(c.itemId) === String(selectedId)) || null,
-    [charList, selectedId]
+    () => (queryId ? charList.find(c => String(c.itemId) === queryId) || null : null),
+    [charList, queryId]
+  );
+  const selectedId = selected ? String(selected.itemId) : null;
+
+  // 角色清單還沒回來就先不要退回選角畫面，不然重新整理會閃一下。
+  // 清單真的抓失敗時要放行，否則畫面會卡在骨架上，連錯誤訊息都看不到。
+  const resolvingQuery = Boolean(queryId) && !charsLoaded && !charsError;
+
+  // query 指到不存在的角色（角色被下架、網址被亂改），等資料到齊再安靜清掉。
+  useEffect(() => {
+    if (!charsLoaded || !queryId || selected) return;
+    setSearchParams({}, { replace: true });
+  }, [charsLoaded, queryId, selected, setSearchParams]);
+
+  // 掛單讀取只有這一條路：effect、購買後刷新、錯誤重試都呼叫它。
+  // book 只存「已經有結果」的那份資料（成功或失敗），in-flight 交給 axios-hooks 的
+  // loading 去講，所以這裡不用在 effect 裡同步寫 state。
+  // book.id 綁住這份資料屬於誰，換角色的那一幀就不會閃到上一位的價格。
+  const [book, setBook] = useState({ id: null, ok: false, rows: [] });
+  const reqSeq = useRef(0);
+
+  const loadListings = useCallback(
+    async itemId => {
+      const id = String(itemId);
+      const seq = ++reqSeq.current;
+      try {
+        const { data } = await fetchListings({ params: { itemId: id } });
+        // 慢回來的舊請求直接丟掉，不能蓋掉新角色的資料。
+        if (seq !== reqSeq.current) return;
+        setBook({ id, ok: true, rows: Array.isArray(data) ? data : [] });
+      } catch {
+        if (seq !== reqSeq.current) return;
+        setBook({ id, ok: false, rows: [] });
+      }
+    },
+    [fetchListings]
   );
 
-  const filtered = useMemo(() => {
-    const q = keyword.trim().toLowerCase();
-    if (!q) return charList;
-    return charList.filter(c => c.name?.toLowerCase().includes(q) || String(c.itemId).includes(q));
-  }, [charList, keyword]);
+  // 只跟著 selectedId 走。charList 重抓會換新物件，但 id 是字串比對，不會多打一次。
+  // （react-hooks/set-state-in-effect 會警告這裡：抓資料本來就得寫回 state，
+  //   跟 repo 內其他 fetch-on-mount effect 同一類，eslint 設定刻意留成 warn。）
+  useEffect(() => {
+    if (!isLoggedIn || !selectedId) return;
+    loadListings(selectedId);
+  }, [isLoggedIn, selectedId, loadListings]);
 
-  const loadListings = itemId => fetchListings({ params: { itemId } }).catch(() => {});
+  // 背包裡的 itemId 999 是女神石本身，不是角色。
+  const ownedIds = useMemo(
+    () =>
+      new Set(
+        (Array.isArray(inventory) ? inventory : [])
+          .filter(i => i.itemId !== 999)
+          .map(i => String(i.itemId))
+      ),
+    [inventory]
+  );
+  // 背包沒載完就不能判斷「沒有的」，否則會把全部角色都說成未持有。
+  const ownedKnown = Array.isArray(inventory) && !invError;
+  const missingCount = useMemo(
+    () => (ownedKnown ? charList.filter(c => !ownedIds.has(String(c.itemId))).length : null),
+    [ownedKnown, charList, ownedIds]
+  );
+  const missingActive = view === "missing" && ownedKnown;
+
+  // 畫面永遠只看「這份資料是不是這位角色的」，避免顯示別人的價格。
+  // 結果還沒回來（換角色、第一次載入）就是 pending；重讀同一位角色時沿用既有列表，
+  // 購買後刷新才不會先閃成空的。
+  const current = book.id === selectedId ? book : null;
+  const rows = current?.ok ? current.rows : [];
+  const rowsPending = Boolean(selectedId) && (!current || listingsLoading);
+  const rowsFailed = Boolean(current) && !current.ok && !listingsLoading;
+  const showSkeleton = Boolean(selectedId) && !current;
+
+  const filtered = useMemo(() => {
+    const base = missingActive ? charList.filter(c => !ownedIds.has(String(c.itemId))) : charList;
+    const q = keyword.trim().toLowerCase();
+    if (!q) return base;
+    return base.filter(c => c.name?.toLowerCase().includes(q) || String(c.itemId).includes(q));
+  }, [charList, keyword, missingActive, ownedIds]);
 
   const handleSelect = itemId => {
-    setSelectedId(itemId);
-    setPickerOpen(false);
-    loadListings(itemId);
+    // push 一筆，讓詳情頁返回時回到同一位角色。
+    setSearchParams({ characterId: String(itemId) });
   };
+
+  const handleBackToAll = () => setSearchParams({});
 
   const handleConfirmBuy = async () => {
     if (!pending) return;
@@ -386,12 +465,13 @@ export default function Market() {
       handleOpen(`已購買 ${data.name}，花費 ${fmtStone(data.price)} 女神石`, "success");
       refetchSummary();
       refetchChars();
-      if (selectedId != null) loadListings(selectedId);
+      refetchInventory().catch(() => {});
+      if (selectedId) loadListings(selectedId);
     } catch (err) {
       setPending(null);
       handleOpen(errorText(err, "購買失敗，請稍後再試"), "error");
       refetchSummary();
-      if (selectedId != null) loadListings(selectedId);
+      if (selectedId) loadListings(selectedId);
     }
   };
 
@@ -399,6 +479,9 @@ export default function Market() {
 
   const hasMine = rows.some(r => r.mine);
   const balance = summary?.balance;
+  // 切到「我沒有的」但背包還沒回來：先擋住清單，不能把全部角色都當成未持有。
+  const waitingInventory = view === "missing" && !ownedKnown && !invError;
+  const showPicker = !selected && !resolvingQuery;
 
   return (
     <Box
@@ -427,7 +510,7 @@ export default function Market() {
         </Alert>
       )}
 
-      {selected && !pickerOpen ? (
+      {selected || resolvingQuery ? (
         <Paper
           elevation={0}
           sx={{
@@ -440,34 +523,104 @@ export default function Market() {
             gap: 1.5,
           }}
         >
-          <CharAvatar
-            itemId={selected.itemId}
-            name={selected.name}
-            headImage={selected.headImage}
-          />
-          <Box sx={{ flex: "1 1 auto", minWidth: 0 }}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-              <Typography sx={{ fontSize: 15, fontWeight: 600 }} noWrap>
-                {selected.name}
-              </Typography>
-              <BaseStar star={selected.star} />
-            </Box>
-            <Typography variant="caption" color="text.secondary" sx={{ ...NUMS }}>
-              {selected.itemId} ・ 目前 {rows.length} 張掛單
-            </Typography>
-          </Box>
-          <IconButton aria-label="更換角色" onClick={() => setPickerOpen(true)}>
-            <SwapHorizIcon />
-          </IconButton>
+          {selected ? (
+            <>
+              <CharAvatar
+                itemId={selected.itemId}
+                name={selected.name}
+                headImage={selected.headImage}
+              />
+              <Box sx={{ flex: "1 1 auto", minWidth: 0 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                  <Typography sx={{ fontSize: 15, fontWeight: 600 }} noWrap>
+                    {selected.name}
+                  </Typography>
+                  <BaseStar star={selected.star} />
+                </Box>
+                <Typography variant="caption" color="text.secondary" sx={{ ...NUMS }}>
+                  {selected.itemId} ・{" "}
+                  {rowsPending
+                    ? "讀取掛單中…"
+                    : rowsFailed
+                      ? "掛單讀取失敗"
+                      : `目前 ${rows.length} 張掛單`}
+                </Typography>
+              </Box>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<SwapHorizIcon />}
+                onClick={handleBackToAll}
+                sx={{ flex: "0 0 auto" }}
+              >
+                所有角色
+              </Button>
+            </>
+          ) : (
+            <>
+              <Skeleton variant="circular" width={44} height={44} animation="wave" />
+              <Box sx={{ flex: "1 1 auto" }}>
+                <Skeleton variant="text" width={120} animation="wave" />
+                <Skeleton variant="text" width={90} animation="wave" />
+              </Box>
+            </>
+          )}
         </Paper>
-      ) : (
+      ) : null}
+
+      {showPicker && (
         <>
-          <Typography
-            variant="caption"
-            sx={{ fontWeight: 600, letterSpacing: ".06em", color: "text.secondary" }}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 1,
+              flexWrap: "wrap",
+            }}
           >
-            選擇角色
-          </Typography>
+            <Typography
+              variant="caption"
+              sx={{ fontWeight: 600, letterSpacing: ".06em", color: "text.secondary" }}
+            >
+              選擇角色
+            </Typography>
+            <ToggleButtonGroup
+              value={view}
+              exclusive
+              size="small"
+              onChange={(_, v) => v !== null && setView(v)}
+              aria-label="角色清單視角"
+              sx={{
+                "& .MuiToggleButton-root": {
+                  px: 1.5,
+                  py: 0.375,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  borderRadius: "999px !important",
+                  textTransform: "none",
+                },
+              }}
+            >
+              <ToggleButton value="all" aria-label="顯示全部有掛單的角色">
+                全部角色{charsLoaded ? ` (${charList.length})` : ""}
+              </ToggleButton>
+              <ToggleButton
+                value="missing"
+                disabled={Boolean(invError)}
+                aria-label="只顯示我還沒有的角色"
+              >
+                我沒有的{missingCount === null ? "" : ` (${missingCount})`}
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Box>
+
+          {invError && (
+            <Alert severity="warning" sx={{ borderRadius: 3 }}>
+              讀不到你的角色清單，先顯示全部角色。
+            </Alert>
+          )}
+
           <TextField
             type="search"
             size="small"
@@ -486,8 +639,8 @@ export default function Market() {
               },
             }}
           />
-          {charsLoading && charList.length === 0 ? (
-            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+          {(charsLoading && charList.length === 0) || waitingInventory ? (
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }} aria-busy="true">
               {[1, 2, 3, 4, 5, 6].map(i => (
                 <Skeleton key={i} variant="rounded" width={104} height={36} animation="wave" />
               ))}
@@ -495,7 +648,7 @@ export default function Market() {
           ) : (
             <Box
               role="group"
-              aria-label="角色列表"
+              aria-label={missingActive ? "我還沒有的角色列表" : "角色列表"}
               sx={{
                 display: "flex",
                 flexWrap: "wrap",
@@ -509,15 +662,24 @@ export default function Market() {
                 <CharacterChip
                   key={c.itemId}
                   char={c}
-                  selected={String(c.itemId) === String(selectedId)}
+                  selected={String(c.itemId) === selectedId}
                   onClick={() => handleSelect(c.itemId)}
                 />
               ))}
             </Box>
           )}
-          {!charsLoading && filtered.length === 0 && (
+          {waitingInventory && (
+            <Typography variant="body2" color="text.secondary" sx={{ px: 0.25 }} role="status">
+              正在確認你已經擁有哪些角色…
+            </Typography>
+          )}
+          {!charsLoading && !waitingInventory && filtered.length === 0 && (
             <Typography variant="body2" color="text.secondary" sx={{ px: 0.25, py: 0.75 }}>
-              找不到符合的角色。
+              {missingActive
+                ? keyword.trim()
+                  ? "你沒有的角色裡找不到符合的。"
+                  : "目前有掛單的角色你都已經擁有了。"
+                : "找不到符合的角色。"}
             </Typography>
           )}
         </>
@@ -531,27 +693,44 @@ export default function Market() {
           {selected ? `${selected.name} 的掛單` : "掛單"}
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          {selected ? (rows.length ? `${rows.length} 張 ・ 價格由低到高` : "0 張") : "價格由低到高"}
+          {!selected
+            ? "價格由低到高"
+            : rowsPending
+              ? "載入中…"
+              : rowsFailed
+                ? "讀取失敗"
+                : rows.length
+                  ? `${rows.length} 張 ・ 價格由低到高`
+                  : "0 張"}
         </Typography>
       </Box>
 
-      {listingsError && (
-        <Alert severity="error" sx={{ borderRadius: 3 }}>
+      {rowsFailed && (
+        <Alert
+          severity="error"
+          sx={{ borderRadius: 3 }}
+          action={
+            <Button color="inherit" size="small" onClick={() => loadListings(selectedId)}>
+              重試
+            </Button>
+          }
+        >
           載入掛單失敗，請稍後再試
         </Alert>
       )}
 
-      {!selected && !listingsLoading && <Note>先從上面挑一個角色，就會看到目前的掛單。</Note>}
+      {!selected && !resolvingQuery && <Note>先從上面挑一個角色，就會看到目前的掛單。</Note>}
 
-      {listingsLoading ? (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+      {showSkeleton || resolvingQuery ? (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }} aria-busy="true">
           {[1, 2, 3].map(i => (
             <Skeleton key={i} variant="rounded" height={88} animation="wave" />
           ))}
         </Box>
-      ) : selected && rows.length === 0 ? (
-        <EmptyBook onPickOther={() => setPickerOpen(true)} />
+      ) : selected && rowsFailed ? null : selected && rows.length === 0 ? (
+        <EmptyBook onBackToAll={handleBackToAll} />
       ) : (
+        selected &&
         rows.length > 0 && (
           <Box
             component="ul"
@@ -571,7 +750,7 @@ export default function Market() {
         )
       )}
 
-      {selected && rows.length === 0 && (
+      {selected && !rowsPending && !rowsFailed && rows.length === 0 && (
         <Note>掛單簿只顯示目前還沒成交的賣單，成交或撤單後會立刻從這裡消失。</Note>
       )}
       {hasMine && (
@@ -586,6 +765,12 @@ export default function Market() {
           </Box>
           。
         </Note>
+      )}
+
+      {selected && (
+        <Button variant="text" onClick={handleBackToAll} startIcon={<SwapHorizIcon />}>
+          回到所有角色
+        </Button>
       )}
 
       <Button variant="outlined" onClick={() => navigate("/trade/sell")}>

--- a/frontend/src/pages/Trade/MarketListing.jsx
+++ b/frontend/src/pages/Trade/MarketListing.jsx
@@ -21,11 +21,23 @@ import AlertLogin from "../../components/AlertLogin";
 import HintSnackBar from "../../components/HintSnackBar";
 import useHintBar from "../../hooks/useHintBar";
 import useLiff from "../../context/useLiff";
-import { NUMS, calcFee, calcNet, displayName, errorInfo, fmtShortDate, fmtStone } from "./_market";
+import {
+  NUMS,
+  ORDER_COPY,
+  calcFee,
+  calcNet,
+  displayName,
+  errorInfo,
+  fmtShortDate,
+  fmtStone,
+  orderTypeOf,
+  posterNameOf,
+} from "./_market";
 import {
   CharAvatar,
   BaseStarBadge,
   GradientPanel,
+  OrderTypeChip,
   Row,
   SectionTitle,
   StatusChip,
@@ -55,15 +67,24 @@ function Card({ children, sx }) {
   );
 }
 
-/** 回市場一律帶著角色，讓人回到剛才在看的那一本掛單簿。 */
-const marketPathFor = listing =>
-  listing?.itemId != null ? `/trade/market?characterId=${listing.itemId}` : "/trade/market";
+/**
+ * 回市場一律帶著角色「和方向」，讓人回到剛才在看的那一本簿子。
+ * 少帶 orderType 的話，從收購簿點進來的人會被丟回賣單簿，看到完全不同的價格。
+ */
+const marketPathFor = (listing, orderType) => {
+  const params = new URLSearchParams();
+  if (orderType === "buy") params.set("orderType", "buy");
+  if (listing?.itemId != null) params.set("characterId", String(listing.itemId));
+  const qs = params.toString();
+  return qs ? `/trade/market?${qs}` : "/trade/market";
+};
 
-function AppHeader({ listing, orderNo, onBack, onRefresh, refreshing }) {
+function AppHeader({ listing, orderType, orderNo, mineLabel, onBack, onRefresh, refreshing }) {
+  const noun = ORDER_COPY[orderType].noun;
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 0.5 }}>
       <IconButton
-        aria-label={listing?.name ? `返回${listing.name}的掛單列表` : "返回市場列表"}
+        aria-label={listing?.name ? `返回${listing.name}的${noun}列表` : "返回市場列表"}
         size="small"
         onClick={onBack}
       >
@@ -73,7 +94,7 @@ function AppHeader({ listing, orderNo, onBack, onRefresh, refreshing }) {
         <Typography sx={{ fontSize: 15.5, fontWeight: 700, lineHeight: 1.2 }}>委託詳情</Typography>
         <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
           {orderNo}
-          {listing?.viewer?.isSeller ? " · 我的掛單" : ""}
+          {mineLabel ? ` · ${mineLabel}` : ""}
         </Typography>
       </Box>
       <Box sx={{ flex: "1 1 auto" }} />
@@ -85,9 +106,9 @@ function AppHeader({ listing, orderNo, onBack, onRefresh, refreshing }) {
 }
 
 /** 開放中用漸層 banner；終態 / 失效用平的卡片，跟設計稿一致。 */
-function HeroBanner({ listing, kicker }) {
+function HeroBanner({ listing, orderType, kicker }) {
   return (
-    <GradientPanel>
+    <GradientPanel tone={orderType}>
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
         <CharAvatar
           itemId={listing.itemId}
@@ -122,7 +143,7 @@ function HeroBanner({ listing, kicker }) {
   );
 }
 
-function HeroFlat({ listing, status, dimmed }) {
+function HeroFlat({ listing, orderType, status, dimmed }) {
   return (
     <Card sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
       <CharAvatar
@@ -139,8 +160,9 @@ function HeroFlat({ listing, status, dimmed }) {
         <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
           ID {listing.itemId}
         </Typography>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.875 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.875, flexWrap: "wrap" }}>
           <StatusChip status={status} />
+          <OrderTypeChip orderType={orderType} />
           <BaseStarBadge star={listing.star} />
         </Box>
       </Box>
@@ -207,15 +229,17 @@ export default function MarketListing() {
   const location = useLocation();
   const viewerId = profile?.userId;
 
-  // 從市場點進來的話，上一頁就是那本掛單簿：直接退回去，history 不會多長一節，
+  // 從市場點進來的話，上一頁就是那本簿子：直接退回去，history 不會多長一節，
   // 不然「頁內返回 push 市場 → 瀏覽器上一頁又回到詳情」會變成一個轉不出去的圈。
-  // 直接開連結（LIFF 分享、書籤）沒有這個標記，改用 replace 導向帶角色的市場，
+  // 直接開連結（LIFF 分享、書籤）沒有這個標記，改用 replace 導向帶角色+方向的市場，
   // 同樣不會留下能退回本頁的紀錄。不看 history.length，那個值猜不準。
   const fromMarket = Boolean(location.state?.fromMarket);
 
-  // 購買失敗回來的終態：把畫面原地降級成 B1 / B4，不重新導頁。
+  // 操作失敗回來的終態：把畫面原地降級，不重新導頁。
   const [deadCode, setDeadCode] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  // 收購單成交／取消時退回去的金額，後端會回 refundedAmount，用來寫實際數字。
+  const [refunded, setRefunded] = useState(null);
 
   const [{ data: listing, loading, error }, refetch] = useAxios(
     `/api/public-market/listings/${id}`,
@@ -223,6 +247,10 @@ export default function MarketListing() {
   );
   const [{ loading: buying }, purchase] = useAxios(
     { url: `/api/public-market/listings/${id}/purchase`, method: "POST" },
+    { manual: true }
+  );
+  const [{ loading: fulfilling }, fulfill] = useAxios(
+    { url: `/api/public-market/listings/${id}/fulfill`, method: "POST" },
     { manual: true }
   );
   const [{ loading: cancelling }, cancelListing] = useAxios(
@@ -241,11 +269,17 @@ export default function MarketListing() {
 
   const orderNo = useMemo(() => `#EX-${id}`, [id]);
 
+  // 方向優先看資料本身；資料還沒到就先用進來時帶的 state，
+  // 免得返回鍵在載入中把人送回錯的一本簿子。
+  const orderType = listing ? orderTypeOf(listing) : (location.state?.orderType ?? "sell");
+  const buyOrder = orderType === "buy";
+  const copy = ORDER_COPY[orderType];
+
   // 這頁所有語義上「回市場」的按鈕都走這裡，行為才會一致。
   const backToMarket = useCallback(() => {
     if (fromMarket) navigate(-1);
-    else navigate(marketPathFor(listing), { replace: true });
-  }, [fromMarket, navigate, listing]);
+    else navigate(marketPathFor(listing, orderType), { replace: true });
+  }, [fromMarket, navigate, listing, orderType]);
 
   const handleBuy = async () => {
     setConfirmOpen(false);
@@ -271,10 +305,39 @@ export default function MarketListing() {
     }
   };
 
+  const handleFulfill = async () => {
+    setConfirmOpen(false);
+    try {
+      const { data } = await fulfill();
+      handleOpen(
+        `已賣出 ${data.name ?? listing?.name}，實收 ${fmtStone(data.netProceeds ?? calcNet(listing?.price ?? 0))} 女神石`,
+        "success"
+      );
+      refetch().catch(() => {});
+    } catch (err) {
+      const { code, title, detail, data } = errorInfo(err, "賣出失敗，請稍後再試");
+      // 收購方在這段時間內自己取得了角色：單子作廢、預扣退還給對方，
+      // 這時候畫面要直接變成失效，不能還留一顆「賣給他」。
+      if (code === "ALREADY_TAKEN" || code === "ALREADY_OWNED_REQUESTER" || code === "NOT_OPEN") {
+        setDeadCode(code);
+        if (data?.refundedAmount != null) setRefunded(data.refundedAmount);
+      }
+      handleOpen(detail ? `${title}，${detail}` : title, "error");
+      refetch().catch(() => {});
+    }
+  };
+
   const handleCancel = async () => {
     try {
-      await cancelListing();
-      handleOpen("已取消掛單", "success");
+      const { data } = await cancelListing();
+      // 收購單取消要退錢，金額用後端回的為準；沒回就退回單價，兩者本來就相等。
+      if (buyOrder) {
+        const amount = data?.refundedAmount ?? listing?.price;
+        setRefunded(amount);
+        handleOpen(`已取消收購單，${fmtStone(amount)} 女神石已全額退還`, "success");
+      } else {
+        handleOpen("已取消掛單", "success");
+      }
       refetch().catch(() => {});
     } catch (err) {
       const { title, detail } = errorInfo(err, "取消失敗，請稍後再試");
@@ -308,6 +371,22 @@ export default function MarketListing() {
   const balance = viewer.balance ?? 0;
   const shortfall = Math.max(0, listing.price - balance);
 
+  // 收購單的「掛單者」是買家。後端會帶 isRequester，沒帶時退回比對 isBuyer / buyerId。
+  const isRequester = buyOrder
+    ? Boolean(
+        viewer.isRequester ?? viewer.isBuyer ?? (viewerId != null && listing.buyerId === viewerId)
+      )
+    : false;
+  const mineLabel = buyOrder
+    ? isRequester
+      ? "我的收購單"
+      : ""
+    : viewer.isSeller
+      ? "我的掛單"
+      : "";
+  const posterName = displayName(posterNameOf(listing));
+  const refundAmount = refunded ?? listing.refundedAmount ?? listing.price;
+
   // 顯示狀態：本地失效碼優先，再看後端 status。
   const dead = Boolean(deadCode) || listing.status === "invalid";
   const shownStatus = deadCode ? "invalid" : listing.status;
@@ -323,10 +402,13 @@ export default function MarketListing() {
     >
       <AppHeader
         listing={listing}
+        orderType={orderType}
         orderNo={orderNo}
+        mineLabel={mineLabel}
         onBack={backToMarket}
         onRefresh={() => {
           setDeadCode(null);
+          setRefunded(null);
           refetch().catch(() => {});
         }}
         refreshing={loading}
@@ -336,61 +418,84 @@ export default function MarketListing() {
     </Box>
   );
 
-  /* ---- B1：搶單失敗（已被買走） / B4：賣家已無此角色 ------------------ */
+  /* ---- 失效（兩種方向共用） ------------------------------------------- */
   if (dead) {
-    const isLostItem = deadCode === "SELLER_LOST_ITEM" || listing.status === "invalid";
+    // 收購單失效只有一種常見成因：收購方自己拿到角色了，錢已全額退回給他。
+    const requesterGotIt =
+      deadCode === "ALREADY_OWNED_REQUESTER" || (buyOrder && listing.status === "invalid");
+    const isLostItem =
+      !buyOrder && (deadCode === "SELLER_LOST_ITEM" || listing.status === "invalid");
+
     return wrap(
       <>
-        <HeroFlat listing={listing} status="invalid" dimmed />
+        <HeroFlat listing={listing} orderType={orderType} status="invalid" dimmed />
 
         <Alert severity="error" role="status" sx={{ borderRadius: 3 }}>
           <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
-            {isLostItem ? "賣家已無此角色，委託已失效" : "此委託已被其他玩家買走或取消"}
+            {buyOrder
+              ? requesterGotIt
+                ? "收購方已取得此角色，收購單已失效"
+                : "此收購單已被其他玩家接走或取消"
+              : isLostItem
+                ? "賣家已無此角色，委託已失效"
+                : "此委託已被其他玩家買走或取消"}
           </AlertTitle>
           <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
-            {isLostItem ? "系統已自動下架這筆委託，沒有任何女神石異動。" : "你的女神石沒有被扣款。"}
+            {buyOrder
+              ? isRequester
+                ? `系統已自動下架，預扣的 ${fmtStone(refundAmount)} 女神石已全額退還給你。`
+                : "你的角色沒有被扣走，也沒有任何女神石異動。"
+              : isLostItem
+                ? "系統已自動下架這筆委託，沒有任何女神石異動。"
+                : "你的女神石沒有被扣款。"}
           </Typography>
         </Alert>
 
         <Card>
-          <Row label="掛單價" value={`${fmtStone(listing.price)} 女神石`} strike />
-          <Row label="賣家" value={displayName(listing.sellerName)} />
-          {isLostItem && <Row label="失效時間" value={fmtShortDate(listing.closedAt)} />}
-          <Row label="你的餘額" value={`${fmtStone(balance)}（未變動）`} />
+          <Row
+            label={buyOrder ? "收購價" : "掛單價"}
+            value={`${fmtStone(listing.price)} 女神石`}
+            strike
+          />
+          <Row label={copy.poster} value={posterName} />
+          {(isLostItem || requesterGotIt) && (
+            <Row label="失效時間" value={fmtShortDate(listing.closedAt)} />
+          )}
+          {buyOrder && isRequester ? (
+            <Row
+              label="已退還"
+              value={`${fmtStone(refundAmount)} 女神石`}
+              valueColor="success.main"
+            />
+          ) : (
+            <Row label="你的餘額" value={`${fmtStone(balance)}（未變動）`} />
+          )}
         </Card>
 
-        {isLostItem ? (
-          <>
-            <Button variant="contained" disabled>
-              委託已失效
-            </Button>
-            <Button variant="outlined" onClick={backToMarket}>
-              回{listing.name}的掛單
-            </Button>
-            <Typography sx={{ fontSize: 11.5, color: "text.secondary", lineHeight: 1.6, mx: 0.25 }}>
-              若你認為這是異常，請在群組輸入「客服」回報單號 {orderNo}。
-            </Typography>
-          </>
-        ) : (
-          <>
-            <Button variant="contained" disabled>
-              立即購買
-            </Button>
-            <BtnNote>此委託已不可購買</BtnNote>
-            <Button variant="outlined" onClick={backToMarket}>
-              看其他{listing.name}的掛單
-            </Button>
-          </>
+        <Button variant="contained" color={buyOrder ? "secondary" : "primary"} disabled>
+          {buyOrder ? "收購單已失效" : isLostItem ? "委託已失效" : "立即購買"}
+        </Button>
+        <BtnNote>此委託已結束，沒有可用的操作</BtnNote>
+        <Button variant="outlined" onClick={backToMarket}>
+          看其他{listing.name}的{copy.noun}
+        </Button>
+        {(isLostItem || requesterGotIt) && (
+          <Typography sx={{ fontSize: 11.5, color: "text.secondary", lineHeight: 1.6, mx: 0.25 }}>
+            若你認為這是異常，請在群組輸入「客服」回報單號 {orderNo}。
+          </Typography>
         )}
       </>
     );
   }
 
-  /* ---- A3：已成交（終態） --------------------------------------------- */
+  /* ---- 已成交（終態） -------------------------------------------------- */
   if (shownStatus === "sold") {
+    const iAmBuyer = viewerId != null && listing.buyerId === viewerId;
+    const iAmSeller = viewerId != null && listing.sellerId === viewerId;
+
     return wrap(
       <>
-        <HeroFlat listing={listing} status="sold" />
+        <HeroFlat listing={listing} orderType={orderType} status="sold" />
 
         <Card>
           <Row label="成交價" value={`${fmtStone(listing.price)} 女神石`} />
@@ -399,42 +504,54 @@ export default function MarketListing() {
         </Card>
 
         <Card>
-          <Row label="賣家" value={displayName(listing.sellerName)} />
-          <Row
-            label="買家"
-            value={
-              viewerId != null && listing.buyerId === viewerId
-                ? "你"
-                : displayName(listing.buyerName)
-            }
-          />
+          <Row label="賣家" value={iAmSeller ? "你" : displayName(listing.sellerName)} />
+          <Row label="買家" value={iAmBuyer ? "你" : displayName(listing.buyerName)} />
           <Row label="成交時間" value={fmtShortDate(listing.soldAt)} />
         </Card>
 
         <Alert severity="info" icon={false} sx={{ borderRadius: 3 }}>
-          角色已入庫，星數為初始值。這筆委託已結束，沒有可用的操作。
+          {iAmSeller
+            ? `角色已交付買家，你已收到 ${fmtStone(net)} 女神石。`
+            : "角色已入庫，星數為初始值。"}
+          這筆委託已結束，沒有可用的操作。
         </Alert>
         <BtnNote>紀錄保留 90 天</BtnNote>
       </>
     );
   }
 
-  /* ---- A3b：已取消（終態） -------------------------------------------- */
+  /* ---- 已取消（終態） -------------------------------------------------- */
   if (shownStatus === "cancelled") {
     return wrap(
       <>
-        <HeroFlat listing={listing} status="cancelled" dimmed />
+        <HeroFlat listing={listing} orderType={orderType} status="cancelled" dimmed />
 
         <Card>
-          <Row label="原掛單價" value={`${fmtStone(listing.price)} 女神石`} strike />
-          <Row label="賣家" value={displayName(listing.sellerName)} />
-          <Row label="掛單時間" value={fmtShortDate(listing.createdAt)} />
+          <Row
+            label={buyOrder ? "原收購價" : "原掛單價"}
+            value={`${fmtStone(listing.price)} 女神石`}
+            strike
+          />
+          <Row label={copy.poster} value={posterName} />
+          <Row label={buyOrder ? "發布時間" : "掛單時間"} value={fmtShortDate(listing.createdAt)} />
           <Row label="取消時間" value={fmtShortDate(listing.closedAt)} />
-          <Row label="取消原因" value="賣家自行取消" />
+          <Row label="取消原因" value={`${copy.poster}自行取消`} />
+          {buyOrder && isRequester && (
+            <Row
+              label="已退還"
+              value={`${fmtStone(refundAmount)} 女神石`}
+              valueColor="success.main"
+            />
+          )}
         </Card>
 
         <Alert severity="info" icon={false} sx={{ borderRadius: 3 }}>
-          這筆委託已取消，無法購買。可以回列表看看其他{listing.name}的掛單。
+          {buyOrder
+            ? isRequester
+              ? `這筆收購單已取消，預扣的 ${fmtStone(refundAmount)} 女神石已全額退還。`
+              : "這筆收購單已取消，無法賣出。"
+            : "這筆委託已取消，無法購買。"}
+          可以回列表看看其他{listing.name}的{copy.noun}。
         </Alert>
         <Button variant="outlined" onClick={backToMarket}>
           回列表找其他{listing.name}
@@ -443,11 +560,67 @@ export default function MarketListing() {
     );
   }
 
-  /* ---- A2：自己的掛單 -------------------------------------------------- */
-  if (viewer.isSeller || viewer.blockReason === "IS_SELLER") {
+  /* ================= 以下皆為 open ================= */
+
+  /* ---- 收購單：我是發單的人 -------------------------------------------- */
+  if (buyOrder && isRequester) {
     return wrap(
       <>
-        <HeroBanner listing={listing} kicker="我的賣出委託" />
+        <HeroBanner listing={listing} orderType="buy" kicker="我的收購單" />
+
+        <Card>
+          <Row
+            label="狀態"
+            value={
+              <Box component="span" sx={{ display: "inline-flex", gap: 0.75 }}>
+                <StatusChip status="open" />
+                <Box component="span" sx={{ display: "inline-flex", alignItems: "center" }}>
+                  <Tag label="我的" />
+                </Box>
+              </Box>
+            }
+          />
+          <Row label="發布時間" value={fmtShortDate(listing.createdAt)} />
+          {Number(listing.star) >= 1 && (
+            <Row label="你會取得" value={`基礎 ${Number(listing.star)} 星`} />
+          )}
+        </Card>
+
+        <SectionTitle>你的女神石</SectionTitle>
+        <Card>
+          <Row
+            label="已預扣（發布時）"
+            value={`${fmtStone(listing.price)} 女神石`}
+            valueColor="error.main"
+          />
+          <Row label="成交時支付" value={`${fmtStone(listing.price)} 女神石`} />
+          <Row label="賣家實收（扣 5%）" value={fmtStone(net)} valueColor="text.secondary" />
+          <Row label="取消時退還" value={`${fmtStone(listing.price)} 女神石`} />
+        </Card>
+
+        <Alert severity="info" sx={{ borderRadius: 3 }}>
+          <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+            這筆錢現在被鎖住
+          </AlertTitle>
+          <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+            {fmtStone(listing.price)} 女神石在發布時就已扣款，收購單還開著的期間不能用來買別的東西。
+            取消或失效時會全額退回，不收任何費用。
+          </Typography>
+        </Alert>
+
+        <Button variant="outlined" color="error" onClick={handleCancel} disabled={cancelling}>
+          取消收購單並退款
+        </Button>
+        <BtnNote>取消後 {fmtStone(listing.price)} 女神石立即全額退回你的錢包</BtnNote>
+      </>
+    );
+  }
+
+  /* ---- 賣單：我是掛單的賣家 -------------------------------------------- */
+  if (!buyOrder && (viewer.isSeller || viewer.blockReason === "IS_SELLER")) {
+    return wrap(
+      <>
+        <HeroBanner listing={listing} orderType="sell" kicker="我的賣出委託" />
 
         <Card>
           <Row
@@ -486,11 +659,168 @@ export default function MarketListing() {
     );
   }
 
-  /* ---- B3：已擁有該角色 ------------------------------------------------ */
+  /* ---- 收購單：我是可能的賣家 ------------------------------------------ */
+  if (buyOrder) {
+    // canFulfill 由後端說了算；沒帶時退回看持有狀態，兩者的判準是同一件事。
+    const owns = viewer.ownsCharacter;
+    const canFulfill = viewer.canFulfill ?? owns === true;
+    const reason = viewer.blockReason;
+    // 持有狀態未知時（後端沒帶 ownsCharacter）不要急著寫「未持有」，
+    // 那句話會讓真的有角色的人直接放棄。
+    const ownsKnown = typeof owns === "boolean";
+    const notOwned = reason === "NOT_OWNED" || owns === false;
+
+    return wrap(
+      <>
+        <HeroBanner listing={listing} orderType="buy" kicker="收購委託" />
+
+        {notOwned && (
+          <Alert severity="warning" role="status" sx={{ borderRadius: 3 }}>
+            <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+              你沒有{listing.name}，無法賣出
+            </AlertTitle>
+            <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+              要接這張收購單，得先真的持有這隻角色。可以去轉蛋，或到出售中的掛單簿買一隻。
+            </Typography>
+          </Alert>
+        )}
+
+        <Card>
+          <Row label="狀態" value={<StatusChip status="open" />} />
+          <Row
+            label="收購方"
+            value={
+              <Box
+                component="span"
+                sx={{ display: "inline-flex", alignItems: "center", gap: 0.875 }}
+              >
+                <CharAvatar
+                  itemId={listing.buyerId ?? listing.itemId}
+                  name={posterName}
+                  size={28}
+                />
+                {posterName}
+              </Box>
+            }
+          />
+          <Row label="發布時間" value={fmtShortDate(listing.createdAt)} />
+          <Row
+            label="你的持有狀態"
+            value={ownsKnown ? (owns ? "已持有，可賣出" : "未持有") : "確認中…"}
+            valueColor={ownsKnown ? (owns ? "success.main" : "error.main") : undefined}
+          />
+        </Card>
+
+        <WalletStrip balance={balance} />
+
+        <Alert severity="warning" sx={{ borderRadius: 3 }}>
+          <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+            賣出後角色就離開你的box
+          </AlertTitle>
+          <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+            你的升星強化不會跟著轉移，也不會退還升星花掉的女神石。買家拿到的是初始星數。
+          </Typography>
+        </Alert>
+
+        <SectionTitle>你會拿到多少</SectionTitle>
+        <Card sx={{ boxShadow: "none" }}>
+          <Row label="收購價" value={`${fmtStone(listing.price)} 女神石`} />
+          <Row label="手續費 5%（銷毀）" value={`−${fmtStone(fee)}`} valueColor="text.secondary" />
+          <Row label="你實收" value={fmtStone(net)} valueColor="secondary.main" />
+          <Row
+            label="你的餘額"
+            value={`${fmtStone(balance)} → ${fmtStone(balance + net)} 女神石`}
+          />
+        </Card>
+
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => setConfirmOpen(true)}
+          disabled={!canFulfill || fulfilling}
+          sx={{ py: 1.5 }}
+        >
+          {notOwned ? `你沒有${listing.name}` : `賣給${posterName}`}
+        </Button>
+        <BtnNote>
+          {notOwned
+            ? "取得這隻角色後就能回來賣出"
+            : `成交後不可反悔，你會收到 ${fmtStone(net)} 女神石。`}
+        </BtnNote>
+        {notOwned && (
+          <Button
+            variant="outlined"
+            onClick={() =>
+              navigate(`/trade/market?characterId=${listing.itemId}`, {
+                state: { fromMarket: false },
+              })
+            }
+          >
+            去買一隻{listing.name}
+          </Button>
+        )}
+
+        <Dialog
+          open={confirmOpen}
+          onClose={() => setConfirmOpen(false)}
+          fullWidth
+          maxWidth="xs"
+          aria-labelledby="fulfill-confirm-title"
+        >
+          <DialogTitle id="fulfill-confirm-title" sx={{ fontWeight: 700 }}>
+            確認把{listing.name}賣給{posterName}？
+          </DialogTitle>
+          <DialogContent>
+            <Alert severity="warning" sx={{ borderRadius: 3, mb: 1.5 }}>
+              <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
+                角色會立刻離開你的box
+              </AlertTitle>
+              <Typography sx={{ fontSize: 12.8, lineHeight: 1.6 }}>
+                升星強化不會轉移，也不會退錢。這個動作無法取消。
+              </Typography>
+            </Alert>
+            <Box sx={{ mb: 1.5 }}>
+              <Row label="角色" value={`${listing.name}（${listing.itemId}）`} />
+              {Number(listing.star) >= 1 && (
+                <Row label="對方會取得" value={`基礎 ${Number(listing.star)} 星`} />
+              )}
+              <Row label="收購價" value={`${fmtStone(listing.price)} 女神石`} />
+              <Row
+                label="手續費 5%（銷毀）"
+                value={`−${fmtStone(fee)}`}
+                valueColor="text.secondary"
+              />
+              <Row label="你實收" value={`${fmtStone(net)} 女神石`} valueColor="secondary.main" />
+              <Row label="交易後餘額" value={`${fmtStone(balance + net)} 女神石`} />
+            </Box>
+            <Typography sx={{ fontSize: 11.5, color: "text.secondary", lineHeight: 1.6 }}>
+              對方發單時已預扣 {fmtStone(listing.price)} 女神石，成交當下就會撥給你，不會跳票。
+            </Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button color="inherit" onClick={() => setConfirmOpen(false)} disabled={fulfilling}>
+              取消
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={handleFulfill}
+              disabled={fulfilling}
+              autoFocus
+            >
+              確認賣出
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  }
+
+  /* ---- 賣單 B3：已擁有該角色 ------------------------------------------ */
   if (viewer.blockReason === "ALREADY_OWNED" || viewer.ownsCharacter) {
     return wrap(
       <>
-        <HeroBanner listing={listing} kicker="賣出委託" />
+        <HeroBanner listing={listing} orderType="sell" kicker="賣出委託" />
 
         <Alert severity="warning" role="status" sx={{ borderRadius: 3 }}>
           <AlertTitle sx={{ fontSize: 13, fontWeight: 700, mb: "2px" }}>
@@ -526,19 +856,26 @@ export default function MarketListing() {
         <Button variant="contained" disabled>
           你已擁有{listing.name}
         </Button>
-        <BtnNote>若要出售自己的{listing.name}，請到「我的掛單」新增委託</BtnNote>
+        <BtnNote>你可以改為掛賣單，或去收購簿看看有沒有人想買</BtnNote>
         <Button variant="outlined" onClick={() => navigate("/trade/sell")}>
           改為掛售我的{listing.name}
+        </Button>
+        <Button
+          variant="text"
+          color="secondary"
+          onClick={() => navigate(`/trade/market?orderType=buy&characterId=${listing.itemId}`)}
+        >
+          看誰在收購{listing.name}
         </Button>
       </>
     );
   }
 
-  /* ---- B2：女神石不足 -------------------------------------------------- */
+  /* ---- 賣單 B2：女神石不足 -------------------------------------------- */
   if (viewer.blockReason === "INSUFFICIENT_FUNDS") {
     return wrap(
       <>
-        <HeroBanner listing={listing} kicker="賣出委託" />
+        <HeroBanner listing={listing} orderType="sell" kicker="賣出委託" />
         <WalletStrip balance={balance} short />
 
         <Alert severity="error" role="status" sx={{ borderRadius: 3 }}>
@@ -568,11 +905,11 @@ export default function MarketListing() {
     );
   }
 
-  /* ---- A1：買家視角，可購買 -------------------------------------------- */
+  /* ---- 賣單 A1：買家視角，可購買 -------------------------------------- */
   const blocked = viewer.canBuy === false;
   return wrap(
     <>
-      <HeroBanner listing={listing} kicker="賣出委託" />
+      <HeroBanner listing={listing} orderType="sell" kicker="賣出委託" />
 
       <Card>
         <Row label="狀態" value={<StatusChip status="open" />} />

--- a/frontend/src/pages/Trade/MarketListing.jsx
+++ b/frontend/src/pages/Trade/MarketListing.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import useAxios from "axios-hooks";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
 import {
   Alert,
   AlertTitle,
@@ -55,11 +55,18 @@ function Card({ children, sx }) {
   );
 }
 
-function AppHeader({ listing, orderNo, onRefresh, refreshing }) {
-  const navigate = useNavigate();
+/** 回市場一律帶著角色，讓人回到剛才在看的那一本掛單簿。 */
+const marketPathFor = listing =>
+  listing?.itemId != null ? `/trade/market?characterId=${listing.itemId}` : "/trade/market";
+
+function AppHeader({ listing, orderNo, onBack, onRefresh, refreshing }) {
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 0.5 }}>
-      <IconButton aria-label="返回列表" size="small" onClick={() => navigate("/trade/market")}>
+      <IconButton
+        aria-label={listing?.name ? `返回${listing.name}的掛單列表` : "返回市場列表"}
+        size="small"
+        onClick={onBack}
+      >
         <ArrowBackIosNewIcon fontSize="small" />
       </IconButton>
       <Box>
@@ -197,7 +204,14 @@ export default function MarketListing() {
   const { loggedIn: isLoggedIn, profile } = useLiff();
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const viewerId = profile?.userId;
+
+  // 從市場點進來的話，上一頁就是那本掛單簿：直接退回去，history 不會多長一節，
+  // 不然「頁內返回 push 市場 → 瀏覽器上一頁又回到詳情」會變成一個轉不出去的圈。
+  // 直接開連結（LIFF 分享、書籤）沒有這個標記，改用 replace 導向帶角色的市場，
+  // 同樣不會留下能退回本頁的紀錄。不看 history.length，那個值猜不準。
+  const fromMarket = Boolean(location.state?.fromMarket);
 
   // 購買失敗回來的終態：把畫面原地降級成 B1 / B4，不重新導頁。
   const [deadCode, setDeadCode] = useState(null);
@@ -226,6 +240,12 @@ export default function MarketListing() {
   }, [isLoggedIn, refetch]);
 
   const orderNo = useMemo(() => `#EX-${id}`, [id]);
+
+  // 這頁所有語義上「回市場」的按鈕都走這裡，行為才會一致。
+  const backToMarket = useCallback(() => {
+    if (fromMarket) navigate(-1);
+    else navigate(marketPathFor(listing), { replace: true });
+  }, [fromMarket, navigate, listing]);
 
   const handleBuy = async () => {
     setConfirmOpen(false);
@@ -272,7 +292,8 @@ export default function MarketListing() {
         <Alert severity="error" sx={{ borderRadius: 3 }}>
           {status === 404 ? "找不到這筆委託" : "載入委託失敗，請稍後再試"}
         </Alert>
-        <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+        {/* listing 沒載到，不知道是哪隻角色；從市場來就退回去，直接開連結則回市場首頁。 */}
+        <Button variant="outlined" onClick={backToMarket}>
           回列表
         </Button>
       </Box>
@@ -303,6 +324,7 @@ export default function MarketListing() {
       <AppHeader
         listing={listing}
         orderNo={orderNo}
+        onBack={backToMarket}
         onRefresh={() => {
           setDeadCode(null);
           refetch().catch(() => {});
@@ -342,8 +364,8 @@ export default function MarketListing() {
             <Button variant="contained" disabled>
               委託已失效
             </Button>
-            <Button variant="outlined" onClick={() => navigate("/trade/market")}>
-              回列表
+            <Button variant="outlined" onClick={backToMarket}>
+              回{listing.name}的掛單
             </Button>
             <Typography sx={{ fontSize: 11.5, color: "text.secondary", lineHeight: 1.6, mx: 0.25 }}>
               若你認為這是異常，請在群組輸入「客服」回報單號 {orderNo}。
@@ -355,7 +377,7 @@ export default function MarketListing() {
               立即購買
             </Button>
             <BtnNote>此委託已不可購買</BtnNote>
-            <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+            <Button variant="outlined" onClick={backToMarket}>
               看其他{listing.name}的掛單
             </Button>
           </>
@@ -414,7 +436,7 @@ export default function MarketListing() {
         <Alert severity="info" icon={false} sx={{ borderRadius: 3 }}>
           這筆委託已取消，無法購買。可以回列表看看其他{listing.name}的掛單。
         </Alert>
-        <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+        <Button variant="outlined" onClick={backToMarket}>
           回列表找其他{listing.name}
         </Button>
       </>
@@ -539,7 +561,7 @@ export default function MarketListing() {
           女神石不足
         </Button>
         <BtnNote>還差 {fmtStone(shortfall)} 女神石</BtnNote>
-        <Button variant="outlined" onClick={() => navigate("/trade/market")}>
+        <Button variant="outlined" onClick={backToMarket}>
           看預算內的{listing.name}（≤ {fmtStone(balance)}）
         </Button>
       </>

--- a/frontend/src/pages/Trade/MyListings.jsx
+++ b/frontend/src/pages/Trade/MyListings.jsx
@@ -1,21 +1,32 @@
 import { useEffect, useMemo } from "react";
 import useAxios from "axios-hooks";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
-import { Alert, Box, Button, IconButton, Paper, Skeleton, Typography } from "@mui/material";
+import { Alert, Box, Button, Paper, Skeleton, Typography } from "@mui/material";
 import { alpha } from "@mui/material/styles";
-import AddIcon from "@mui/icons-material/Add";
+import SellRoundedIcon from "@mui/icons-material/SellRounded";
+import ShoppingBasketRoundedIcon from "@mui/icons-material/ShoppingBasketRounded";
 import AlertLogin from "../../components/AlertLogin";
 import useLiff from "../../context/useLiff";
 import { STATUS } from "./_shared";
-import { NUMS, calcNet, fmtShortDate, fmtShortDay, fmtStone } from "./_market";
-import { CharAvatar, BaseStar, SectionTitle, StatusChip } from "./_marketUi";
+import {
+  MAX_OPEN_FALLBACK,
+  NUMS,
+  calcNet,
+  fmtShortDate,
+  fmtShortDay,
+  fmtStone,
+  orderTypeOf,
+} from "./_market";
+import { CharAvatar, BaseStar, OrderTypeChip, SectionTitle, StatusChip } from "./_marketUi";
 
 /* ---------------------------------------------------------------- 一列委託 */
-function ListingItem({ listing, meta, strike }) {
+function ListingItem({ listing, meta, note, strike }) {
+  const orderType = orderTypeOf(listing);
   return (
     <Paper
       component={RouterLink}
       to={`/trade/listings/${listing.id}`}
+      state={{ orderType }}
       elevation={0}
       sx={{
         display: "flex",
@@ -31,15 +42,21 @@ function ListingItem({ listing, meta, strike }) {
     >
       <CharAvatar itemId={listing.itemId} name={listing.name} headImage={listing.headImage} />
       <Box sx={{ minWidth: 0, flex: "1 1 auto" }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, flexWrap: "wrap" }}>
+          <OrderTypeChip orderType={orderType} />
           <Typography sx={{ fontSize: 14, fontWeight: 600 }} noWrap>
             {listing.name}
           </Typography>
           <BaseStar star={listing.star} />
         </Box>
-        <Typography sx={{ fontSize: 11.5, color: "text.secondary", mt: "2px", ...NUMS }} noWrap>
+        <Typography sx={{ fontSize: 11.5, color: "text.secondary", mt: "3px", ...NUMS }} noWrap>
           {meta}
         </Typography>
+        {note && (
+          <Typography sx={{ fontSize: 11.5, color: note.color, mt: "2px", ...NUMS }} noWrap>
+            {note.text}
+          </Typography>
+        )}
       </Box>
       <Box
         sx={{
@@ -196,6 +213,16 @@ export default function MyListings() {
   const open = useMemo(() => (Array.isArray(mine?.open) ? mine.open : []), [mine]);
   const closed = useMemo(() => (Array.isArray(mine?.closed) ? mine.closed : []), [mine]);
 
+  // 額度是兩種單合計。這裡自己數一次，數字才會跟上面那排 chip 對得起來。
+  const openBuyCount = useMemo(() => open.filter(l => orderTypeOf(l) === "buy").length, [open]);
+  const openSellCount = open.length - openBuyCount;
+  // 收購單的錢現在被鎖住，放在最上面講清楚，不然餘額變少會讓人以為被偷。
+  const reserved = useMemo(
+    () => open.reduce((sum, l) => (orderTypeOf(l) === "buy" ? sum + Number(l.price || 0) : sum), 0),
+    [open]
+  );
+  const maxOpen = summary?.maxOpen ?? MAX_OPEN_FALLBACK;
+
   if (!isLoggedIn) return <AlertLogin />;
 
   return (
@@ -208,18 +235,35 @@ export default function MyListings() {
       }}
     >
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
-        <Box>
+        <Box sx={{ minWidth: 0 }}>
           <Typography sx={{ fontSize: 15.5, fontWeight: 700, lineHeight: 1.2 }}>
             我的掛單 / 紀錄
           </Typography>
           <Typography sx={{ fontSize: 11.5, color: "text.secondary", ...NUMS }}>
             女神石餘額 {fmtStone(summary?.balance)}
+            {reserved > 0 && ` ・ 收購單預扣中 ${fmtStone(reserved)}`}
           </Typography>
         </Box>
-        <Box sx={{ flex: "1 1 auto" }} />
-        <IconButton aria-label="新增賣出委託" onClick={() => navigate("/trade/sell")}>
-          <AddIcon />
-        </IconButton>
+      </Box>
+
+      <Box sx={{ display: "flex", gap: 1.25 }}>
+        <Button
+          variant="outlined"
+          startIcon={<SellRoundedIcon />}
+          onClick={() => navigate("/trade/sell")}
+          sx={{ flex: "1 1 0" }}
+        >
+          新增賣單
+        </Button>
+        <Button
+          variant="outlined"
+          color="secondary"
+          startIcon={<ShoppingBasketRoundedIcon />}
+          onClick={() => navigate("/trade/buy")}
+          sx={{ flex: "1 1 0" }}
+        >
+          新增收購單
+        </Button>
       </Box>
 
       {error && (
@@ -228,9 +272,16 @@ export default function MyListings() {
         </Alert>
       )}
 
-      <SectionTitle>開放中 · {open.length}</SectionTitle>
+      <SectionTitle>
+        開放中 · {open.length} / {maxOpen}
+      </SectionTitle>
+      {!loading && open.length > 0 && (
+        <Typography sx={{ fontSize: 11.5, color: "text.secondary", mx: 0.25, mt: -0.75 }}>
+          賣單 {openSellCount} 筆 ・ 收購單 {openBuyCount} 筆，兩種合計共用 {maxOpen} 筆額度。
+        </Typography>
+      )}
       {loading && !mine ? (
-        [1, 2].map(i => <Skeleton key={i} variant="rounded" height={72} animation="wave" />)
+        [1, 2].map(i => <Skeleton key={i} variant="rounded" height={78} animation="wave" />)
       ) : open.length === 0 ? (
         <Paper
           elevation={0}
@@ -245,38 +296,77 @@ export default function MyListings() {
           <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
             目前沒有開放中的委託。
           </Typography>
-          <Button variant="outlined" sx={{ mt: 1.5 }} onClick={() => navigate("/trade/sell")}>
-            我要掛賣單
-          </Button>
+          <Box
+            sx={{ display: "flex", gap: 1.25, justifyContent: "center", mt: 1.5, flexWrap: "wrap" }}
+          >
+            <Button variant="outlined" onClick={() => navigate("/trade/sell")}>
+              我要掛賣單
+            </Button>
+            <Button variant="outlined" color="secondary" onClick={() => navigate("/trade/buy")}>
+              我要發收購單
+            </Button>
+          </Box>
         </Paper>
       ) : (
-        open.map(l => (
-          <ListingItem
-            key={l.id}
-            listing={l}
-            meta={`${l.itemId} · ${fmtShortDate(l.createdAt)} · 可得 ${fmtStone(l.netProceeds ?? calcNet(l.price))}`}
-          />
-        ))
+        open.map(l => {
+          const buy = orderTypeOf(l) === "buy";
+          return (
+            <ListingItem
+              key={l.id}
+              listing={l}
+              meta={`${l.itemId} · ${fmtShortDate(l.createdAt)}`}
+              note={
+                buy
+                  ? { text: `已預扣 ${fmtStone(l.price)}，取消可全額退回`, color: "warning.main" }
+                  : {
+                      text: `成交可得 ${fmtStone(l.netProceeds ?? calcNet(l.price))}`,
+                      color: "text.secondary",
+                    }
+              }
+            />
+          );
+        })
       )}
 
       <SectionTitle>已結束 · {closed.length}</SectionTitle>
       {loading && !mine ? (
-        [1, 2].map(i => <Skeleton key={i} variant="rounded" height={72} animation="wave" />)
+        [1, 2].map(i => <Skeleton key={i} variant="rounded" height={78} animation="wave" />)
       ) : closed.length === 0 ? (
         <Typography sx={{ fontSize: 12, color: "text.secondary", mx: 0.25 }}>
           還沒有結束的委託。
         </Typography>
       ) : (
         closed.map(l => {
+          const buy = orderTypeOf(l) === "buy";
           const sold = l.status === "sold";
           // 後端已標好 role；沒帶到時退回比對 sellerId。
+          // 這一格決定畫面寫「買入」還是「賣出」，兩者的金流方向相反，不能猜錯。
           const bought = sold && (l.role ? l.role === "buyer" : l.sellerId !== viewerId);
+          const net = fmtStone(l.netProceeds ?? calcNet(l.price));
+
           const meta = sold
+            ? `${l.itemId} · ${fmtShortDate(l.soldAt)}`
+            : `${l.itemId} · ${fmtShortDate(l.closedAt)} · ${
+                l.status === "invalid" ? "已失效自動下架" : "自行取消"
+              }`;
+
+          const note = sold
             ? bought
-              ? `${l.itemId} · ${fmtShortDate(l.soldAt)} · 買入`
-              : `${l.itemId} · ${fmtShortDate(l.soldAt)} · 賣出，實收 ${fmtStone(l.netProceeds ?? calcNet(l.price))}`
-            : `${l.itemId} · ${fmtShortDate(l.closedAt)} · ${l.status === "invalid" ? "逾期自動下架" : "自行取消"}`;
-          return <ListingItem key={l.id} listing={l} meta={meta} strike={!sold} />;
+              ? {
+                  text: buy
+                    ? `收購成交，支付 ${fmtStone(l.price)}`
+                    : `買入，支付 ${fmtStone(l.price)}`,
+                  color: "text.secondary",
+                }
+              : {
+                  text: buy ? `履約賣出，實收 ${net}` : `賣出，實收 ${net}`,
+                  color: "success.main",
+                }
+            : buy
+              ? { text: `已退還 ${fmtStone(l.refundedAmount ?? l.price)}`, color: "success.main" }
+              : null;
+
+          return <ListingItem key={l.id} listing={l} meta={meta} note={note} strike={!sold} />;
         })
       )}
 

--- a/frontend/src/pages/Trade/_market.js
+++ b/frontend/src/pages/Trade/_market.js
@@ -44,6 +44,53 @@ export const LISTING_STATUS = {
   invalid: { label: "已失效", color: "error" },
 };
 
+/* ------------------------------------------------------------ 委託方向 */
+
+/**
+ * 掛單有兩個方向：賣單（sell）與收購單（buy）。
+ * 網址、API query、listing 欄位都用同一組字串，缺值一律當賣單，
+ * 這樣第一階段留下來的連結與資料都還會照舊運作。
+ */
+export const normalizeOrderType = v => (String(v ?? "").toLowerCase() === "buy" ? "buy" : "sell");
+
+export const orderTypeOf = listing => normalizeOrderType(listing?.orderType);
+
+/**
+ * 兩個方向的固定用字。不是抽象層，只是把「賣家／收購方」這種
+ * 會在三個頁面同時出現、講錯就會誤導金流的字集中在一處。
+ */
+export const ORDER_COPY = {
+  sell: {
+    chip: "賣出",
+    book: "出售中",
+    noun: "賣單",
+    poster: "賣家",
+    best: "最低價",
+    bestPrice: "最低售價",
+    sortNote: "價格由低到高",
+    action: "立即購買",
+  },
+  buy: {
+    chip: "求購",
+    book: "收購中",
+    noun: "收購單",
+    poster: "收購方",
+    best: "最高價",
+    bestPrice: "最高收購價",
+    sortNote: "價格由高到低",
+    action: "賣給他",
+  },
+};
+
+/** 掛出這張單的人：賣單是賣家，收購單是收購方（買家）。 */
+export const posterIdOf = listing =>
+  orderTypeOf(listing) === "buy" ? (listing?.buyerId ?? listing?.sellerId) : listing?.sellerId;
+
+export const posterNameOf = listing =>
+  orderTypeOf(listing) === "buy"
+    ? (listing?.buyerName ?? listing?.sellerName)
+    : listing?.sellerName;
+
 /**
  * 後端錯誤碼 → 文案。UI 一律看 code，認不得的才退回 message。
  */
@@ -58,18 +105,49 @@ export const MARKET_ERROR = {
   },
   INSUFFICIENT_FUNDS: { title: "女神石不足，無法購買" },
   ALREADY_OWNED: {
-    title: "你已擁有此角色，無法購買",
+    title: "你已擁有此角色",
     detail: "角色為一人一隻，重複持有不會生效。",
   },
   IS_SELLER: { title: "這是你自己的掛單，無法購買" },
-  NOT_OPEN: { title: "此委託已結束，無法購買" },
+  NOT_OPEN: { title: "此委託已結束，無法再操作" },
   LISTING_CAP: {
-    title: "最多只能同時上架 10 筆",
-    detail: "先去「我的掛單」取消一筆，或等現有的賣單成交，才能再掛新的。",
+    title: "最多只能同時掛 10 筆",
+    detail: "賣單和收購單合計算，先去「我的掛單」取消一筆，或等現有的單成交，才能再掛新的。",
   },
-  NOT_OWNED: { title: "你目前沒有這個角色，無法掛單" },
+  NOT_OWNED: {
+    title: "你目前沒有這個角色",
+    detail: "要掛賣單或賣給收購方，都得先真的持有這隻角色。",
+  },
   ALREADY_LISTED: { title: "這個角色你已經有一張掛單了" },
-  INVALID_PRICE: { title: "售價只能填 1 ～ 10,000,000" },
+  INVALID_PRICE: { title: "價格只能填 1 ～ 10,000,000" },
+
+  /* ---- 收購單 ---- */
+  INVALID_ORDER_TYPE: {
+    title: "委託方向不正確",
+    detail: "請回上一頁重新操作，網址可能被改過。",
+  },
+  WRONG_ORDER_TYPE: {
+    title: "這筆委託不是用這種方式成交的",
+    detail: "賣單要用購買、收購單要用賣出，請重新整理後再試一次。",
+  },
+  ALREADY_REQUESTED: {
+    title: "這個角色你已經有一張收購單了",
+    detail: "同一個角色同時只能掛一張收購單，先取消原本那張再改價。",
+  },
+  IS_BUYER: {
+    title: "這是你自己發的收購單，無法賣給自己",
+  },
+  IS_REQUESTER: {
+    title: "這是你自己發的收購單，無法賣給自己",
+  },
+  ALREADY_OWNED_REQUESTER: {
+    title: "收購方已經有這個角色了，收購單已失效",
+    detail: "系統已自動下架這筆收購單，並把預扣的女神石全額退還給對方。",
+  },
+  NOT_ENOUGH_TO_RESERVE: {
+    title: "女神石不足，無法發布收購單",
+    detail: "發布時就會先預扣全額，請先確認餘額夠付出價金額。",
+  },
 };
 
 export function errorInfo(err, fallback = "操作失敗，請稍後再試") {

--- a/frontend/src/pages/Trade/_marketUi.jsx
+++ b/frontend/src/pages/Trade/_marketUi.jsx
@@ -1,7 +1,17 @@
-import { Avatar, Box, Chip, Paper, Typography } from "@mui/material";
+import {
+  Avatar,
+  Box,
+  Chip,
+  Paper,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import StarRateRoundedIcon from "@mui/icons-material/StarRateRounded";
-import { LISTING_STATUS, NUMS, charGradient } from "./_market";
+import SellRoundedIcon from "@mui/icons-material/SellRounded";
+import ShoppingBasketRoundedIcon from "@mui/icons-material/ShoppingBasketRounded";
+import { LISTING_STATUS, NUMS, ORDER_COPY, charGradient, normalizeOrderType } from "./_market";
 
 /* ---------------------------------------------------------------- 版面零件 */
 
@@ -168,8 +178,79 @@ export function StatusChip({ status, size = "small", sx }) {
   );
 }
 
-/** 主色漸層面板，三個頁面的 banner 共用同一層底。 */
-export function GradientPanel({ children, sx }) {
+/**
+ * 賣單 / 收購單的方向標。
+ *
+ * 這個 chip 是整個第二階段最不能誤讀的一格：同一張列表會同時出現
+ * 「我要賣掉的角色」跟「我想買進的角色」，兩者的金流方向完全相反。
+ * 所以顏色分開（賣＝主色、購＝次色）、圖示分開，字也直接寫「賣出／求購」，
+ * 不用「買/賣」單字，避免在小字級被看成同一個字。
+ */
+export function OrderTypeChip({ orderType, size = "small", sx }) {
+  const type = normalizeOrderType(orderType);
+  const buy = type === "buy";
+  const Icon = buy ? ShoppingBasketRoundedIcon : SellRoundedIcon;
+
+  return (
+    <Chip
+      size={size}
+      label={ORDER_COPY[type].chip}
+      color={buy ? "secondary" : "primary"}
+      variant="outlined"
+      icon={<Icon aria-hidden="true" sx={{ fontSize: "14px !important" }} />}
+      aria-label={buy ? "收購單，你把角色賣出去" : "賣單，你把角色賣給買家"}
+      sx={{ fontWeight: 700, height: 25, ...sx }}
+    />
+  );
+}
+
+/**
+ * 出售中 / 收購中的切換。Market 用它換整本掛單簿，
+ * 所以做成兩顆等寬的按鈕，不縮成 icon —— 按錯方向的代價是看錯價格。
+ */
+export function OrderTypeSwitch({ value, onChange, disabled }) {
+  const type = normalizeOrderType(value);
+
+  return (
+    <ToggleButtonGroup
+      value={type}
+      exclusive
+      size="small"
+      fullWidth
+      disabled={disabled}
+      onChange={(_, v) => v !== null && onChange(v)}
+      aria-label="切換掛單簿方向"
+      sx={{
+        "& .MuiToggleButton-root": {
+          py: 0.75,
+          fontSize: 13,
+          fontWeight: 700,
+          textTransform: "none",
+          gap: 0.75,
+          borderRadius: "999px !important",
+        },
+      }}
+    >
+      <ToggleButton value="sell" aria-label="看別人賣出的角色，你可以買">
+        <SellRoundedIcon aria-hidden="true" sx={{ fontSize: 16 }} />
+        {ORDER_COPY.sell.book}
+      </ToggleButton>
+      <ToggleButton value="buy" aria-label="看別人收購的角色，你可以賣">
+        <ShoppingBasketRoundedIcon aria-hidden="true" sx={{ fontSize: 16 }} />
+        {ORDER_COPY.buy.book}
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+}
+
+/**
+ * 主色漸層面板，三個頁面的 banner 共用同一層底。
+ *
+ * tone="buy" 換成琥珀色那一套：收購單的錢是從你自己口袋先扣出去的，
+ * 跟賣單的青色分開，掃一眼就知道現在站在哪一邊，不用讀完標題。
+ */
+export function GradientPanel({ children, tone = "sell", sx }) {
+  const buy = tone === "buy";
   return (
     <Paper
       elevation={0}
@@ -181,8 +262,13 @@ export function GradientPanel({ children, sx }) {
         color: "#fff",
         border: "1px solid",
         borderColor: alpha("#fff", 0.14),
-        background:
-          theme.palette.mode === "dark"
+        background: buy
+          ? theme.palette.mode === "dark"
+            ? `radial-gradient(120% 140% at 88% -20%, ${alpha(theme.palette.secondary.light, 0.24)}, transparent 55%),
+               linear-gradient(135deg, #4A2C05, #A9670A 58%, ${theme.palette.secondary.main})`
+            : `radial-gradient(120% 140% at 88% -20%, rgba(255,255,255,.3), transparent 55%),
+               linear-gradient(135deg, ${theme.palette.secondary.dark}, ${theme.palette.secondary.main} 55%, ${theme.palette.secondary.light})`
+          : theme.palette.mode === "dark"
             ? `radial-gradient(120% 140% at 88% -20%, ${alpha(theme.palette.primary.light, 0.22)}, transparent 55%),
                linear-gradient(135deg, #0B3A4C, #0E7A8C 60%, ${theme.palette.primary.main})`
             : `radial-gradient(120% 140% at 88% -20%, rgba(255,255,255,.28), transparent 55%),


### PR DESCRIPTION
## Summary
- add market ownership filters and URL-backed character navigation
- add escrowed character buy orders with atomic reserve, refund, cancellation, and fulfillment flows
- extend LIFF market, listing detail, and history views for sell and buy order books
- preserve concurrent god stone ledger updates in shop exchanges and inventory compaction

## Transaction rules
- publishing a buy order reserves the full amount immediately
- cancelling or invalidating a buy order refunds the reserve exactly once
- fulfillment transfers the character and pays the seller net of the 5% fee
- sell and buy orders share the same 10-open-order limit

## Test plan
- [x] 249 targeted PublicMarket and GodStoneShop tests
- [x] `yarn lint:app`
- [x] `yarn lint:frontend` (0 errors; existing warnings remain)
- [x] `yarn build:frontend`
- [x] `git diff --check`
- [x] independent transaction-safety review
- [ ] run the new Knex migration against deployment MySQL

## Deployment note
This PR adds `app/migrations/20260810155919_extend_public_market_buy_orders.js`. Production must run `yarn migrate` before the new application code serves buy-order requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)