### PR TITLE
feat(achievement): 補回 race/market 成就骨架 seed

### DIFF
--- a/app/migrations/20260828175811_seed_missing_race_market_achievements.js
+++ b/app/migrations/20260828175811_seed_missing_race_market_achievements.js
@@ -1,0 +1,242 @@
+// The five hidden achievements intentionally omit `condition` here. The
+// thresholds are kept only in production so this migration can restore the
+// non-sensitive schema without exposing the unlock rules in git. Consequently
+// those five achievements exist on a fresh database but cannot unlock there.
+
+const CATEGORIES = [
+  { key: "race", name: "賽跑", icon: "🏇", order: 6 },
+  { key: "market", name: "市集", icon: "🏪", order: 7 },
+];
+
+const ACHIEVEMENTS = [
+  {
+    category: "race",
+    key: "race_first_bet",
+    name: "初次下注",
+    description: "第一次在賽跑中下注",
+    icon: "🎫",
+    type: "milestone",
+    rarity: 0,
+    target_value: 1,
+    reward_stones: 30,
+    order: 1,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "race",
+    key: "race_win_10",
+    name: "看眼識馬",
+    description: "累計猜中賽跑 10 次",
+    icon: "🐎",
+    type: "milestone",
+    rarity: 1,
+    target_value: 10,
+    reward_stones: 200,
+    order: 2,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "race",
+    key: "race_all_in",
+    name: "孤注一擲",
+    description: "在賽跑中押上全部身家下注",
+    icon: "🎰",
+    type: "hidden",
+    rarity: 2,
+    target_value: 1,
+    reward_stones: 300,
+    order: 3,
+    notify_on_unlock: true,
+    notify_message: "🎉 {user} 孤注一擲，解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石",
+  },
+  {
+    category: "race",
+    key: "race_big_win",
+    name: "以小博大",
+    description: "賽跑下注獲勝且賠率達到高倍數",
+    icon: "💰",
+    type: "hidden",
+    rarity: 3,
+    target_value: 1,
+    reward_stones: 500,
+    order: 4,
+    notify_on_unlock: true,
+    notify_message:
+      "🎉 {user} 以小博大命中高賠率，解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石",
+  },
+  {
+    category: "market",
+    key: "trade_first",
+    name: "初次交易",
+    description: "第一次完成交易市場交易",
+    icon: "🤝",
+    type: "milestone",
+    rarity: 0,
+    target_value: 1,
+    reward_stones: 30,
+    order: 1,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "market",
+    key: "trade_50",
+    name: "交易大亨",
+    description: "累計完成交易 50 次",
+    icon: "💼",
+    type: "milestone",
+    rarity: 1,
+    target_value: 50,
+    reward_stones: 200,
+    order: 2,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "market",
+    key: "atm_whale",
+    name: "一擲千金",
+    description: "單次轉帳金額達到指定門檻",
+    icon: "🐋",
+    type: "hidden",
+    rarity: 2,
+    target_value: 1,
+    reward_stones: 300,
+    order: 3,
+    notify_on_unlock: true,
+    notify_message: "🎉 {user} 一擲千金，解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石",
+  },
+  {
+    category: "market",
+    key: "coupon_first",
+    name: "序號獵人",
+    description: "第一次兌換優惠券",
+    icon: "🎟️",
+    type: "milestone",
+    rarity: 0,
+    target_value: 1,
+    reward_stones: 30,
+    order: 4,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "market",
+    key: "coupon_collector",
+    name: "優惠達人",
+    description: "累計兌換優惠券 10 次",
+    icon: "🎁",
+    type: "milestone",
+    rarity: 1,
+    target_value: 10,
+    reward_stones: 200,
+    order: 5,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "market",
+    key: "shop_first_exchange",
+    name: "首次兌換",
+    description: "第一次在女神石商店兌換商品",
+    icon: "🛍️",
+    type: "milestone",
+    rarity: 0,
+    target_value: 1,
+    reward_stones: 30,
+    order: 6,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "market",
+    key: "shop_big_spender",
+    name: "課金戰士",
+    description: "單次兌換消耗大量女神石",
+    icon: "💎",
+    type: "hidden",
+    rarity: 2,
+    target_value: 1,
+    reward_stones: 300,
+    order: 7,
+    notify_on_unlock: true,
+    notify_message: "🎉 {user} 揮金如土，解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石",
+  },
+  {
+    category: "chat",
+    key: "prestige_first",
+    name: "轉生初體驗",
+    description: "完成第一次轉生",
+    icon: "🔄",
+    type: "milestone",
+    rarity: 1,
+    target_value: 1,
+    reward_stones: 100,
+    order: 19,
+    notify_on_unlock: false,
+    notify_message: null,
+  },
+  {
+    category: "chat",
+    key: "prestige_3",
+    name: "三生三世",
+    description: "累計完成 3 次轉生",
+    icon: "♻️",
+    type: "hidden",
+    rarity: 2,
+    target_value: 1,
+    reward_stones: 300,
+    order: 20,
+    notify_on_unlock: true,
+    notify_message: "🎉 {user} 歷經三世輪迴，解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石",
+  },
+];
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex("achievement_categories").insert(CATEGORIES).onConflict("key").ignore();
+
+  const categories = await knex("achievement_categories").select("id", "key");
+  const categoryMap = {};
+  categories.forEach(category => {
+    categoryMap[category.key] = category.id;
+  });
+
+  // `onConflict().ignore()` compiles to INSERT IGNORE on MySQL, which swallows
+  // every error rather than just the duplicate key -- a missing category would
+  // silently drop rows instead of failing. Fail loudly first, like
+  // 20260424154256_seed_prestige_achievements.js does.
+  const achievements = ACHIEVEMENTS.map(({ category, ...rest }) => {
+    const categoryId = categoryMap[category];
+    if (!categoryId) {
+      throw new Error(`achievement_categories row with key='${category}' not found`);
+    }
+    return { ...rest, category_id: categoryId };
+  });
+  await knex("achievements").insert(achievements).onConflict("key").ignore();
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  // This removes rows by key, including production rows if rolled back there.
+  await knex("achievements")
+    .whereIn(
+      "key",
+      ACHIEVEMENTS.map(achievement => achievement.key)
+    )
+    .del();
+  await knex("achievement_categories")
+    .whereIn(
+      "key",
+      CATEGORIES.map(category => category.key)
+    )
+    .del();
+};


### PR DESCRIPTION
## 問題

線上 achievements 的 id 67–79（13 筆）與 `race` / `market` 兩個 category 是手動 SQL 建的，**git 裡沒有 seed**。

fresh DB 跑 `yarn migrate && yarn knex seed:run` 之後這批成就完全不存在，本機與新環境無法開發測試。`resolveAchievements()` 用 `.filter(Boolean)` 靜默過濾，所以不會 crash，只是賽馬、市場、序號、商店、轉生次數這些成就整批消失。

而這批屬於「半套」的保密狀態 —— `AchievementEngine.js:235-247` **早已把 13 個 key 和它們的 strategy 明碼寫進 git**：

```js
race_all_in:      (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
atm_whale:        (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
shop_big_spender: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
```

挖 codebase 的玩家早就知道有「孤注一擲」「一擲千金」「課金戰士」存在、也知道是門檻型。**保密已破，卻仍在付 fresh DB 起不出來的代價。**

（對照組：id 95–105 的 `signin_*` 是完整的三代設計 —— code 對它零知識，靠 `condition.event` + `condition.metric` 驅動。那批刻意不進 git，不在本 PR 範圍。）

## 改動

補回**不敏感的骨架**：`key` / `name` / `description` / `icon` / `type` / `rarity` / `target_value` / `reward_stones` / `order` / `notify_*`，外加 `race` / `market` 兩個 category。

`category_id` 用 `key` 反查，不寫死 id（線上 race=9/market=10，fresh DB 會不同）。`order` 照抄線上現況（race 的 6 與 subscribe 重複，不「修正」）。

### condition 一律不進 git

線上 5 筆帶 `condition`（`race_all_in`、`race_big_win`、`atm_whale`、`shop_big_spender`、`prestige_3`），內容是 `{"minValue": N, "contextKey": "..."}`。**這是唯一真正機密的部分**，seed 時留 NULL。

後果：fresh DB 上這 5 個 hidden 成就存在但**永不解鎖** —— `AchievementEngine.js:132-137` 的 `conditionThreshold` 在 `minValue === undefined` 時直接回傳 `currentValue`。這是保密優先的刻意取捨，已在 migration 檔頭註記，避免未來被誤判為 bug。另 8 筆非 hidden 成就在 fresh DB 上完全可測。

### 為什麼 description / notify_message 可以進 git

這批的 description 本來就**已刻意模糊化**（`atm_whale` 寫「單次轉帳金額達到指定門檻」而不寫 50 萬），`notify_message` 也不含任何數字。且 `20260424154256_seed_prestige_achievements.js` 就是明碼進 git 的先例。真正的數值只在 `condition`。

## 線上安全性

這支在 production 必須是**完全 no-op** —— 13 筆與 2 個 category 都已存在，且絕不能把既有 `condition` 覆寫成 NULL（那會讓 4 個 hidden 成就永久無法解鎖）。

`onConflict("key").ignore()` 保證既有列原封不動。但該寫法在 MySQL 譯成 `INSERT IGNORE`，會吞掉**所有**錯誤而不只重複鍵 —— category 反查失敗時 `category_id` 為 undefined 會被靜默跳過。故先明確 `throw`，比照 `20260424154256:130-133` 既有守衛。

## 驗證（本機 MySQL 實測，非僅靜態檢查）

**fresh DB**：`DROP DATABASE` 重建後跑完 148 migrations，13 筆到位、`condition` 皆 NULL、category `order` 與線上一致、總數 62。

**模擬線上重跑**：塞回真實 `condition`、把 `race_first_bet` 的 name 改成別的字、建立一筆 `user_achievements` 解鎖紀錄，移除 migration 記錄後重跑 `up`：

| 檢查 | 結果 |
|---|---|
| `atm_whale` / `race_big_win` 的 condition | 完整保留 ✅ |
| 被改過的 name | 未被覆寫 ✅ |
| 重複列 | 各 1 筆 ✅ |
| category 重複 | 各 1 筆 ✅ |
| 解鎖紀錄 | 完整保留 ✅ |
| 成就總數 | 仍 62，未新增 ✅ |

eslint / prettier 通過。

## down 的風險

`down` 依 key 刪除這 13 筆與 2 個 category。在 production rollback 會刪掉**真實資料**（含玩家解鎖紀錄的 FK 關聯），已在註解標明。實務上不該對線上跑這支的 down。

## 未處理

真正對應 `prestige_count = 5` 覺醒終態的成就仍不存在（相關背景見 #803），另案。屆時要一併決定 `prestige_awakening` 佔著「覺醒」這名字要不要讓 —— 改名會影響已持有的 55 人。