### PR TITLE
fix(achievement): 修正覺醒成就的條件敘述與半形逗號

### DIFF
--- a/app/migrations/20260828173311_fix_prestige_awakening_description.js
+++ b/app/migrations/20260828173311_fix_prestige_awakening_description.js
@@ -1,0 +1,54 @@
+// eslint-disable-next-line no-unused-vars
+const { Knex } = require("knex");
+
+/**
+ * `prestige_awakening` is awarded by PrestigeService when a user passes the ★5
+ * trial (prestige_trials.reward_meta.achievement_slug), NOT when they reach
+ * prestige_count = 5. Its seeded description claimed both:
+ *
+ *   通過 ★5 覺悟試煉,達成覺醒終態
+ *
+ * As of 2026-08 that second clause is false for 53 of the 55 holders — only 2
+ * users have actually awakened. Nobody could see the text before, because
+ * `description` was never rendered; the achievement detail sheet now shows it
+ * to whoever unlocked the achievement, so the claim has to be true.
+ *
+ * Rewritten to state only what the achievement really certifies, reusing the
+ * reward's own name (PrestigeService.js `覺醒之證`). A separate achievement for
+ * the actual prestige_count = 5 terminal state does not exist yet.
+ *
+ * The half-width comma on both prestige rows is fixed in the same pass.
+ */
+const REWRITES = [
+  {
+    key: "prestige_departure",
+    from: "通過 ★1 啟程試煉,踏上轉生之路",
+    to: "通過 ★1 啟程試煉，踏上轉生之路",
+  },
+  {
+    key: "prestige_awakening",
+    from: "通過 ★5 覺悟試煉,達成覺醒終態",
+    to: "通過 ★5 覺悟試煉，取得覺醒之證",
+  },
+];
+
+// Matching on the expected current text keeps this a no-op if the row was
+// already edited by hand on production, instead of clobbering that edit.
+const apply = (knex, direction) =>
+  Promise.all(
+    REWRITES.map(r =>
+      knex("achievements")
+        .where({ key: r.key, description: direction === "up" ? r.from : r.to })
+        .update({ description: direction === "up" ? r.to : r.from })
+    )
+  );
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = knex => apply(knex, "up");
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = knex => apply(knex, "down");


### PR DESCRIPTION
## 問題

`prestige_awakening`（覺醒）的 description 是：

> 通過 ★5 覺悟試煉**,達成覺醒終態**

後半句是假的。這個成就實際由 `PrestigeService.js:230-233` 在**通過 ★5 覺悟試煉**時，依 `prestige_trials.reward_meta.achievement_slug` 發出，與 `prestige_count` 是否達到 5 無關。

線上數據：

| | 人數 |
|---|---|
| `prestige_awakening` 持有者 | 55 |
| 通過 trial 5（★5 覺悟試煉） | 55 |
| 實際覺醒（`prestige_count = 5`） | **2** |

兩邊數字完全吻合，所以**成就沒有發錯**，機制運作正常。是命名與語義錯位：它佔著「你覺醒了」的位置，實際只代表「你過了一場硬試煉」。

### 為什麼現在要修

先前 `description` 從未被前端渲染，所以沒人看得到這行字。#802 讓已解鎖者看得到條件文字之後，**53 個沒有覺醒的人會看到系統告訴他們達成了覺醒終態**。

## 改動

改為只陳述成就真正證明的事，沿用 `PrestigeService.js:185` 既有的說法（該處對此獎勵的顯示名稱就是「覺醒之證」）：

```
通過 ★5 覺悟試煉,達成覺醒終態
→ 通過 ★5 覺悟試煉，取得覺醒之證
```

同批修掉 `prestige_departure` 與 `prestige_awakening` 混在全形中文裡的半形逗號（全表僅此兩處，`chat_1000` / `chat_5000` 的是千分位、`mention_void_gazer` 的是全形，皆不動）。

## 為什麼是 migration 而非手動 SQL

這兩行 description 在 git 裡（`20260424154256_seed_prestige_achievements.js:10,23`），不是純線上 SQL 的那批。prod 的 `redive-migrate` service 會在 `compose up` 時自動跑 `yarn migrate`，手動 UPDATE 會讓線上與 git 分岔，且 fresh deploy 會被 seed 蓋回舊文字。

原 seed migration 已套用過不能改（knex 記錄過就不重跑），故另開一支。

`WHERE` 同時比對 `key` 與**預期原文**，若該列已被手動改過則為 no-op，不會覆蓋既有修正。`down` 對稱還原。

## 驗證

- 線上唯讀確認 `WHERE` 條件兩筆都命中，migration 會實際生效（未寫入）
- `cd app && yarn test -- __tests__/service/PrestigeService.test.js` → 47 passed
- eslint / prettier 通過

## 未處理

真正對應 `prestige_count = 5` 終態的成就目前**不存在**，另案。屆時要一併決定 `prestige_awakening` 要不要改名 —— 改名會影響已持有的 55 人觀感。