### PR TITLE
feat(worldboss): 群組可自選啟用 Flex postback 攻擊

### DIFF
--- a/app/doc/GroupConfig.json
+++ b/app/doc/GroupConfig.json
@@ -28,5 +28,10 @@
     "title": "梗圖指令",
     "description": "內含多個梗圖指令，等待你發現更多彩蛋",
     "name": "GlobalOrder"
+  },
+  {
+    "title": "世界王群組內攻擊",
+    "description": "開啟後，群組成員可以直接在 #世界王 戰況卡上按按鈕攻擊；關閉則只能透過戰況板（LIFF）攻擊。",
+    "name": "WorldBossAttack"
   }
 ]

--- a/app/src/controller/application/WorldBossController.js
+++ b/app/src/controller/application/WorldBossController.js
@@ -1,33 +1,79 @@
 const { text } = require("bottender/router");
+const { getClient } = require("bottender");
 const SeasonService = require("../../service/WorldBossSeasonService");
+const WorldBossAttackService = require("../../service/WorldBossAttackService");
 const WorldBossTemplate = require("../../templates/application/WorldBoss");
 const { getLiffUri } = require("../../templates/common");
+const { DefaultLogger } = require("../../util/Logger");
 
+const LineClient = getClient("line");
 const WORLD_BOSS_LIFF_PATH = "/worldboss";
 
 /**
  * `#世界王` is a shared group board: season, cycle, the five boss snapshots and the
- * one LIFF link everybody uses. Nothing about the person who typed it may appear —
- * quota, EXP, rewards and personal damage live behind authenticated LIFF only.
+ * one LIFF link everybody uses. Nothing about the person who typed it may appear.
  */
 async function showBattleStatus(context) {
   const status = await SeasonService.getBattleStatus();
+  const attackEnabled =
+    context.event.source.type === "group" && context.state?.guildConfig?.WorldBossAttack === "Y";
   const bubble = WorldBossTemplate.generateWorldBossReply({
     status,
     liffUri: getLiffUri("full", WORLD_BOSS_LIFF_PATH),
+    attackEnabled,
   });
   return context.replyFlex("世界王", bubble);
 }
 
-/**
- * Retired. Attacks moved to the authenticated LIFF endpoint
- * `POST /api/world-boss/attack`; no Flex message produces this postback any more.
- * Old cards still in users' chat history must hit a dead end, not a second code
- * path that could drift from the API's rules — so this executes nothing and
- * replies nothing.
- */
-async function attackOnBoss() {
-  return;
+/** Handle a group attack postback using the shared attack service. */
+async function attackOnBoss(context, { payload }) {
+  const source = context.event.source;
+  if (source.type !== "group") return;
+  if (context.state?.guildConfig?.WorldBossAttack !== "Y") return;
+
+  const { roundId, attackType } = payload || {};
+  if (!["standard", "skill"].includes(attackType)) return;
+
+  let displayName = "未知玩家";
+  try {
+    const profile = await LineClient.getGroupMemberProfile(source.groupId, source.userId);
+    if (profile && typeof profile.displayName === "string" && profile.displayName.trim()) {
+      displayName = profile.displayName.trim();
+    }
+  } catch (error) {
+    DefaultLogger.warn("[world-boss-attack] profile lookup failed", error);
+  }
+
+  try {
+    const { result } = await WorldBossAttackService.attack({
+      userId: source.userId,
+      roundId,
+      attackType,
+      displayName,
+    });
+    const damage = new Intl.NumberFormat("en-US").format(result.effectiveDamage);
+    const firstLine = `⚔️ ${displayName} 造成 ${damage} 傷害`;
+    const secondLine = result.cleared
+      ? result.cycleAdvanced
+        ? `🎊 ${displayName} 擊破第 ${result.attackedCycleNo} 輪最後一隻王「${result.boss.position} 號 ${result.boss.name}」，本周回五王全滅！`
+        : `⚔️ ${displayName} 擊破了第 ${result.attackedCycleNo} 輪 ${result.boss.position} 號王「${result.boss.name}」！`
+      : `\u3000 ${result.attackedCycleNo} 輪 ${result.boss.position} 號王「${result.boss.name}」剩餘 ${
+          (BigInt(result.round.current_hp) * 100n + BigInt(result.round.max_hp) / 2n) /
+          BigInt(result.round.max_hp)
+        }%`;
+    await context.replyText(`${firstLine}\n${secondLine}`);
+  } catch (error) {
+    if (["DAILY_LIMIT_EXCEEDED", "ATTACK_COOLDOWN"].includes(error && error.code)) return;
+    if (["ROUND_CLEARED", "ROUND_STALE"].includes(error && error.code)) {
+      await context.replyText("這隻王已被擊破，請打 #世界王 取得最新戰況");
+      return;
+    }
+    if (["SEASON_ENDED", "NO_ACTIVE_SEASON", "NO_ACTIVE_ROUND"].includes(error && error.code)) {
+      await context.replyText("世界王賽季已結束或尚未開始");
+      return;
+    }
+    DefaultLogger.error("[world-boss-attack] failed", error);
+  }
 }
 
 exports.router = [text(/^[.#/](世界王|worldboss)$/i, showBattleStatus)];

--- a/app/src/controller/application/__tests__/WorldBossController.test.js
+++ b/app/src/controller/application/__tests__/WorldBossController.test.js
@@ -18,9 +18,7 @@ jest.mock("bottender", () => ({
 }));
 jest.mock("bottender/router", () => jest.requireActual("bottender/router"));
 jest.mock("../../../templates/application/Job", () => ({}));
-jest.mock("../../../controller/application/OpenaiController", () => ({
-  recordSession: jest.fn(),
-}));
+jest.mock("../../../controller/application/OpenaiController", () => ({ recordSession: jest.fn() }));
 jest.mock("../../../service/WorldBossBattleService", () => ({
   attack: jest.fn(),
   getRemainingDailyCost: jest.fn(),
@@ -33,9 +31,7 @@ jest.mock("../../../service/WorldBossAttackService", () => ({ attack: jest.fn() 
 jest.mock("../../../templates/application/WorldBoss", () => ({
   generateWorldBossReply: jest.fn(),
 }));
-jest.mock("../../../templates/common", () => ({
-  getLiffUri: jest.fn(),
-}));
+jest.mock("../../../templates/common", () => ({ getLiffUri: jest.fn() }));
 jest.mock("../../../util/redis", () => ({
   set: jest.fn(),
   get: jest.fn(),
@@ -65,11 +61,50 @@ const activeStatus = {
   ended: false,
 };
 
-function context(userId = "Uworldboss") {
+function context(userId = "Uworldboss", type = "user", guildConfig) {
   return {
-    event: { source: { userId } },
+    event: { source: { userId, type, groupId: "Cgroup" } },
+    ...(guildConfig === undefined ? {} : { state: { guildConfig } }),
     replyText: jest.fn(),
     replyFlex: jest.fn(),
+  };
+}
+
+function postbackContext(action, userId = "Uworldboss", cooldown = 1, extra = {}, type = "group") {
+  return {
+    event: {
+      isPayload: true,
+      payload: JSON.stringify({ action, attackType: "standard", cooldown, ...extra }),
+      source: { userId, type, groupId: "Cgroup" },
+    },
+    state: { guildConfig: { WorldBossAttack: "Y" } },
+    replyText: jest.fn(),
+    replyFlex: jest.fn(),
+  };
+}
+
+async function runPostback(ctx) {
+  let next = await HandlePostback(ctx, { next: jest.fn() });
+  while (typeof next === "function") next = await next(ctx, {});
+}
+
+function error(code, message = code) {
+  return Object.assign(new Error(message), { code });
+}
+
+function attackResult(overrides = {}) {
+  return {
+    effectiveDamage: "12345",
+    attackedCycleNo: 3,
+    cleared: false,
+    cycleAdvanced: false,
+    round: { current_hp: "500", max_hp: "1000" },
+    boss: { position: 2, name: "炎王" },
+    levelResult: { newLevel: 55 },
+    daily: { remaining: 77 },
+    seasonTotalDamage: "99999999",
+    cost: 10,
+    ...overrides,
   };
 }
 
@@ -79,106 +114,191 @@ function expectReplyOnlyDelivery() {
   expect(mockLineClient.broadcast).not.toHaveBeenCalled();
 }
 
-function postbackContext(action, userId = "Uworldboss", cooldown = 1, extra = {}) {
-  return {
-    event: {
-      isPayload: true,
-      payload: JSON.stringify({ action, attackType: "standard", cooldown, ...extra }),
-      source: { userId },
-    },
-    replyText: jest.fn(),
-    replyFlex: jest.fn(),
-  };
-}
-
-async function runPostback(context) {
-  let next = await HandlePostback(context, { next: jest.fn() });
-  while (typeof next === "function") next = await next(context, {});
-}
-
 beforeEach(() => {
   jest.clearAllMocks();
   SeasonService.getBattleStatus.mockResolvedValue(activeStatus);
-  SeasonService.getLatestSettledResult.mockResolvedValue(null);
   redis.set.mockResolvedValue("OK");
-  redis.get.mockResolvedValue(null);
-  redis.incr.mockResolvedValue();
   commonTemplate.getLiffUri.mockReturnValue("https://liff.example/worldboss");
   WorldBossTemplate.generateWorldBossReply.mockReturnValue({ type: "world-reply" });
+  mockLineClient.getGroupMemberProfile.mockResolvedValue({ displayName: "群組玩家" });
+  AttackService.attack.mockResolvedValue({ result: attackResult(), latestReward: null });
 });
 
 describe("WorldBossController.showBattleStatus — public board only", () => {
-  it("renders the public board from season status alone, with no personal lookups", async () => {
+  it("passes attackEnabled false for the default user context", async () => {
     const ctx = context();
-
     await Controller.showBattleStatus(ctx);
-
     expect(WorldBossTemplate.generateWorldBossReply).toHaveBeenCalledWith({
       status: activeStatus,
       liffUri: "https://liff.example/worldboss",
+      attackEnabled: false,
     });
-    // No quota, no settled reward: nothing that identifies the triggering user.
     expect(BattleService.getRemainingDailyCost).not.toHaveBeenCalled();
     expect(SeasonService.getLatestSettledResult).not.toHaveBeenCalled();
-    expect(ctx.replyFlex).toHaveBeenCalledWith("世界王", { type: "world-reply" });
     expectReplyOnlyDelivery();
   });
 
-  it("renders the board even without a resolvable user, since it is not user specific", async () => {
-    const ctx = context(undefined);
+  it("enables attack postbacks for a group with the toggle on", async () => {
+    await Controller.showBattleStatus(context("Ugroup", "group", { WorldBossAttack: "Y" }));
+    expect(WorldBossTemplate.generateWorldBossReply).toHaveBeenCalledWith(
+      expect.objectContaining({ attackEnabled: true })
+    );
+  });
 
-    await Controller.showBattleStatus(ctx);
+  it.each(["N", undefined])("keeps attack disabled for group toggle %s", async value => {
+    await Controller.showBattleStatus(
+      context("Ugroup", "group", value === undefined ? {} : { WorldBossAttack: value })
+    );
+    expect(WorldBossTemplate.generateWorldBossReply).toHaveBeenCalledWith(
+      expect.objectContaining({ attackEnabled: false })
+    );
+  });
 
-    expect(ctx.replyText).not.toHaveBeenCalled();
-    expect(ctx.replyFlex).toHaveBeenCalledWith("世界王", { type: "world-reply" });
+  it("keeps attack disabled in 1:1 chats even when config is present", async () => {
+    await Controller.showBattleStatus(context("Uuser", "user", { WorldBossAttack: "Y" }));
+    expect(WorldBossTemplate.generateWorldBossReply).toHaveBeenCalledWith(
+      expect.objectContaining({ attackEnabled: false })
+    );
   });
 
   it("passes a missing season through to the template unchanged", async () => {
     SeasonService.getBattleStatus.mockResolvedValue(null);
-    const ctx = context();
-
-    await Controller.showBattleStatus(ctx);
-
+    await Controller.showBattleStatus(context(undefined));
     expect(WorldBossTemplate.generateWorldBossReply).toHaveBeenCalledWith({
       status: null,
       liffUri: "https://liff.example/worldboss",
+      attackEnabled: false,
     });
-    expect(ctx.replyFlex).toHaveBeenCalledWith("世界王", { type: "world-reply" });
   });
 });
 
-describe("Retired worldBossAttack postback", () => {
-  it("performs no attack and sends no reply for an old card", async () => {
-    const ctx = postbackContext("worldBossAttack", "Uworldboss", 5, { roundId: 2 });
-
+describe("worldBossAttack postback — group attack", () => {
+  it("silently rejects a 1:1 old card", async () => {
+    const ctx = postbackContext("worldBossAttack", "Uuser", 1, { roundId: 2 }, "user");
     await runPostback(ctx);
-
     expect(ctx.replyText).not.toHaveBeenCalled();
-    expect(ctx.replyFlex).not.toHaveBeenCalled();
     expect(AttackService.attack).not.toHaveBeenCalled();
-    expect(BattleService.attack).not.toHaveBeenCalled();
     expectReplyOnlyDelivery();
   });
 
-  it("is silent when called directly with a well-formed legacy payload", async () => {
-    const ctx = context();
-
-    await Controller.attackOnBoss(ctx, { payload: { attackType: "standard", roundId: 2 } });
-
+  it("silently rejects a group old card after the toggle was disabled", async () => {
+    const ctx = postbackContext("worldBossAttack");
+    ctx.state.guildConfig.WorldBossAttack = "N";
+    await runPostback(ctx);
     expect(ctx.replyText).not.toHaveBeenCalled();
-    expect(ctx.replyFlex).not.toHaveBeenCalled();
     expect(AttackService.attack).not.toHaveBeenCalled();
-    expect(BattleService.attack).not.toHaveBeenCalled();
-    // The retired handler must not even reserve the attack cooldown.
-    expect(redis.set).not.toHaveBeenCalled();
   });
 
-  it("stops at the generic guard without calling the controller", async () => {
+  it("silently handles an undefined state without throwing", async () => {
+    const ctx = context("Ugroup", "group");
+    await expect(
+      Controller.attackOnBoss(ctx, { payload: { roundId: 2, attackType: "standard" } })
+    ).resolves.toBeUndefined();
+    expect(ctx.replyText).not.toHaveBeenCalled();
+    expect(AttackService.attack).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, "heavy"])("silently rejects invalid attack type %s", async attackType => {
+    const ctx = postbackContext("worldBossAttack", "Ugroup", 1, { roundId: 2, attackType });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 2, attackType } });
+    expect(ctx.replyText).not.toHaveBeenCalled();
+    expect(AttackService.attack).not.toHaveBeenCalled();
+  });
+
+  it.each(["DAILY_LIMIT_EXCEEDED", "ATTACK_COOLDOWN"])("silently handles %s", async code => {
+    AttackService.attack.mockRejectedValue(error(code));
+    const ctx = context("Ugroup", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 2, attackType: "standard" } });
+    expect(ctx.replyText).not.toHaveBeenCalled();
+    expectReplyOnlyDelivery();
+  });
+
+  it("attacks with source identity, profile name, and no groupId", async () => {
+    const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 22, attackType: "skill" } });
+    expect(AttackService.attack).toHaveBeenCalledWith({
+      userId: "Usource",
+      roundId: 22,
+      attackType: "skill",
+      displayName: "群組玩家",
+    });
+    expect(AttackService.attack.mock.calls[0][0]).not.toHaveProperty("groupId");
+    expectReplyOnlyDelivery();
+  });
+
+  it("does not trust a malicious payload userId", async () => {
+    const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, {
+      payload: { roundId: 22, attackType: "standard", userId: "Uattacker" },
+    });
+    expect(AttackService.attack.mock.calls[0][0].userId).toBe("Usource");
+  });
+
+  it("falls back to 未知玩家 when profile lookup fails", async () => {
+    mockLineClient.getGroupMemberProfile.mockRejectedValue(new Error("LINE down"));
+    const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 22, attackType: "standard" } });
+    expect(AttackService.attack.mock.calls[0][0].displayName).toBe("未知玩家");
+  });
+
+  it("replies with public status only and uses effective damage", async () => {
+    AttackService.attack.mockResolvedValue({
+      result: attackResult({ latestReward: "not-public" }),
+      latestReward: { stoneAmount: 100 },
+    });
+    const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 22, attackType: "standard" } });
+    const reply = ctx.replyText.mock.calls[0][0];
+    expect(reply).toContain("群組玩家");
+    expect(reply).toContain("12,345");
+    expect(reply).toContain("3 輪 2 號王「炎王」剩餘 50%");
+    ["99999999", "77", "55", "10", "not-public", "100"].forEach(value =>
+      expect(reply).not.toContain(value)
+    );
+    expectReplyOnlyDelivery();
+  });
+
+  it.each([
+    [false, "⚔️ 群組玩家 擊破了第 3 輪 2 號王「炎王」！"],
+    [true, "🎊 群組玩家 擊破第 3 輪最後一隻王「2 號 炎王」，本周回五王全滅！"],
+  ])("uses the correct clear text when cycleAdvanced=%s", async (cycleAdvanced, expected) => {
+    AttackService.attack.mockResolvedValue({
+      result: attackResult({ cleared: true, cycleAdvanced }),
+    });
+    const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 22, attackType: "standard" } });
+    expect(ctx.replyText).toHaveBeenCalledWith(expect.stringContaining(expected));
+  });
+
+  it.each(["ROUND_CLEARED", "ROUND_STALE"])("reports a cleared boss for %s", async code => {
+    AttackService.attack.mockRejectedValue(error(code));
+    const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 22, attackType: "standard" } });
+    expect(ctx.replyText).toHaveBeenCalledWith("這隻王已被擊破，請打 #世界王 取得最新戰況");
+  });
+
+  it.each(["SEASON_ENDED", "NO_ACTIVE_SEASON", "NO_ACTIVE_ROUND"])(
+    "reports season state for %s",
+    async code => {
+      AttackService.attack.mockRejectedValue(error(code));
+      const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+      await Controller.attackOnBoss(ctx, { payload: { roundId: 22, attackType: "standard" } });
+      expect(ctx.replyText).toHaveBeenCalledWith("世界王賽季已結束或尚未開始");
+    }
+  );
+
+  it("silently logs unexpected errors without exposing them", async () => {
+    AttackService.attack.mockRejectedValue(error("BOOM", "secret stack details"));
+    const ctx = context("Usource", "group", { WorldBossAttack: "Y" });
+    await Controller.attackOnBoss(ctx, { payload: { roundId: 22, attackType: "standard" } });
+    expect(ctx.replyText).not.toHaveBeenCalled();
+    expectReplyOnlyDelivery();
+  });
+
+  it("stops at the generic postback guard without calling the controller", async () => {
     redis.set.mockResolvedValue(null);
     const ctx = postbackContext("worldBossAttack");
-
     await runPostback(ctx);
-
     expect(redis.set).toHaveBeenCalledWith("Postback_Uworldboss_worldBossAttack", 1, {
       EX: 1,
       NX: true,
@@ -190,9 +310,7 @@ describe("Retired worldBossAttack postback", () => {
   it("keeps the generic postback guard for other actions", async () => {
     redis.set.mockResolvedValue(null);
     const ctx = postbackContext("janken", "Ulegacy", 7);
-
     await runPostback(ctx);
-
     expect(redis.set).toHaveBeenCalledWith("Postback_Ulegacy_janken", 1, {
       EX: 7,
       NX: true,

--- a/app/src/model/application/GuildConfig.js
+++ b/app/src/model/application/GuildConfig.js
@@ -16,6 +16,7 @@ exports.fetchConfig = async groupId => {
           GlobalOrder: "Y",
           Gacha: "Y",
           PrincessInformation: "Y",
+          WorldBossAttack: "N",
         };
         insertConfig(groupId, res);
       } else {

--- a/app/src/templates/application/Group/line.js
+++ b/app/src/templates/application/Group/line.js
@@ -259,6 +259,7 @@ exports.showGroupConfig = context => {
     `群組人數:${count}`,
     `轉蛋功能:${getIcon(guildConfig.Gacha)}`,
     `戰隊功能:${getIcon(guildConfig.Battle)}`,
+    `世界王攻擊:${getIcon(guildConfig.WorldBossAttack)}`,
     `公主指令:${getIcon(guildConfig.GlobalOrder)}`,
     `自訂指令:${getIcon(guildConfig.CustomerOrder)}`,
     `公主查詢:${getIcon(guildConfig.PrincessCharacter)}`,

--- a/app/src/templates/application/WorldBoss.js
+++ b/app/src/templates/application/WorldBoss.js
@@ -131,7 +131,7 @@ function validateRound(round) {
  * snapshot, HP, cleared. No viewer-specific data (quota, EXP, rewards, personal
  * damage) may be added; the LIFF board is where personal state belongs.
  */
-function generateBattleStatusBubble({ season, round, boss, liffUri }) {
+function generateBattleStatusBubble({ season, round, boss, liffUri, attackEnabled = false }) {
   const { maxHp, currentHp } = validateRound(round);
   const hpPercent = roundedPercent(currentHp, maxHp);
   const description = truncateUtf8(boss.description, MAX_BOSS_DESCRIPTION_BYTES);
@@ -198,6 +198,33 @@ function generateBattleStatusBubble({ season, round, boss, liffUri }) {
       contents: cleared
         ? [textNode("已擊破", { color: SEMANTIC.success.main, weight: "bold", align: "center" })]
         : [
+            ...(attackEnabled
+              ? [
+                  {
+                    type: "box",
+                    layout: "horizontal",
+                    spacing: "sm",
+                    contents: [
+                      ["⚔️ 攻擊", "standard"],
+                      ["✨ 技能", "skill"],
+                    ].map(([label, attackType]) => ({
+                      type: "button",
+                      style: "primary",
+                      color: ACCENT.main,
+                      height: "sm",
+                      action: {
+                        type: "postback",
+                        label,
+                        data: JSON.stringify({
+                          action: "worldBossAttack",
+                          roundId: round.id,
+                          attackType,
+                        }),
+                      },
+                    })),
+                  },
+                ]
+              : []),
             {
               type: "button",
               style: "primary",
@@ -249,7 +276,7 @@ function generateNoActiveSeasonBubble({ ended, liffUri }) {
  * attack-result card were personal state and now live in LIFF, so this returns
  * either the five-boss board or the no-season notice and nothing else.
  */
-function generateWorldBossReply({ status, liffUri }) {
+function generateWorldBossReply({ status, liffUri, attackEnabled = false }) {
   const active = Boolean(
     status &&
     !status.ended &&
@@ -266,7 +293,13 @@ function generateWorldBossReply({ status, liffUri }) {
       .slice()
       .sort((left, right) => Number(left.position) - Number(right.position))
       .map(round =>
-        generateBattleStatusBubble({ season: status.season, round, boss: round, liffUri })
+        generateBattleStatusBubble({
+          season: status.season,
+          round,
+          boss: round,
+          liffUri,
+          attackEnabled,
+        })
       ),
   };
 }

--- a/app/src/templates/application/__tests__/WorldBoss.test.js
+++ b/app/src/templates/application/__tests__/WorldBoss.test.js
@@ -79,7 +79,7 @@ describe("WorldBoss Flex production contract", () => {
       "第 3 輪 · 4 號 · 王4",
       "第 3 輪 · 5 號 · 王5",
     ]);
-    // Attacks moved to authenticated LIFF: no postback may survive in a group card.
+    // 預設關閉時群組卡不得有 postback。
     expect(actions(reply)).toEqual([]);
     const uris = uriActions(reply);
     expect(uris).toHaveLength(5);
@@ -87,9 +87,38 @@ describe("WorldBoss Flex production contract", () => {
     expect(new URL(uris[0].uri).pathname.endsWith("/worldboss")).toBe(true);
   });
 
+  it("renders attack postbacks only when enabled, without personal identity data", () => {
+    const reply = WorldBoss.generateWorldBossReply({
+      status: makeStatus({ cleared: [2] }),
+      liffUri: LIFF,
+      attackEnabled: true,
+    });
+
+    reply.contents.forEach((bubble, index) => {
+      const postbacks = actions(bubble);
+      if (index === 1) {
+        expect(postbacks).toHaveLength(0);
+        return;
+      }
+      expect(postbacks).toHaveLength(2);
+      expect(postbacks.map(action => JSON.parse(action.data))).toEqual([
+        { action: "worldBossAttack", roundId: 21 + index, attackType: "standard" },
+        { action: "worldBossAttack", roundId: 21 + index, attackType: "skill" },
+      ]);
+      postbacks.forEach(action => {
+        expect(JSON.parse(action.data)).not.toHaveProperty("userId");
+      });
+      expect(uriActions(bubble)).toHaveLength(1);
+    });
+  });
+
   it("excludes every personal field from the public board", () => {
     const values = text(
-      WorldBoss.generateWorldBossReply({ status: makeStatus(), liffUri: LIFF })
+      WorldBoss.generateWorldBossReply({
+        status: makeStatus(),
+        liffUri: LIFF,
+        attackEnabled: true,
+      })
     ).join("|");
 
     for (const forbidden of [

--- a/frontend/src/pages/Group/Config.jsx
+++ b/frontend/src/pages/Group/Config.jsx
@@ -270,6 +270,7 @@ export default function GroupConfig() {
     GroupConfigData: [],
     GroupConfig: {
       Battle: "Y",
+      WorldBossAttack: "N",
       PrincessCharacter: "Y",
       CustomerOrder: "Y",
       GlobalOrder: "Y",


### PR DESCRIPTION
## 為什麼

世界王 v2 攻擊目前只走 LIFF，群組成員得離開對話才能打，互動性差。這個 PR 新增 group config toggle `WorldBossAttack`，讓各群組**自行決定**要不要直接在 `#世界王` 戰況卡上按按鈕攻擊。

## 設計決策

### 為什麼可以解除 `attackOnBoss` 退役

`attackOnBoss` 當初是被主動退役的（原註解：「Old cards must hit a dead end, not a second code path that could drift from the API's rules」），而且 `WorldBoss.test.js` 有斷言把它釘死。

但 `WorldBossAttackService.js:129-137` 的 docstring 寫的是：

> The single application seam for a world boss attack... so **no transport (HTTP today, anything later)** can drift from another.

所以當初擋的是「postback 自己算一套傷害」，不是「永遠不准 postback」。本次 postback 直接呼叫**同一個** `WorldBossAttackService.attack()`，維持該 service 作為唯一 application seam 的設計，沒有第二條規則路徑。

### 為什麼沒有 migration

toggle 存在 `guild_config.Config` 的 JSON 欄位裡，不是獨立 column。既有群組的 JSON 沒有這個 key → `undefined`，判斷式一律用 `=== "Y"` → 自然關閉。**預設關閉不需要任何回填**，opt-in 天生成立。

### 為什麼呼叫 `attack()` 時刻意不傳 `groupId`

`WorldBossAttackService.js:94-110` 的 `announceClear` 在有 `groupId` 時會另外走 `broadcastQueue` 發一則擊破公告。postback 路徑我們自己 reply，傳了會導致擊破時群組**收到兩則訊息**。有測試明確斷言 `attack()` 的參數不含 `groupId`。

### 群組回覆遵守 group message design

CLAUDE.md 規定群組訊息不得混公開與個人狀態。攻擊結果幾乎全是個人狀態，所以回覆只寫**公開狀態**：

| 資料 | 群組可見 |
|---|---|
| 攻擊者、實際傷害、輪次、boss、剩餘百分比 | 是 |
| EXP／升級、今日剩餘次數、賽季累積傷害、cost、獎勵 | 否（留在 LIFF） |

測試用哨兵值（`seasonTotalDamage: "99999999"`、`daily.remaining: 77`、`levelResult.newLevel: 55`）斷言 reply 字串**不含**這些值。

失敗依性質分流：
- 個人狀態（`DAILY_LIMIT_EXCEEDED`、`ATTACK_COOLDOWN`）→ **靜默**，不得公開個人 quota
- 共享狀態（`ROUND_CLEARED`、`ROUND_STALE`、`SEASON_ENDED` 等）→ 回一則公開提示
- 未預期錯誤 → 記 log 後靜默，不把 stack 吐到群組

傷害用 `result.effectiveDamage` 而非 `result.damage`（溢傷會被丟棄，不該顯示）。

### 安全性

沿用 `JankenController` 群組競技場的既有 pattern：
- payload 只帶 `roundId` / `attackType`
- 攻擊者一律取 `context.event.source.userId`，**不信任 payload**（有測試塞惡意 `userId: "Uattacker"` 驗證）
- handler 二次驗證 toggle，擋掉「開過又關掉」仍留在聊天記錄裡的舊卡片
- 1:1 聊天沒有 `guildConfig`，一併擋掉

`config` middleware（`app.js:426`）早於 `HandlePostback`（`:428`），所以 handler 拿得到 `guildConfig`。

## 改動

| 檔案 | 內容 |
|---|---|
| `model/application/GuildConfig.js` | 預設加 `WorldBossAttack: "N"`（僅影響全新群組） |
| `templates/application/WorldBoss.js` | 新增 `attackEnabled` 參數，條件加「⚔️ 攻擊」「✨ 技能」兩顆 postback |
| `controller/application/WorldBossController.js` | 解除退役、實作 handler、`showBattleStatus` 讀 toggle |
| `doc/GroupConfig.json` | LIFF 設定頁 metadata |
| `frontend/pages/Group/Config.jsx` | 前端 default state |
| `templates/application/Group/line.js` | `群組設定` 指令狀態文字 |

按鈕**不標示 cost 數字** — 技能 cost 因職業而異（7/10/20），卡片是群組共用的，標不出正確值。

Postback route（`app.js:110-113`）本來就存在，未改動 `app.js`。

## 驗證

```
yarn jest src/controller/application/__tests__/WorldBossController.test.js
  → 27 passed
yarn jest src/templates/application/__tests__/WorldBoss.test.js
  → 21 passed
yarn jest --runInBand
  → 142 suites / 1722 tests 全綠
eslint（app 6 檔 + frontend 1 檔）
  → 0 errors
```

`WorldBoss.test.js` 原本那條「no postback may survive」的斷言改成**雙態**（關閉時必須無 postback／開啟時必須有），不是刪掉。

### 已知：全量測試在平行模式下 flaky

`yarn jest`（預設平行）連跑三次得到 `1 failed` → `2 failed` → `0 failed`，失敗都落在 `JankenRewardService`，與本 PR 無關。`--runInBand` 則穩定全綠。

根因是 5 個 Janken 測試檔都 `jest.unmock` mysql 打真 DB，共用 `janken_records` / `janken_rating` / `janken_daily_reward_log` / `janken_seasons` 四張表，各自在 `beforeEach` 無條件 `DELETE`，平行 worker 互相清桌。

⚠️ 誠實交代：main baseline 平行跑三次是全綠的（1701 tests），所以是本 PR 讓既有的競爭條件更容易被觸發（多了 21 個測試、改變了 worker 時序），而不是本來就在壞。這個 Janken 測試隔離問題本身不屬於世界王範圍，建議另開 issue 處理（加 `.serial` 或改用 per-suite 資料前綴）。CI 目前不跑測試，不會阻塞合併。

## 部署後啟用方式

預設全部關閉。要開的群組：LIFF「群組設定」頁把「世界王群組內攻擊」打開，或打 `群組設定` 指令查看狀態。
