### PR TITLE
ci: 補上 app 的 jest 測試 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,43 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint
 
-  # Jest fully mocks MySQL/Redis/LINE in __tests__/setup.js, so no services here.
+  # __tests__/setup.js mocks MySQL by default, but 11 test files call
+  # jest.unmock("util/mysql") and hit a real database (janken_*, chat_exp_*,
+  # chat_daily_weather, inventory…). Without this service they fail with
+  # AggregateError, so CI needs a real MySQL 8 and a migrated schema.
+  #
+  # MYSQL_DATABASE creates Princess with the server default collation
+  # (utf8mb4_0900_ai_ci). Do NOT pin utf8mb4_unicode_ci here — see the header
+  # of migrations/20210101000000_baseline_initial_schema.js for why that
+  # breaks 20260327_unify_all_collation_to_0900.
   test-app:
     name: Test (app)
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: app
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: Princess
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_USER: root
+      DB_USER_PASSWORD: root
+      # The World Boss suites create throwaway databases as root and read the
+      # password from DB_PASSWORD, not DB_USER_PASSWORD — see
+      # src/__tests__/helpers/worldBossFixture.js:34. Omitting it fails 7 suites.
+      DB_PASSWORD: root
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -58,6 +88,9 @@ jobs:
           cache: yarn
           cache-dependency-path: app/yarn.lock
       - run: yarn install --frozen-lockfile
+      # The documented fresh-DB bootstrap (see CLAUDE.md). Seeds fill
+      # chat_exp_unit / GachaPool, which the chatXp pipeline tests read.
+      - run: yarn migrate && yarn knex seed:run
       - run: yarn test
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
           cache: yarn
           cache-dependency-path: app/yarn.lock
       - run: yarn install --frozen-lockfile
+      # bin/__tests__/WorldBossSeasonSettle.test.js:77 spawns the cron CLI and
+      # asserts it loads DB creds from the root .env (CLAUDE.md: that file is the
+      # single env source). A clean checkout has none, so the job env above is
+      # not enough — the file itself must exist.
+      - name: Create root .env
+        run: printf 'DB_HOST=127.0.0.1\nDB_PORT=3306\nDB_USER=root\nDB_USER_PASSWORD=root\nDB_PASSWORD=root\n' > ../.env
       # The documented fresh-DB bootstrap (see CLAUDE.md). Seeds fill
       # chat_exp_unit / GachaPool, which the chatXp pipeline tests read.
       - run: yarn migrate && yarn knex seed:run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,23 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint
 
+  # Jest fully mocks MySQL/Redis/LINE in __tests__/setup.js, so no services here.
+  test-app:
+    name: Test (app)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: app/yarn.lock
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+
   format:
     name: Prettier
     runs-on: ubuntu-latest

--- a/app/migrations/20260327_seed_race_characters_from_game.js
+++ b/app/migrations/20260327_seed_race_characters_from_game.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const path = require("path");
 const betterSqlite3 = require("better-sqlite3");
 
@@ -5,6 +6,18 @@ const AVATAR_BASE = "https://chieru.hanshino.dev/assets/units/head";
 
 exports.up = async function (knex) {
   const dbPath = path.resolve(__dirname, "../assets/redive_tw.db");
+
+  // assets/redive_tw.db is gitignored (30MB game data), so a clean checkout —
+  // CI, or a fresh dev box — does not have it and this migration used to abort
+  // the whole `yarn migrate` bootstrap with "unable to open database file".
+  // Production ran this in batch 38 (2026-03-26) and never re-runs it, so
+  // skipping is only ever hit where the seed data is unavailable anyway.
+  // Drop the file in and re-run `knex seed:run` if you need race characters locally.
+  if (!fs.existsSync(dbPath)) {
+    console.warn(`[seed_race_characters_from_game] skipped: ${dbPath} not found`);
+    return;
+  }
+
   const sqlite = betterSqlite3(dbPath, { readonly: true });
 
   // All playable characters from unit_profile


### PR DESCRIPTION
## 問題

`.github/workflows/ci.yml` 只有 `Lint (app)` / `Lint (frontend)` / `Prettier` 三個 job，`main.yml` 則只負責 build/push 映像檔。**`yarn test` 從來沒有在 CI 跑過。**

後果實例：#802 把 `description` 收斂成「解鎖後才可見」，但漏改兩處斷言未解鎖列仍有該欄位的測試 ——

- `app/__tests__/service/AchievementEngine.test.js:1055`
- `app/__tests__/api/achievements.test.js:67`

這兩個失敗一路 merge 進 main 沒被擋下，直到 #805 開發時才發現並順手修掉。

## 改動

`ci.yml` 新增 `Test (app)` job，跑 `yarn test`，並帶一個 `mysql:8` service container。

過程中連續踩到三個坑，每個都是「這個測試在乾淨環境本來就跑不起來」的既有問題，一併修掉。

### 坑 1：測試不是全 mock，需要真的資料庫

第一版我以為 `__tests__/setup.js` 已經 mock 掉一切、不需要 service container，**這是錯的**，CI 直接給了 20 suites / 146 tests 失敗。實際情況：

- **11 個檔案**主動 `jest.unmock("util/mysql")` 打真實 DB —— `JankenSeason`、`JankenSeasonSnapshot`、`JankenDailyRewardLog`、`JankenRating`、`weatherModels`、`ChatWeatherService`、`JankenRewardService`、`JankenSeasonService`、`XpHistoryService.buildDaily`、`pipeline.weather`、`pipeline.alchemy`
- **另外 7 個** World Boss / runtime 測試會用 `worldBossFixture.js` **動態建立臨時資料庫**再跑完整 migration

這 18 個檔案在任何沒開 MySQL 的機器上本來就是紅的，本機看到全綠只是因為剛好有 container 在跑。

兩個容易漏的設定：

**`DB_PASSWORD` 和 `DB_USER_PASSWORD` 都得給。**
`src/__tests__/helpers/worldBossFixture.js:34-35` 以 `root` 身分建臨時 DB 時讀的是 `DB_PASSWORD`，跟其他地方用的 `DB_USER_PASSWORD` 不同名。只給後者，那 7 個 World Boss suite 會掛在 `Access denied for user 'root'`。

**不可以指定 `utf8mb4_unicode_ci`。**
`MYSQL_DATABASE: Princess` 讓資料庫沿用 MySQL 8 的 server 預設 `utf8mb4_0900_ai_ci`。理由寫在 `migrations/20210101000000_baseline_initial_schema.js` 檔頭：手動指定 unicode_ci 會讓 `20260327_unify_all_collation_to_0900` 之後的新舊表 collation 相反，一 JOIN 就 `Illegal mix of collations`。2026-07-29 遷移 EC2 時已經踩過一次。

### 坑 2：`yarn migrate` 在乾淨 checkout 上是壞的

`migrations/20260327_seed_race_characters_from_game.js:8` 直接開 `app/assets/redive_tw.db`，但那是 **gitignored 的 30MB 遊戲資料**（`app/assets/.gitignore` 的 `*`），只存在於 prod 的 host volume `/home/ubuntu/data/redive-assets`。

所以 CLAUDE.md 記載的 fresh-DB bootstrap（`yarn migrate && yarn knex seed:run`）**在任何乾淨 checkout 上都會中斷**在 `SqliteError: unable to open database file` —— 不只 CI，新的開發機也一樣。

本 PR 加了 `fs.existsSync` skip guard。Prod 早在 batch 38（2026-03-26）跑過這支 migration、`race_character` 有 318 列，不會再執行，所以跳過只會發生在本來就拿不到種子資料的環境。

### 坑 3：cron CLI 測試需要根目錄 `.env` 實際存在

`bin/__tests__/WorldBossSeasonSettle.test.js:77-99` 會 spawn 一個子行程跑 `bin/WorldBossSeasonSettle.js`，並斷言它從**根目錄 `.env`** 載到 `DB_USER` / `DB_USER_PASSWORD`（CLAUDE.md：根 `.env` 是唯一 env 檔）。

job 層級的 `env:` 不夠 —— 那支 CLI 讀的是檔案。乾淨 checkout 沒有 `.env`，所以 `userLoaded: false`。加一個建檔步驟。

## 驗證

本機起與 CI service 定義相同的 `mysql:8` throwaway container 跑完整流程，**並把 `assets/redive_tw.db` 暫時移走以模擬乾淨 checkout**：

| 步驟 | 結果 |
|---|---|
| 建 DB 後 collation | `utf8mb4_0900_ai_ci` |
| `yarn migrate`（無 sqlite 檔） | 148 migrations，skip guard 正常觸發 |
| `yarn knex seed:run` | 7 seed files |
| `yarn test` | **144 suites / 1742 tests 全綠** |
| `WorldBossSeasonSettle`（CI 式 `.env`） | 6/6 通過 |

驗證用 container 已移除，`assets/redive_tw.db` 已放回。

CI 實測：`Test (app)` **pass, 2m12s**。

## 成本

這是 public repo，GitHub Actions 標準 runner 免費不計分鐘數，沒有 quota 風險。實測 2m12s，與既有 lint job 平行執行。
