### PR TITLE
fix(janken): 退還逾時未成交的猜拳賭注

### DIFF
--- a/app/__tests__/service/JankenService.autoFate.test.js
+++ b/app/__tests__/service/JankenService.autoFate.test.js
@@ -72,7 +72,7 @@ describe("JankenService.autoFateIfEligible", () => {
     expect(redis.set).toHaveBeenCalledWith(
       "jankenDecide:match-1:Up2",
       result.choice,
-      expect.objectContaining({ EX: 7 * 24 * 60 * 60 })
+      expect.objectContaining({ EX: 60 * 60 })
     );
   });
 

--- a/app/__tests__/service/JankenService.test.js
+++ b/app/__tests__/service/JankenService.test.js
@@ -111,7 +111,7 @@ describe("JankenService", () => {
       expect(redis.set).toHaveBeenCalledWith(
         expect.stringContaining("match-123:user-1"),
         "rock",
-        expect.objectContaining({ EX: 7 * 24 * 60 * 60 })
+        expect.objectContaining({ EX: 60 * 60 })
       );
     });
 

--- a/app/bin/JankenEscrowRefund.js
+++ b/app/bin/JankenEscrowRefund.js
@@ -1,0 +1,25 @@
+// Standalone-CLI dotenv preload — must run before the requires below, since
+// knex/config read process.env at import time. Gated so worker re-loads skip.
+if (require.main === module && process.env.NODE_ENV !== "production") {
+  require("dotenv").config({ path: require("path").resolve(__dirname, "../../.env") });
+}
+
+const JankenService = require("../src/service/JankenService");
+const { DefaultLogger } = require("../src/util/Logger");
+
+async function main() {
+  DefaultLogger.info("[JankenEscrowRefund] running");
+  const result = await JankenService.refundStaleEscrows();
+  DefaultLogger.info(`[JankenEscrowRefund] done: ${JSON.stringify(result)}`);
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch(err => {
+      DefaultLogger.error("[JankenEscrowRefund] failed", err);
+      process.exit(1);
+    });
+}

--- a/app/config/crontab.config.js
+++ b/app/config/crontab.config.js
@@ -134,6 +134,14 @@ module.exports = [
     require_path: "./bin/JankenDailyRewards",
   },
   {
+    name: "Janken Escrow Refund",
+    description:
+      "refund escrowed women-stones for janken bet matches that timed out without resolving",
+    period: ["0", "*/10", "*", "*", "*", "*"],
+    immediate: false,
+    require_path: "./bin/JankenEscrowRefund",
+  },
+  {
     name: "World Boss Season Settle",
     description: "settle expired active world boss seasons",
     period: ["0", "10", "*", "*", "*", "*"],

--- a/app/locales/zh_tw.json
+++ b/app/locales/zh_tw.json
@@ -117,6 +117,7 @@
       "streak_continue": "{{{ displayName }}} 已經連勝 {{ streak }} 場！目前懸賞金：{{ bounty }} 女神石，快來終結他！",
       "streak_broken": "{{{ breakerName }}} 終結了 {{{ holderName }}} 的 {{ streak }} 連勝！獲得懸賞金 {{ bounty }} 女神石！",
       "insufficient_funds": "餘額不足！目前餘額：{{ balance }} 女神石",
+      "match_expired": "此對戰已逾時失效，賭注將自動退還",
       "rank_query_not_found": "你還沒有猜拳記錄，快去挑戰吧！",
       "elo_change": "積分：{{ before }} → {{ after }} ({{ change }})"
     },

--- a/app/src/controller/application/JankenController.js
+++ b/app/src/controller/application/JankenController.js
@@ -137,6 +137,9 @@ async function duel(context) {
     betAmount = parseInt(betMatch[1], 10);
   }
 
+  // Generated before escrow so the escrow can be tagged with its match for timeout refunds.
+  const matchId = uuid();
+
   if (betAmount > 0) {
     const [initiatorRating, targetRating] = await Promise.all([
       JankenRating.findOrCreate(userId),
@@ -155,8 +158,11 @@ async function duel(context) {
       return;
     }
 
-    const escrow = await JankenService.escrowBet(userId, betAmount);
-    if (!escrow.success) {
+    // tryEscrowOnce (not escrowBet) so p1's escrow lock key gets written: that key is the
+    // liveness probe isMatchAlive/decide rely on. matchId is a fresh uuid here, so the NX
+    // lock always succeeds and the `alreadyEscrowed` branch is unreachable in practice.
+    const escrow = await JankenService.tryEscrowOnce(matchId, userId, betAmount);
+    if (!escrow.alreadyEscrowed && !escrow.success) {
       await context.replyText(
         i18n.__("message.duel.insufficient_funds", { balance: escrow.balance })
       );
@@ -165,8 +171,6 @@ async function duel(context) {
   }
 
   const targetProfile = await LineClient.getGroupMemberProfile(groupId, targetUserId);
-
-  const matchId = uuid();
 
   const pkBubble = jankenTemplate.generateDuelCard({
     p1IconUrl: pictureUrl || "https://i.imgur.com/469kcyB.png",
@@ -223,6 +227,16 @@ exports.decide = async (context, { payload }) => {
   }
 
   const choice = get(payload, "type", "random");
+
+  // LINE postback buttons never expire, but a bet match stops being resolvable after
+  // MATCH_WINDOW_SECONDS and its escrow is refunded by the cron ~2h in. Without this
+  // guard a late click would re-debit p2 and/or let an already-refunded match settle,
+  // paying the winner from stones nobody staked. Applies to both players.
+  // Non-bet matches are unrestricted: no escrow, no money at risk.
+  if (betAmount > 0 && !(await JankenService.isMatchAlive(matchId, userId))) {
+    await context.replyText(i18n.__("message.duel.match_expired"));
+    return;
+  }
 
   // Escrow opponent's bet when they first submit (if bet > 0 and they are not the initiator)
   if (betAmount > 0 && sourceUserId === targetUserId) {

--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -18,7 +18,23 @@ const BOUNTY_MIN_BET = config.get("minigame.janken.streak.bountyMinBet");
 const BOUNTY_CLAIM_MULTIPLIER = config.get("minigame.janken.streak.bountyClaimMultiplier");
 const PAIR_DAMP_THRESHOLD = config.get("minigame.janken.pairDampening.matchesThreshold");
 const PAIR_DAMP_BIAS_MULTIPLIER = config.get("minigame.janken.pairDampening.biasMultiplier");
-const MATCH_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+// How long a duel stays playable: the per-player choice keys and the escrow NX locks both
+// expire after this. Once it lapses the match can never be resolved, so any escrow still
+// posted for it is dead money. REFUND_THRESHOLD_MS below MUST stay strictly greater than
+// this, otherwise the refund cron could race a still-resolvable match and mint stones.
+const MATCH_WINDOW_SECONDS = 60 * 60;
+
+// Refund escrows that have been pending longer than this. Must be > MATCH_WINDOW_SECONDS
+// so a refunded match is provably unresolvable (its choice keys are already gone).
+const REFUND_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+
+// Sorted set of outstanding escrows, scored by the epoch-ms the stones were taken.
+const PENDING_ESCROW_KEY = `${REDIS_PREFIX}:escrow:pending`;
+// matchId is a uuid (hex + "-") and userId is "U" + 32 hex, so neither can ever contain
+// "|" — it is a safe, collision-free separator for the packed member.
+const ESCROW_MEMBER_SEP = "|";
+const packEscrowMember = (matchId, userId, amount) =>
+  [matchId, userId, amount].join(ESCROW_MEMBER_SEP);
 
 // LINE userIds are fixed-length (`U` + 32 hex chars), so byte-order ordering is canonical.
 const orderedPair = (uA, uB) => (uA < uB ? [uA, uB] : [uB, uA]);
@@ -70,12 +86,35 @@ exports.validateBet = function (amount, maxBet) {
   return { valid: true };
 };
 
-exports.escrowBet = async function (userId, amount) {
+exports.escrowBet = async function (userId, amount, matchId) {
   const { amount: balance } = (await inventory.getUserMoney(userId)) || { amount: 0 };
   if (balance < amount) {
     return { success: false, balance };
   }
   await inventory.decreaseGodStone({ userId, amount, note: "janken_bet_escrow" });
+  // Track the escrow so refundStaleEscrows can return it if the match never resolves.
+  // Ledger-first ordering: if we crash between the debit and the zAdd, zAdd-first would
+  // let the cron refund an escrow that was never actually taken (minting stones).
+  try {
+    await redis.zAdd(PENDING_ESCROW_KEY, {
+      score: Date.now(),
+      value: packEscrowMember(matchId, userId, amount),
+    });
+  } catch (err) {
+    // Debited but untracked = permanently lost stones. Reverse immediately rather than
+    // leaving it for manual reconciliation.
+    DefaultLogger.error(
+      `[Janken] escrow tracking failed, rolling back match_id=${matchId} ` +
+        `user_id=${userId} amount=${amount}: ${err && err.message}`,
+      err
+    );
+    await inventory.increaseGodStone({
+      userId,
+      amount,
+      note: "janken_bet_escrow_rollback",
+    });
+    return { success: false, balance };
+  }
   return { success: true };
 };
 
@@ -85,8 +124,79 @@ exports.tryEscrowOnce = async function (matchId, userId, amount) {
   if (!locked) {
     return { alreadyEscrowed: true };
   }
-  const result = await exports.escrowBet(userId, amount);
+  const result = await exports.escrowBet(userId, amount, matchId);
   return result;
+};
+
+/**
+ * Is this bet match still resolvable?
+ *
+ * Probes p1's escrow lock, which is written with EX = MATCH_WINDOW_SECONDS at the moment
+ * p1 posts their stake — the same lifetime as the per-player choice keys. So the lock
+ * being gone is equivalent to "the choice keys are gone too", i.e. the match can never
+ * reach resolveMatch and its escrow has been (or will be) refunded by the cron.
+ *
+ * Only meaningful for bet matches; non-bet matches have no escrow lock and no money at
+ * risk, so callers must not gate them on this.
+ *
+ * @param {string} matchId
+ * @param {string} p1UserId the duel initiator (payload.userId)
+ * @returns {Promise<boolean>}
+ */
+exports.isMatchAlive = async function (matchId, p1UserId) {
+  const escrowKey = `${REDIS_PREFIX}:escrow:${matchId}:${p1UserId}`;
+  const exists = await redis.exists(escrowKey);
+  return exists === 1;
+};
+
+/**
+ * Refund escrows whose match is past REFUND_THRESHOLD_MS and therefore unresolvable.
+ *
+ * Claim-then-pay: the zRem must return 1 before any stones are credited. If another
+ * worker (or resolveMatch's settlement cleanup) already took the member, we pay nothing.
+ * Losing a refund is recoverable by hand from the `janken_bet_escrow` ledger rows;
+ * double-paying is not.
+ *
+ * @returns {Promise<{scanned:number, refunded:number, failed:number}>}
+ */
+exports.refundStaleEscrows = async function () {
+  const cutoff = Date.now() - REFUND_THRESHOLD_MS;
+  const members = (await redis.zRangeByScore(PENDING_ESCROW_KEY, 0, cutoff)) || [];
+  let refunded = 0;
+  let failed = 0;
+
+  for (const member of members) {
+    try {
+      const [matchId, userId, rawAmount] = String(member).split(ESCROW_MEMBER_SEP);
+      const amount = parseInt(rawAmount, 10);
+      if (!matchId || !userId || !Number.isFinite(amount) || amount <= 0) {
+        await redis.zRem(PENDING_ESCROW_KEY, member);
+        DefaultLogger.error(`[JankenEscrowRefund] dropped malformed member=${member}`);
+        failed += 1;
+        continue;
+      }
+
+      const claimed = await redis.zRem(PENDING_ESCROW_KEY, member);
+      if (claimed !== 1) {
+        // Settled or claimed elsewhere — never pay out on an unclaimed member.
+        continue;
+      }
+
+      await inventory.increaseGodStone({ userId, amount, note: "janken_bet_timeout_refund" });
+      refunded += 1;
+      DefaultLogger.info(
+        `[JankenEscrowRefund] refunded match_id=${matchId} user_id=${userId} amount=${amount}`
+      );
+    } catch (err) {
+      failed += 1;
+      DefaultLogger.error(
+        `[JankenEscrowRefund] failed member=${member}: ${err && err.message}`,
+        err
+      );
+    }
+  }
+
+  return { scanned: members.length, refunded, failed };
 };
 
 exports.calculateBountyIncrement = function (fee) {
@@ -287,6 +397,14 @@ exports.resolveMatch = async function ({
         note: "janken_bet_win",
       });
     }
+
+    // Settled — drop both escrows from the pending set so the refund cron can't pay again.
+    // Safe to do after payout: MATCH_WINDOW_SECONDS (1h) < REFUND_THRESHOLD_MS (2h), so a
+    // match that is still resolvable can never be inside the cron's scan window.
+    await Promise.all([
+      redis.zRem(PENDING_ESCROW_KEY, packEscrowMember(matchId, p1UserId, betAmount)),
+      redis.zRem(PENDING_ESCROW_KEY, packEscrowMember(matchId, p2UserId, betAmount)),
+    ]);
   }
 
   await JankenRecords.create({

--- a/app/src/service/__tests__/JankenService.escrowRefund.test.js
+++ b/app/src/service/__tests__/JankenService.escrowRefund.test.js
@@ -1,0 +1,297 @@
+// JankenService escrow timeout-refund tests.
+// Core invariant under test: stones are only credited when the pending-set member was
+// successfully claimed (zRem === 1). Losing a refund is acceptable; minting is not.
+
+jest.mock("config", () => {
+  const store = {
+    "redis.keys.jankenDecide": "jankenDecide",
+    "redis.keys.jankenChallenge": "jankenChallenge",
+    "minigame.janken.bet.feeRate": 0.1,
+    "minigame.janken.bet.minAmount": 10,
+    "minigame.janken.streak.bountyMinBet": 1000,
+    "minigame.janken.streak.bountyClaimMultiplier": 5,
+    "minigame.janken.pairDampening.matchesThreshold": 10,
+    "minigame.janken.pairDampening.biasMultiplier": 0.1,
+    "minigame.janken.elo.nonBetK": 0,
+    "minigame.janken.elo.lossFactor": 0.5,
+    "minigame.janken.elo.streakBonus": [],
+    "minigame.janken.elo.kFactorTiers": [{ minBet: 0, k: 12 }],
+  };
+  return { get: jest.fn(key => store[key]), has: jest.fn(key => key in store) };
+});
+
+jest.mock("../../model/application/Inventory", () => ({
+  inventory: {
+    getUserMoney: jest.fn(),
+    decreaseGodStone: jest.fn().mockResolvedValue(undefined),
+    increaseGodStone: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock("../../model/application/JankenRecords", () => ({
+  create: jest.fn().mockResolvedValue(1),
+  update: jest.fn().mockResolvedValue(1),
+}));
+jest.mock("../../model/application/JankenResult", () => ({
+  insert: jest.fn().mockResolvedValue(1),
+  resultMap: { win: 1, lose: 2, draw: 3 },
+}));
+jest.mock("../../service/EventCenterService", () => ({
+  add: jest.fn().mockResolvedValue(undefined),
+  getEventName: jest.fn(n => n),
+}));
+
+const redis = require("../../util/redis");
+const { inventory } = require("../../model/application/Inventory");
+const JankenService = require("../JankenService");
+
+const PENDING_KEY = "jankenDecide:escrow:pending";
+const HOUR = 60 * 60 * 1000;
+
+describe("JankenService.refundStaleEscrows", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redis.zRangeByScore.mockResolvedValue([]);
+    redis.zRem.mockResolvedValue(1);
+    redis.del.mockResolvedValue(1);
+    inventory.increaseGodStone.mockResolvedValue(undefined);
+  });
+
+  it("refunds a stale escrow with the exact userId and amount", async () => {
+    redis.zRangeByScore.mockResolvedValueOnce(["match-1|Uaaa|500"]);
+
+    const result = await JankenService.refundStaleEscrows();
+
+    expect(inventory.increaseGodStone).toHaveBeenCalledTimes(1);
+    expect(inventory.increaseGodStone).toHaveBeenCalledWith({
+      userId: "Uaaa",
+      amount: 500,
+      note: "janken_bet_timeout_refund",
+    });
+    expect(result).toEqual({ scanned: 1, refunded: 1, failed: 0 });
+  });
+
+  it("scans with a cutoff of now - 2h (threshold > 1h match window)", async () => {
+    const before = Date.now();
+    await JankenService.refundStaleEscrows();
+    const after = Date.now();
+
+    expect(redis.zRangeByScore).toHaveBeenCalledTimes(1);
+    const [key, min, max] = redis.zRangeByScore.mock.calls[0];
+    expect(key).toBe(PENDING_KEY);
+    expect(min).toBe(0);
+    expect(max).toBeGreaterThanOrEqual(before - 2 * HOUR);
+    expect(max).toBeLessThanOrEqual(after - 2 * HOUR);
+  });
+
+  it("NEVER pays out when zRem returns 0 (already claimed/settled elsewhere)", async () => {
+    redis.zRangeByScore.mockResolvedValueOnce(["match-1|Uaaa|500"]);
+    redis.zRem.mockResolvedValueOnce(0);
+
+    const result = await JankenService.refundStaleEscrows();
+
+    expect(inventory.increaseGodStone).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 1, refunded: 0, failed: 0 });
+  });
+
+  it("claims before paying — zRem is called before increaseGodStone", async () => {
+    redis.zRangeByScore.mockResolvedValueOnce(["match-1|Uaaa|500"]);
+    const order = [];
+    redis.zRem.mockImplementationOnce(async () => {
+      order.push("zRem");
+      return 1;
+    });
+    inventory.increaseGodStone.mockImplementationOnce(async () => {
+      order.push("pay");
+    });
+
+    await JankenService.refundStaleEscrows();
+
+    expect(order).toEqual(["zRem", "pay"]);
+  });
+
+  it("does not refund escrows newer than the threshold (they are outside the scan)", async () => {
+    // zRangeByScore is bounded by the cutoff, so a fresh escrow simply isn't returned.
+    redis.zRangeByScore.mockImplementationOnce(async (_key, _min, max) =>
+      // A 10-minute-old escrow scores above the 2h cutoff.
+      Date.now() - 10 * 60 * 1000 <= max ? ["match-fresh|Ubbb|300"] : []
+    );
+
+    const result = await JankenService.refundStaleEscrows();
+
+    expect(inventory.increaseGodStone).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 0, refunded: 0, failed: 0 });
+  });
+
+  it("one failing refund does not abort the rest of the batch", async () => {
+    redis.zRangeByScore.mockResolvedValueOnce(["m1|Uaaa|100", "m2|Ubbb|200", "m3|Uccc|300"]);
+    inventory.increaseGodStone
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("db down"))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await JankenService.refundStaleEscrows();
+
+    expect(inventory.increaseGodStone).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ scanned: 3, refunded: 2, failed: 1 });
+  });
+});
+
+describe("JankenService.escrowBet pending tracking", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redis.zAdd.mockResolvedValue(1);
+  });
+
+  it("registers the escrow in the pending set after the ledger debit", async () => {
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10000 });
+
+    const result = await JankenService.escrowBet("Uaaa", 500, "match-1");
+
+    expect(result).toEqual({ success: true });
+    expect(inventory.decreaseGodStone).toHaveBeenCalledWith({
+      userId: "Uaaa",
+      amount: 500,
+      note: "janken_bet_escrow",
+    });
+    expect(redis.zAdd).toHaveBeenCalledWith(PENDING_KEY, {
+      score: expect.any(Number),
+      value: "match-1|Uaaa|500",
+    });
+  });
+
+  it("does not register anything when the balance is insufficient", async () => {
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10 });
+
+    const result = await JankenService.escrowBet("Uaaa", 500, "match-1");
+
+    expect(result).toEqual({ success: false, balance: 10 });
+    expect(inventory.decreaseGodStone).not.toHaveBeenCalled();
+    expect(redis.zAdd).not.toHaveBeenCalled();
+  });
+
+  it("reverses the debit when zAdd throws, so stones are never lost untracked", async () => {
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10000 });
+    redis.zAdd.mockRejectedValueOnce(new Error("redis down"));
+
+    const result = await JankenService.escrowBet("Uaaa", 500, "match-1");
+
+    expect(result).toEqual({ success: false, balance: 10000 });
+    // The rollback credit must exactly match the debit.
+    expect(inventory.decreaseGodStone).toHaveBeenCalledWith({
+      userId: "Uaaa",
+      amount: 500,
+      note: "janken_bet_escrow",
+    });
+    expect(inventory.increaseGodStone).toHaveBeenCalledTimes(1);
+    expect(inventory.increaseGodStone).toHaveBeenCalledWith({
+      userId: "Uaaa",
+      amount: 500,
+      note: "janken_bet_escrow_rollback",
+    });
+    const debited = inventory.decreaseGodStone.mock.calls[0][0].amount;
+    const credited = inventory.increaseGodStone.mock.calls[0][0].amount;
+    expect(credited).toBe(debited);
+  });
+
+  it("leaves no pending member behind on the rollback path", async () => {
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10000 });
+    redis.zAdd.mockRejectedValueOnce(new Error("redis down"));
+    redis.zRangeByScore.mockResolvedValueOnce([]);
+
+    await JankenService.escrowBet("Uaaa", 500, "match-1");
+
+    // zAdd rejected, so nothing was ever stored; a subsequent cron pass finds nothing
+    // and therefore cannot double-refund the already-reversed escrow.
+    const result = await JankenService.refundStaleEscrows();
+    expect(result).toEqual({ scanned: 0, refunded: 0, failed: 0 });
+    expect(inventory.increaseGodStone).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("JankenService.isMatchAlive", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns true while p1's escrow lock is still present", async () => {
+    redis.exists.mockResolvedValueOnce(1);
+
+    await expect(JankenService.isMatchAlive("m1", "Uaaa")).resolves.toBe(true);
+    expect(redis.exists).toHaveBeenCalledWith("jankenDecide:escrow:m1:Uaaa");
+  });
+
+  it("returns false once the lock has expired", async () => {
+    redis.exists.mockResolvedValueOnce(0);
+
+    await expect(JankenService.isMatchAlive("m1", "Uaaa")).resolves.toBe(false);
+  });
+
+  it("tryEscrowOnce writes the very key isMatchAlive probes (guard is wired correctly)", async () => {
+    jest.clearAllMocks();
+    redis.set.mockResolvedValueOnce("OK");
+    redis.zAdd.mockResolvedValueOnce(1);
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10000 });
+
+    await JankenService.tryEscrowOnce("m1", "Uaaa", 500);
+
+    // p1's duel path must go through tryEscrowOnce, not bare escrowBet, or the liveness
+    // probe would report every bet match as already expired.
+    expect(redis.set).toHaveBeenCalledWith(
+      "jankenDecide:escrow:m1:Uaaa",
+      "1",
+      expect.objectContaining({ EX: 60 * 60, NX: true })
+    );
+  });
+});
+
+describe("JankenService.resolveMatch clears pending escrows", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    redis.set.mockResolvedValue("OK");
+    redis.del.mockResolvedValue(1);
+    redis.zRem.mockResolvedValue(1);
+    // Elo/streak run real knex transactions (forUpdate) that the shared mock builder
+    // doesn't model; they're covered by JankenService.elo.test.js.
+    jest.spyOn(JankenService, "updateElo").mockResolvedValue({ p1EloChange: 0, p2EloChange: 0 });
+    jest
+      .spyOn(JankenService, "updateStreaks")
+      .mockResolvedValue({ winnerStreak: 0, loserPreviousStreak: 0, loserBounty: 0 });
+  });
+
+  afterAll(() => jest.restoreAllMocks());
+
+  const baseParams = {
+    matchId: "m1",
+    groupId: "G1",
+    p1UserId: "Uaaa",
+    p2UserId: "Ubbb",
+    betAmount: 500,
+  };
+
+  it("removes both members on a draw (both sides refunded)", async () => {
+    await JankenService.resolveMatch({ ...baseParams, p1Choice: "rock", p2Choice: "rock" });
+
+    expect(redis.zRem).toHaveBeenCalledWith(PENDING_KEY, "m1|Uaaa|500");
+    expect(redis.zRem).toHaveBeenCalledWith(PENDING_KEY, "m1|Ubbb|500");
+  });
+
+  it("removes both members on a decisive result (winner paid)", async () => {
+    await JankenService.resolveMatch({ ...baseParams, p1Choice: "rock", p2Choice: "scissors" });
+
+    expect(redis.zRem).toHaveBeenCalledWith(PENDING_KEY, "m1|Uaaa|500");
+    expect(redis.zRem).toHaveBeenCalledWith(PENDING_KEY, "m1|Ubbb|500");
+  });
+
+  it("does not touch the pending set for a no-bet match", async () => {
+    await JankenService.resolveMatch({
+      ...baseParams,
+      betAmount: 0,
+      p1Choice: "rock",
+      p2Choice: "scissors",
+    });
+
+    expect(redis.zRem).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 問題

猜拳下注會先扣女神石 escrow，但**只有 `resolveMatch` 平手時才退款**。對手一直不出拳（已讀不回／離開群組／沒看到卡片），該場永遠不會結算，先扣的石頭就永久消失。

- `JankenService.js` `escrowBet()` → 扣款
- `JankenController.js` p1 發起指令時扣款、p2 第一次出拳時扣款
- 唯一退款路徑在 `resolveMatch` 的平手分支，未成交就完全走不到
- crontab 沒有任何猜拳退款排程（對照賽馬有 `race_refund`）

## 解法

新增 escrow 逾時退款 cron，並修補因此暴露出的生錢缺口。

- **對戰有效時間 7 天 → 1 小時，退款門檻 2 小時。** 門檻必須嚴格大於有效時間，這樣退款時該場的出拳 key 已失效、絕對不可能成交，cron 不會與結算競爭而憑空生錢。
- **escrow 進 Redis sorted set 追蹤**，`JankenEscrowRefund` cron 每 10 分鐘掃逾期項目退款。不掃 `inventory` 表 — 那是全站最大帳本且 `note` 無索引，`LIKE` 會全表掃描。
- **claim-then-pay**：先 `zRem` 回傳 1 才付款。反過來在崩潰時會重複發錢。寧可漏退（帳本仍有 `janken_bet_escrow` 可人工補償）也不可生錢。
- **`resolveMatch` 結算後移除 pending 紀錄**，避免已結算的對戰被 cron 再退一次。
- **`zAdd` 失敗即刻沖正扣款**，避免「錢被扣但不在退款清單」的永久漏錢。
- **`decide` 加存活守衛**（本次縮短 TTL 直接引入的風險）：LINE postback 按鈕永不失效，退款後的遲到點擊會重新扣 p2、且讓已退款的對戰照「雙方都有押」結算，淨生出 `betAmount * 2 - fee - 已退款` 的女神石，且可被刻意重複觸發。守衛以 p1 的 escrow 鎖當存活探針，同時擋住 p1／p2 兩個方向。非賭注場不受限（無金流風險）。
- **退款不通知使用者**，只寫 log。cron 沒有 reply token，走 LINE Push 違反專案準則；且個人金流不該進群組訊息。

## 已知且接受的行為

- 使用者在第 61 分鐘才點出拳會被守衛擋下，石頭由 cron 在第 120 分鐘退還。只是延遲退款，不生錢。
- 沖正本身也失敗（Redis 與 MySQL 同時故障）時該筆會漏退，error log 帶完整 matchId／userId／amount 可人工補償。要再收斂需把扣款與 zAdd 納入同一交易邊界，超出本次範圍。

## Test plan

- [x] `yarn test -- JankenService` — 67 passed / 67，4 suites 全過（改動前 62）
- [x] 新增 `JankenService.escrowRefund.test.js`：逾期退款、**`zRem` 回傳 0 時絕不付款**、未逾期不退、結算後 pending 移除（平手與非平手）、單筆失敗不影響其他筆、`isMatchAlive` true/false、zAdd 拋錯沖正且金額相等、沖正後 zset 無殘留
- [x] 一條測試鎖住「`tryEscrowOnce` 寫的 key 正是 `isMatchAlive` 探的 key」，防止日後有人把 p1 改回 `escrowBet` 而讓守衛全面誤擋
- [x] `npx eslint` 對所有改動檔案 exit 0
- [ ] 部署後觀察 `[JankenEscrowRefund]` log 的 refunded／failed 計數

## 部署注意

新增 cron `Janken Escrow Refund`（`config/crontab.config.js`）。**無需手動操作** — `redive-worker` 與 `redive-bot` 共用 `ghcr.io/hanshino/redive_backend:latest`，crontab 設定包在 image 內，host 上的 `stack-deploy.timer`（每 5 分鐘 `docker compose pull` + `up -d`）會因 digest 變動自動重建 worker 容器。無新 migration、無新環境變數、無新依賴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
