### PR TITLE
feat(achievement): 新增輪迴盡頭成就，補發給既有覺醒者

### DIFF
--- a/app/__tests__/api/achievements.test.js
+++ b/app/__tests__/api/achievements.test.js
@@ -64,7 +64,6 @@ describe("GET /api/achievements", () => {
       id: 1,
       key: "secret_key",
       name: "秘密成就",
-      description: "描述",
       icon: "🗝",
       type: "hidden",
       rarity: 3,

--- a/app/__tests__/service/AchievementEngine.test.js
+++ b/app/__tests__/service/AchievementEngine.test.js
@@ -1052,7 +1052,6 @@ describe("AchievementEngine", () => {
           id: 1,
           key: "secret_key",
           name: "秘密成就",
-          description: "描述",
           icon: "🗝",
           type: "hidden",
           rarity: 3,
@@ -1340,6 +1339,31 @@ describe("AchievementEngine", () => {
 
       expect(result).toEqual({ unlocked: false, reason: "ineligible" });
       expect(UserAchievementModel.unlock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("prestige_5 strategy", () => {
+    it.each([4, 5, 6])("uses the prestige threshold for prestigeCount=%i", async prestigeCount => {
+      AchievementEngine._setCache([
+        {
+          id: 301,
+          key: "prestige_5",
+          type: "hidden",
+          target_value: 1,
+          reward_stones: 500,
+          condition: null,
+        },
+      ]);
+      UserAchievementModel.getUnlockedIds.mockResolvedValue(new Set());
+      UserProgressModel.getProgressByIds.mockResolvedValue(new Map());
+
+      const result = await AchievementEngine.evaluate("Uabc", "prestige_complete", {
+        prestigeCount,
+      });
+
+      expect(result.unlocked.map(achievement => achievement.key)).toEqual(
+        prestigeCount >= 5 ? ["prestige_5"] : []
+      );
     });
   });
 

--- a/app/migrations/20260828180818_seed_prestige_5_achievement_backfill.js
+++ b/app/migrations/20260828180818_seed_prestige_5_achievement_backfill.js
@@ -1,0 +1,86 @@
+const GODDESS_STONE_ITEM_ID = 999;
+const ACHIEVEMENT_KEY = "prestige_5";
+const SENTINEL_NOTE = "成就獎勵 [prestige-5-backfill-2026-08-28]";
+
+const ACHIEVEMENT = {
+  key: ACHIEVEMENT_KEY,
+  name: "輪迴盡頭",
+  description: "累計完成 5 次轉生，抵達轉生終點",
+  icon: "🌌",
+  type: "hidden",
+  rarity: 3,
+  target_value: 1,
+  reward_stones: 500,
+  order: 21,
+  notify_on_unlock: true,
+  notify_message: "🎉 {user} 走完五世輪迴，解鎖成就「{icon} {name}」！獲得 {reward} 顆女神石",
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  let backfilled = 0;
+
+  await knex.transaction(async trx => {
+    const category = await trx("achievement_categories").where({ key: "chat" }).first();
+    if (!category) throw new Error("achievement_categories row with key='chat' not found");
+
+    await trx("achievements")
+      .insert({ ...ACHIEVEMENT, category_id: category.id, condition: null })
+      .onConflict("key")
+      .ignore();
+    const achievement = await trx("achievements").where({ key: ACHIEVEMENT_KEY }).first("id");
+
+    // Ledger first: the NOT EXISTS gate must see the pre-backfill achievement state.
+    const [inventoryResult] = await trx.raw(
+      `
+        INSERT INTO inventory (userId, itemId, itemAmount, note)
+        SELECT cud.user_id, ?, ?, ?
+        FROM chat_user_data cud
+        WHERE cud.prestige_count >= 5
+          AND NOT EXISTS (
+            SELECT 1 FROM user_achievements ua
+            WHERE ua.user_id = cud.user_id AND ua.achievement_id = ?
+          )
+      `,
+      [GODDESS_STONE_ITEM_ID, ACHIEVEMENT.reward_stones, SENTINEL_NOTE, achievement.id]
+    );
+
+    const [achievementResult] = await trx.raw(
+      `
+        INSERT IGNORE INTO user_achievements (user_id, achievement_id, unlocked_at)
+        SELECT cud.user_id, ?, NOW()
+        FROM chat_user_data cud
+        WHERE cud.prestige_count >= 5
+      `,
+      [achievement.id]
+    );
+    backfilled = achievementResult.affectedRows || 0;
+    console.log(
+      `[${ACHIEVEMENT_KEY}-backfill] achievements=${backfilled} inventory=${
+        inventoryResult.affectedRows || 0
+      }`
+    );
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.transaction(async trx => {
+    const achievement = await trx("achievements").where({ key: ACHIEVEMENT_KEY }).first("id");
+    if (!achievement) return;
+
+    // Rollback intentionally deletes real unlocks created by this achievement.
+    await trx("user_achievements").where({ achievement_id: achievement.id }).delete();
+    await trx("inventory").where({ note: SENTINEL_NOTE }).delete();
+    await trx("achievements").where({ id: achievement.id }).delete();
+    console.warn(
+      `[${ACHIEVEMENT_KEY}-backfill:down] deleted real user achievement and inventory data`
+    );
+  });
+};

--- a/app/src/service/AchievementEngine.js
+++ b/app/src/service/AchievementEngine.js
@@ -107,7 +107,7 @@ const EVENT_ACHIEVEMENT_MAP = {
   atm_transfer: ["atm_whale"],
   coupon_redeem: ["coupon_first", "coupon_collector"],
   shop_exchange: ["shop_first_exchange", "shop_big_spender"],
-  prestige_complete: ["prestige_first", "prestige_3"],
+  prestige_complete: ["prestige_first", "prestige_3", "prestige_5"],
 };
 
 // --- Progress calculation strategies by achievement type ---
@@ -245,6 +245,8 @@ const ACHIEVEMENT_STRATEGY = {
   shop_big_spender: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
   prestige_first: (cv, a) => STRATEGIES.instant(cv, a),
   prestige_3: (cv, a, ctx) => STRATEGIES.conditionThreshold(cv, a, ctx),
+  // 5 matches PrestigeService.PRESTIGE_CAP, which is already public to players.
+  prestige_5: (cv, a, ctx) => STRATEGIES.threshold(cv, a, ctx, "prestigeCount", 5),
 };
 
 const GODDESS_STONE_ITEM_ID = 999;


### PR DESCRIPTION
## 背景

`prestige_awakening`（覺醒）實際是在通過 ★5 覺悟試煉時發放（`PrestigeService.js:230-233`），與 `prestige_count` 無關 —— 線上 55 人持有，但只有 **2 人**真正達到 `prestige_count = 5`。

該成就的文案已在 #803 修正為「取得覺醒之證」。本 PR **不再更動它**，改為另立一個真正對應終態的成就。

## 新增成就

| 欄位 | 值 |
|---|---|
| key | `prestige_5` |
| name | 輪迴盡頭 |
| description | 累計完成 5 次轉生，抵達轉生終點 |
| type / rarity | hidden / 3 |
| reward_stones | 500 |
| order | 21（接在 `prestige_3` 之後） |

命名刻意避開「覺醒」二字 —— 那個詞已被 `prestige_awakening` 佔用，兩個成就必須能區分。舊成就零改動，55 名持有者不受影響。

## 門檻 5 為什麼寫在 code 而非 DB condition

`prestige_3` 的門檻放在 DB `condition` JSON，因為那類數值是機密。但 **5 不是**：

- `Lv100CTA.js:34` 本來就對玩家顯示「累計 5 次轉生 → 覺醒終態（封頂）」
- `PrestigeService.js:16` 的 `PRESTIGE_CAP = 5` 也在 git 裡

若比照 `prestige_3` 留 NULL condition 走 `conditionThreshold`，`AchievementEngine.js:132-137` 在 `minValue === undefined` 時會直接回傳原值，導致 **fresh DB 上永不解鎖**、與線上行為不一致。故改用既有的 `STRATEGIES.threshold` 硬寫 5。

未 `import PRESTIGE_CAP` —— `PrestigeService` 已 require `AchievementEngine`，反向 import 會造成循環依賴。

## Code 改動（兩行）

```diff
- prestige_complete: ["prestige_first", "prestige_3"],
+ prestige_complete: ["prestige_first", "prestige_3", "prestige_5"],
```
```diff
+ // 5 matches PrestigeService.PRESTIGE_CAP, which is already public to players.
+ prestige_5: (cv, a, ctx) => STRATEGIES.threshold(cv, a, ctx, "prestigeCount", 5),
```

`PrestigeService.js:304` 既有的 `prestige_complete` 事件已帶 `prestigeCount`，未來第 5 次轉生自動觸發，**不需改 PrestigeService**。

## Backfill

那 2 位在 2026-08-01 就覺醒了，不會再觸發 `prestige_complete`，必須補發。**不發 LINE 通知**（現在才宣布 8/1 的事顯得突兀）。

比照 `20260501150000_grant_legacy_tier_achievements.js`：

- 先寫 `inventory` ledger（`NOT EXISTS` 尚未解鎖者為 gate），**再** `INSERT IGNORE` 寫 `user_achievements`。順序顛倒會讓 NOT EXISTS 判斷失效、重跑時重複發石。
- 條件為 `chat_user_data.prestige_count >= 5`，不寫死 user_id
- sentinel note `成就獎勵 [prestige-5-backfill-2026-08-28]` 讓 `down` 能精準刪除
- 全程 transaction

seed 與 backfill 放同一支 migration，seed 先 backfill 後，天然保證順序。

## 驗證（本機 MySQL 實測）

Backfill 路徑實際跑過，不是只有靜態檢查：

塞入 2 筆 `prestige_count = 5` 與 1 筆 `= 4` 對照組 →

| 檢查 | 結果 |
|---|---|
| 補發筆數 | `achievements=2 inventory=2` ✅ |
| 女神石 | 各 500，itemId 999 ✅ |
| 對照組 p4 | 無滲漏 ✅ |
| 移除 migration 記錄重跑 | `achievements=0 inventory=0` ✅ |
| no-op 後 ledger | 仍各 1 筆，未重複發石 ✅ |

測試資料已清除。`yarn test` 全綠：**144 suites / 1742 tests**。

## 順帶修掉 #802 的兩處遺留

`description` 收斂為已解鎖可見之後，未解鎖列不應再有該欄位，但這兩處仍斷言其存在：

- `__tests__/service/AchievementEngine.test.js:1055`
- `__tests__/api/achievements.test.js:67`

**這兩個失敗在 main 上就已存在**（我在 `eea821ac` 覆驗過），不是本 PR 造成的。CI 沒擋下來是因為 `.github/workflows/main.yml` 只有 build/push 兩個 job，**完全沒有測試 job** —— 這點值得另案處理。

## 依賴

與 #804（race/market 骨架 seed）功能上不相依，可各自 merge。