### PR TITLE
feat(achievement): 解鎖後才公開成就條件，新增詳情底部抽屜

### DIFF
--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -460,12 +460,15 @@ exports.getUserSummary = async userId => {
       total: catAchievements.length,
       unlocked: catUnlocked.length,
       achievements: catAchievements.map(a =>
-        toPublic({
-          ...a,
-          isUnlocked: unlockedIds.has(a.id),
-          currentValue: progressMap[a.id] || 0,
-          unlockedAt: (unlocked.find(u => u.id === a.id) || {}).unlocked_at || null,
-        })
+        toPublic(
+          {
+            ...a,
+            isUnlocked: unlockedIds.has(a.id),
+            currentValue: progressMap[a.id] || 0,
+            unlockedAt: (unlocked.find(u => u.id === a.id) || {}).unlocked_at || null,
+          },
+          { includeDescription: unlockedIds.has(a.id) }
+        )
       ),
     };
   });
@@ -480,7 +483,7 @@ exports.getUserSummary = async userId => {
     unlocked: unlockedCount,
     percentage: total > 0 ? Math.round((unlockedCount / total) * 100) : 0,
     categories: categorySummary,
-    recentUnlocks: toPublicList(recentUnlocks),
+    recentUnlocks: toPublicList(recentUnlocks, { includeDescription: true }),
     nearCompletion: toPublicList(nearCompletion),
     profile: userProfile
       ? { displayName: userProfile.display_name, pictureUrl: userProfile.picture_url }

--- a/app/src/service/__tests__/achievementPublicView.test.js
+++ b/app/src/service/__tests__/achievementPublicView.test.js
@@ -1,0 +1,30 @@
+const assert = require("assert");
+const { toPublic, toPublicList } = require("../achievementPublicView");
+
+const achievement = {
+  id: 1,
+  name: "秘密成就",
+  description: "累計抽卡 500 次",
+  condition: "secret",
+  isUnlocked: true,
+};
+
+test("achievement descriptions are included only for explicitly unlocked views", () => {
+  assert.strictEqual(
+    toPublic(achievement, { includeDescription: true }).description,
+    achievement.description
+  );
+  assert.ok(!Object.hasOwn(toPublic({ ...achievement, isUnlocked: false }), "description"));
+  assert.ok(!Object.hasOwn(toPublic({ ...achievement, isUnlocked: undefined }), "description"));
+  assert.ok(!Object.hasOwn(toPublicList([{ ...achievement }])[0], "description"));
+  assert.ok(
+    !Object.hasOwn(
+      toPublicList([{ ...achievement }], { includeDescription: false })[0],
+      "description"
+    )
+  );
+  assert.strictEqual(
+    toPublicList([achievement], { includeDescription: true })[0].description,
+    achievement.description
+  );
+});

--- a/app/src/service/achievementPublicView.js
+++ b/app/src/service/achievementPublicView.js
@@ -22,7 +22,6 @@ const PUBLIC_FIELDS = [
   "id",
   "key",
   "name",
-  "description",
   "icon",
   "type",
   "rarity",
@@ -55,10 +54,18 @@ const UNLOCK_NOTICE_FIELDS = [
   "category_key",
 ];
 
-const toPublic = achievement =>
-  achievement ? pick(achievement, [...PUBLIC_FIELDS, ...DERIVED_FIELDS]) : achievement;
+const toPublic = (achievement, options = {}) => {
+  if (!achievement) return achievement;
+  const { includeDescription = false } = options;
+  return pick(achievement, [
+    ...PUBLIC_FIELDS,
+    ...DERIVED_FIELDS,
+    ...(includeDescription ? ["description"] : []),
+  ]);
+};
 
-const toPublicList = rows => (Array.isArray(rows) ? rows.map(toPublic) : []);
+const toPublicList = (rows, options) =>
+  Array.isArray(rows) ? rows.map(row => toPublic(row, options)) : [];
 
 /**
  * Shape used when telling a client "you just unlocked this".

--- a/frontend/src/pages/Achievement/AchievementDetailSheet.jsx
+++ b/frontend/src/pages/Achievement/AchievementDetailSheet.jsx
@@ -1,0 +1,304 @@
+import {
+  SwipeableDrawer,
+  Box,
+  Typography,
+  Avatar,
+  Chip,
+  IconButton,
+  LinearProgress,
+} from "@mui/material";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import DiamondOutlinedIcon from "@mui/icons-material/DiamondOutlined";
+import EventAvailableOutlinedIcon from "@mui/icons-material/EventAvailableOutlined";
+import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import { RARITY_CONFIG } from "./constants";
+
+/**
+ * Bottom-sheet detail view for one achievement.
+ *
+ * The unlock criteria (`description`) only exists on unlocked achievements —
+ * the API omits the key entirely while locked. That gap is intentional product
+ * behaviour, so the locked state renders a sealed placeholder instead of an
+ * empty box: the sheet should read "there is something here you haven't earned
+ * yet", never "the data failed to load".
+ */
+export default function AchievementDetailSheet({ open, onClose, achievement, stats, icon }) {
+  const rarity = RARITY_CONFIG[achievement?.rarity] || RARITY_CONFIG[0];
+
+  if (!achievement) return null;
+
+  const Icon = icon || EmojiEventsIcon;
+  const isUnlocked = achievement.isUnlocked === true;
+  const isHidden = achievement.type === "hidden" && !isUnlocked;
+  const condition = achievement.description;
+  const unlockedAt = formatUnlockedAt(achievement.unlockedAt);
+  const unlockRate = stats ? `${stats.unlock_rate.toFixed(1)}%` : null;
+  const reward = achievement.reward_stones > 0 ? `${achievement.reward_stones} 女神石` : null;
+  const target = Number(achievement.target_value) || 0;
+  const progress =
+    target > 0 ? Math.min(Math.round((achievement.currentValue / target) * 100), 100) : 0;
+
+  return (
+    <SwipeableDrawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      onOpen={() => {}}
+      disableSwipeToOpen
+      slotProps={{
+        paper: {
+          sx: {
+            borderTopLeftRadius: 20,
+            borderTopRightRadius: 20,
+            maxHeight: "88dvh",
+            overflow: "hidden",
+          },
+        },
+      }}
+    >
+      {/* Rarity wash: carries the collection language from the card into the sheet. */}
+      <Box
+        sx={{
+          position: "relative",
+          overflowY: "auto",
+          background: `linear-gradient(180deg, ${rarity.color}1f 0%, transparent 180px)`,
+        }}
+      >
+        <Box
+          sx={{
+            width: 40,
+            height: 4,
+            borderRadius: 2,
+            bgcolor: "divider",
+            mx: "auto",
+            mt: 1.25,
+          }}
+        />
+        <IconButton
+          onClick={onClose}
+          size="small"
+          aria-label="關閉成就詳情"
+          sx={{ position: "absolute", top: 6, right: 8, color: "text.secondary" }}
+        >
+          <CloseRoundedIcon fontSize="small" />
+        </IconButton>
+
+        <Box
+          sx={{
+            width: "100%",
+            maxWidth: 480,
+            mx: "auto",
+            px: 2.5,
+            pt: 2,
+            pb: "calc(env(safe-area-inset-bottom) + 24px)",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+            <Avatar
+              sx={{
+                width: 60,
+                height: 60,
+                flexShrink: 0,
+                bgcolor: isUnlocked ? `${rarity.color}1f` : "action.hover",
+                border: isUnlocked ? `2px solid ${rarity.color}` : "1px solid",
+                borderColor: isUnlocked ? rarity.color : "divider",
+                boxShadow: isUnlocked ? `0 0 16px ${rarity.color}3d` : "none",
+              }}
+            >
+              <Icon sx={{ fontSize: 30, color: isUnlocked ? rarity.color : "text.disabled" }} />
+            </Avatar>
+            <Box sx={{ minWidth: 0 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 0.5 }}>
+                <Chip
+                  label={rarity.label}
+                  size="small"
+                  sx={{
+                    height: 20,
+                    fontSize: "0.68rem",
+                    fontWeight: 700,
+                    color: isUnlocked ? "#fff" : rarity.color,
+                    bgcolor: isUnlocked ? rarity.color : `${rarity.color}1f`,
+                  }}
+                />
+                {isUnlocked ? (
+                  <Typography
+                    variant="caption"
+                    sx={{ color: rarity.color, fontWeight: 700, letterSpacing: "0.04em" }}
+                  >
+                    已解鎖
+                  </Typography>
+                ) : (
+                  <Typography variant="caption" sx={{ color: "text.disabled" }}>
+                    {isHidden ? "隱藏成就" : "未解鎖"}
+                  </Typography>
+                )}
+              </Box>
+              <Typography variant="h6" sx={{ fontWeight: 700, lineHeight: 1.3 }}>
+                {isHidden ? "???" : achievement.name}
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* The criteria block — the reason this sheet exists. */}
+          {isUnlocked && condition ? (
+            <Box
+              sx={{
+                position: "relative",
+                mt: 2.5,
+                pl: 2.25,
+                pr: 2,
+                py: 1.75,
+                borderRadius: 2,
+                overflow: "hidden",
+                border: `1px solid ${rarity.color}3d`,
+                background: `linear-gradient(135deg, ${rarity.color}1a, ${rarity.color}08)`,
+                "&::before": {
+                  content: '""',
+                  position: "absolute",
+                  left: 0,
+                  top: 0,
+                  bottom: 0,
+                  width: 3,
+                  bgcolor: rarity.color,
+                },
+                "@keyframes conditionReveal": {
+                  from: { opacity: 0, transform: "translateY(10px)" },
+                  to: { opacity: 1, transform: "none" },
+                },
+                animation: "conditionReveal 400ms cubic-bezier(0.16, 1, 0.3, 1) 140ms both",
+              }}
+            >
+              <Typography
+                variant="caption"
+                sx={{
+                  display: "block",
+                  color: rarity.color,
+                  fontWeight: 700,
+                  letterSpacing: "0.12em",
+                }}
+              >
+                解鎖條件
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{ mt: 0.5, lineHeight: 1.8, fontWeight: 500, wordBreak: "break-word" }}
+              >
+                {condition}
+              </Typography>
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                mt: 2.5,
+                px: 2,
+                py: 1.75,
+                borderRadius: 2,
+                border: "1px dashed",
+                borderColor: "divider",
+                display: "flex",
+                alignItems: "center",
+                gap: 1.25,
+              }}
+            >
+              <LockOutlinedIcon sx={{ fontSize: 20, color: "text.disabled", flexShrink: 0 }} />
+              <Typography variant="body2" sx={{ color: "text.secondary", lineHeight: 1.7 }}>
+                {isHidden
+                  ? "這個成就尚未公開，解鎖後會顯示名稱與條件。"
+                  : "達成後才會公開解鎖條件。"}
+              </Typography>
+            </Box>
+          )}
+
+          {!isUnlocked && !isHidden && target > 0 && (
+            <Box sx={{ mt: 2.5 }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "baseline",
+                  mb: 0.75,
+                }}
+              >
+                <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                  目前進度
+                </Typography>
+                <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                  {achievement.currentValue} / {target}
+                </Typography>
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={progress}
+                sx={{
+                  height: 6,
+                  borderRadius: 3,
+                  "& .MuiLinearProgress-bar": { bgcolor: rarity.color, borderRadius: 3 },
+                }}
+              />
+            </Box>
+          )}
+
+          {/* Skipped entirely when every row is empty — an empty bordered
+              block reads as a rendering bug. */}
+          {(unlockedAt || reward || (unlockRate && !isHidden)) && (
+            <Box sx={{ mt: 2.5, display: "flex", flexDirection: "column", gap: 0.25 }}>
+              {unlockedAt && (
+                <MetaRow icon={EventAvailableOutlinedIcon} label="解鎖時間" value={unlockedAt} />
+              )}
+              {reward && <MetaRow icon={DiamondOutlinedIcon} label="獎勵" value={reward} />}
+              {unlockRate && !isHidden && (
+                <MetaRow
+                  icon={GroupsOutlinedIcon}
+                  label="全服解鎖率"
+                  value={`${unlockRate} 的人已解鎖`}
+                />
+              )}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </SwipeableDrawer>
+  );
+}
+
+function MetaRow({ icon: Icon, label, value }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.25,
+        py: 1,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        "&:last-of-type": { borderBottom: "none" },
+      }}
+    >
+      <Icon sx={{ fontSize: 18, color: "text.disabled", flexShrink: 0 }} />
+      <Typography variant="caption" sx={{ color: "text.secondary", flexShrink: 0 }}>
+        {label}
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{ ml: "auto", fontWeight: 600, textAlign: "right", wordBreak: "break-word" }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function formatUnlockedAt(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString("zh-TW", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/frontend/src/pages/Achievement/index.jsx
+++ b/frontend/src/pages/Achievement/index.jsx
@@ -5,6 +5,7 @@ import {
   Tab,
   Box,
   Card,
+  CardActionArea,
   CardContent,
   LinearProgress,
   Chip,
@@ -37,7 +38,9 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutlined";
 import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
 import DiamondIcon from "@mui/icons-material/Diamond";
 import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
+import NotesRoundedIcon from "@mui/icons-material/NotesRounded";
 import { RARITY_CONFIG, CATEGORY_ICONS } from "./constants";
+import AchievementDetailSheet from "./AchievementDetailSheet";
 
 const ACHIEVEMENT_ICONS = {
   chat_100: ChatBubbleOutlineIcon,
@@ -81,6 +84,10 @@ export default function Achievement() {
   const [activeTab, setActiveTab] = useState("all");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  // Holds the tapped achievement so the sheet can animate out with content
+  // still mounted; cleared only when it fully closes.
+  const [selected, setSelected] = useState(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
 
   const { loggedIn: isLoggedIn, profile } = useLiff();
   const [searchParams] = useSearchParams();
@@ -177,7 +184,7 @@ export default function Achievement() {
             mb: 2,
           }}
         >
-          探索並解鎖所有成就吧！
+          探索並解鎖所有成就吧！點卡片看詳情。
         </Typography>
         <Typography
           variant="h4"
@@ -245,10 +252,21 @@ export default function Achievement() {
               key={achievement.id}
               achievement={achievement}
               stats={statsMap[achievement.id]}
+              onOpen={(item, icon) => {
+                setSelected({ item, icon });
+                setSheetOpen(true);
+              }}
             />
           ))
         )}
       </Box>
+      <AchievementDetailSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        achievement={selected?.item}
+        icon={selected?.icon}
+        stats={selected ? statsMap[selected.item.id] : undefined}
+      />
     </Box>
   );
 }
@@ -302,7 +320,7 @@ function AchievementStatus({ achievement, isHidden, progress, rarity }) {
   );
 }
 
-function AchievementCard({ achievement, stats }) {
+function AchievementCard({ achievement, stats, onOpen }) {
   const rarity = RARITY_CONFIG[achievement.rarity] || RARITY_CONFIG[0];
   const isHidden = achievement.type === "hidden" && !achievement.isUnlocked;
   const progress =
@@ -317,15 +335,15 @@ function AchievementCard({ achievement, stats }) {
 
   const iconColor = achievement.isUnlocked ? rarity.color : "#bdbdbd";
   const iconBg = achievement.isUnlocked ? rarity.bg : "#f5f5f5";
+  // Only unlocked achievements carry `description`, so only they get the
+  // corner note marker. Its absence on locked cards is the same information
+  // gap the sheet spells out, told once more at a glance.
+  const hasCondition = Boolean(achievement.description);
 
   return (
     <Card
       sx={{
         height: CARD_HEIGHT,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
         border: achievement.isUnlocked ? `2px solid ${rarity.color}` : "1px solid #e0e0e0",
         boxShadow: achievement.isUnlocked ? `0 0 12px ${rarity.color}33` : "none",
         opacity: isHidden ? 0.6 : 1,
@@ -337,63 +355,89 @@ function AchievementCard({ achievement, stats }) {
         },
       }}
     >
-      <CardContent
+      <CardActionArea
+        onClick={() => onOpen(achievement, IconComponent)}
+        aria-label={`查看成就詳情：${isHidden ? "隱藏成就" : achievement.name}`}
         sx={{
+          position: "relative",
+          height: "100%",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          width: "100%",
-          height: "100%",
-          py: 2,
-          px: 1.5,
-          "&:last-child": { pb: 2 },
         }}
       >
-        <Avatar
-          sx={{
-            width: 48,
-            height: 48,
-            bgcolor: iconBg,
-            mb: 1,
-          }}
-        >
-          <IconComponent sx={{ fontSize: 26, color: iconColor }} />
-        </Avatar>
-
-        <Typography
-          variant="body2"
-          noWrap
-          sx={{
-            fontWeight: "bold",
-            width: "100%",
-            textAlign: "center",
-            mb: 0.5,
-          }}
-        >
-          {isHidden ? "???" : achievement.name}
-        </Typography>
-
-        <AchievementStatus
-          achievement={achievement}
-          isHidden={isHidden}
-          progress={progress}
-          rarity={rarity}
-        />
-
-        {unlockRate && !isHidden && (
-          <Typography
-            variant="caption"
+        {hasCondition && (
+          <NotesRoundedIcon
+            aria-hidden="true"
             sx={{
-              color: "text.disabled",
-              mt: "auto",
-              fontSize: "0.65rem",
+              position: "absolute",
+              top: 6,
+              right: 6,
+              fontSize: 14,
+              color: rarity.color,
+              opacity: 0.7,
+            }}
+          />
+        )}
+        <CardContent
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            height: "100%",
+            py: 2,
+            px: 1.5,
+            "&:last-child": { pb: 2 },
+          }}
+        >
+          <Avatar
+            sx={{
+              width: 48,
+              height: 48,
+              bgcolor: iconBg,
+              mb: 1,
             }}
           >
-            {unlockRate} 已解鎖
+            <IconComponent sx={{ fontSize: 26, color: iconColor }} />
+          </Avatar>
+
+          <Typography
+            variant="body2"
+            noWrap
+            sx={{
+              fontWeight: "bold",
+              width: "100%",
+              textAlign: "center",
+              mb: 0.5,
+            }}
+          >
+            {isHidden ? "???" : achievement.name}
           </Typography>
-        )}
-      </CardContent>
+
+          <AchievementStatus
+            achievement={achievement}
+            isHidden={isHidden}
+            progress={progress}
+            rarity={rarity}
+          />
+
+          {unlockRate && !isHidden && (
+            <Typography
+              variant="caption"
+              sx={{
+                color: "text.disabled",
+                mt: "auto",
+                fontSize: "0.65rem",
+              }}
+            >
+              {unlockRate} 已解鎖
+            </Typography>
+          )}
+        </CardContent>
+      </CardActionArea>
     </Card>
   );
 }


### PR DESCRIPTION
## 背景

`achievements.description` 存的是成就解鎖條件文字（例：「覺醒時擁有『迅雷語速』與『燃燒餘熱』兩項冷卻祝福」）。

它先前在公開白名單裡（`achievementPublicView.js`），**所有成就的條件都會隨 API 送到瀏覽器，包含使用者尚未解鎖的**；而前端 `AchievementCard` 從未渲染它。等於條件既外流又看不到。

本 PR 讓「解開成就的人看得到條件」，同時把未解鎖的條件收回去。

## 後端：預設拒絕

`description` 從預設 allowlist 移除，改由 `toPublic` / `toPublicList` 的 `includeDescription` 明確開啟。延續該檔原本 allowlist 而非 blocklist 的設計意圖 —— 新增欄位或新 caller 時預設不外流。

四個出口逐一處理：

| 出口 | 處理 |
|---|---|
| `getUserSummary` 主列表 | 依 `unlockedIds` 逐筆決定 |
| `recentUnlocks` | 依定義皆已解鎖 → 明確保留 |
| `nearCompletion` | 依定義皆未解鎖 → 預設剝除 |
| `GET /api/achievements` | 無 userId 可判斷 → 一律剝除 |

契約：未解鎖時 `description` **key 完全不存在**（非空字串、非 null），前端據此判斷。

已確認 `app/src/templates/application/Achievement.js` 的 LINE flex 模板未讀 `description`，群組公開訊息不受影響。

## 前端：底部抽屜

新增 `AchievementDetailSheet.jsx`。點卡片開 `SwipeableDrawer`，顯示解鎖條件、解鎖時間、獎勵女神石、全服解鎖率（後三者 API 本來就有回傳，先前只用到解鎖率）。

- 180px 密集網格與稀有度光暈維持不變 —— 一眼掃收藏進度的體驗不動
- 已解鎖卡片右上角一枚便條標記，提示此處可看條件
- 整張卡片包 `CardActionArea`，觸控目標遠超 44px，並取得 ripple、鍵盤 focus、`button` 語意
- 未解鎖時抽屜顯示虛線封緘態而非空白區塊（實線空框會讀成載入失敗）；非隱藏成就仍給看目前進度
- 隱藏成就未解鎖時抽屜內仍為 `???`，解鎖率整列隱藏，不從抽屜洩漏卡片上看不到的資訊
- `maxHeight: 88dvh` + `env(safe-area-inset-bottom)`，配合 LINE 內建瀏覽器網址列收合與 iPhone home indicator

未選用卡片內嵌文字（最長條件 30+ 字，xs 兩欄塞不下且高度會參差）、Tooltip（手機無 hover、可發現性差）、卡片翻面（會蓋掉稀有度光暈）。

## 驗證

- `cd app && yarn test -- src/service/__tests__/achievementPublicView.test.js` → 1 passed
- `cd app && npx eslint <改動檔案>` → 0 error
- `cd frontend && npx eslint src/pages/Achievement/` → 0 error（1 warning 為改動前既有）
- `cd frontend && npx vite build` → 通過

新增的測試蓋住核心不變式：已解鎖有 description、未解鎖無此 key、`nearCompletion` 被剝、`recentUnlocks` 保留。

## 注意

未涉及 DB schema、migration，或成就 condition / notify 邏輯。