### PR TITLE
docs: 記錄轉生「覺醒」語意脫鉤的現況

### DIFF
--- a/docs/plans/2026-08-28-prestige-awakening-semantics.md
+++ b/docs/plans/2026-08-28-prestige-awakening-semantics.md
@@ -1,0 +1,81 @@
+# 轉生「覺醒」語意現況說明
+
+**日期**：2026-08-28
+**狀態**：現況紀錄（非規劃文件）
+
+`docs/plans/chat-level-prestige*.md` 是 2026-04 的規劃文件，記錄當時的設計決定，**不會回頭改寫**。這支文件說明那批文件裡的一個假設在實作後脫鉤了，以及現行 code 的真實語意。
+
+## 一句話
+
+「覺醒」在這個系統裡有**兩個不同的東西**，當初的設計假設它們是同一件事：
+
+| | 是什麼 | 觸發條件 | 線上人數 |
+|---|---|---|---|
+| `prestige_awakening`（成就） | ★5 試煉「覺悟」的通關證明 | 通過 ★5 試煉 | **55** |
+| `prestige_count = 5`（狀態） | 轉生封頂的終態 | 累計完成 5 次轉生 | **2** |
+
+規劃文件寫的是「★5 = 第 5 次轉生」，所以只設計了一個成就。實際上兩者可以差很遠。
+
+## 為什麼會脫鉤
+
+試煉是 **opt-in 且不強制按星級順序**，玩家可以自由挑要打哪一關。而 ★5 的門檻定價失衡：
+
+| star | slug | display_name | required_exp | 通過人數 |
+|---|---|---|---|---|
+| 1 | departure | 啟程 | 10000 | 65 |
+| 2 | hardship | 刻苦 | 9000 | 26 |
+| 3 | rhythm | 律動 | 12500 | 10 |
+| 4 | solitude | 孤鳴 | 12500 | 15 |
+| **5** | **awakening** | **覺悟** | **10000** | **55** |
+
+★5「覺悟」只要 10000 XP，比 ★3 律動 / ★4 孤鳴 的 12500 還便宜。玩家自然挑最划算的打，於是 ★5 通過人數（55）遠高於 ★3（10）和 ★4（15）。
+
+通過 ★5 只代表「打完那一關試煉」，跟轉生次數無關 —— 轉生要另外消耗一個已通過未使用的試煉才會 +1。
+
+線上 `prestige_count` 分布（2026-08-28）：
+
+| prestige_count | 人數 |
+|---|---|
+| 0 | 22305 |
+| 1 | 12 |
+| 4 | 1 |
+| 5 | **2** |
+
+## 現行 code 的真實語意
+
+**`prestige_awakening` — ★5 試煉通關證明**
+
+`PrestigeService.js:230-233` 在任何試煉通過時讀 `trial.reward_meta.achievement_slug` 發放。★5「覺悟」的 `reward_meta` 帶 `achievement_slug: "prestige_awakening"`，所以是那一關的通關獎勵，與 `prestige_count` 無關。
+
+`PrestigeService.js:185` 把它的獎勵文案顯示為「覺醒之證」—— 證明，不是狀態。
+
+**`prestige_5`「輪迴盡頭」— 真正的轉生終態**（2026-08-28 新增，PR #805）
+
+`AchievementEngine.js:110` 掛在 `prestige_complete` 事件，`:249` 用 `STRATEGIES.threshold(..., "prestigeCount", 5)` 判定。這才是「累計 5 次轉生」。
+
+命名刻意避開「覺醒」二字，因為那個詞已被 `prestige_awakening` 佔用，兩者必須能區分。
+
+**門檻 5 為什麼寫在 code 而非 DB `condition`**
+
+`prestige_3` 的門檻放在 DB（數值機密），但 5 不是機密 —— `Lv100CTA.js:34` 本來就對玩家顯示「累計 5 次轉生 → 覺醒終態（封頂）」，`PrestigeService.js:16` 的 `PRESTIGE_CAP = 5` 也在 git 裡。
+
+若比照 `prestige_3` 留 NULL condition 走 `conditionThreshold`，`AchievementEngine.js:132-137` 在 `minValue === undefined` 時會直接回傳原值，導致 fresh DB 上永不解鎖。故改用 `STRATEGIES.threshold` 硬寫 5。
+
+未 `import PRESTIGE_CAP`：`PrestigeService` 已 require `AchievementEngine`，反向 import 會循環依賴。
+
+## 讀舊規劃文件時的對照
+
+`docs/plans/chat-level-prestige*.md` 裡大量出現的「覺醒」，**絕大多數指的是 `prestige_count = 5` 的遊戲終態概念，那些敘述仍然正確** —— 包括封頂規則、祝福鎖定、`✨ 覺醒者` 狀態顯示、覺醒廣播、build 成就檢查。
+
+只有把成就 `prestige_awakening` 綁到「第 5 次轉生」的敘述是錯的。已在對應位置加註：
+
+- `chat-level-prestige-impl.md:164`
+- `chat-level-prestige-acceptance.md:83`
+
+`chat-level-prestige-m5.md:141`（「★5 trial 通過 → `unlockByKey("prestige_awakening")`」）**沒有錯**，它描述的正是現行行為。
+
+## 已知未決
+
+**★5 定價失衡**：`required_exp = 10000` 低於 ★3/★4 的 12500，導致玩家跳過中段直攻 ★5。是否調整尚未討論 —— 若調，會影響既有 55 名通過者的觀感。
+
+**55 vs 2 的落差**：目前無計畫回收或重發 `prestige_awakening`。舊成就零改動，55 名持有者不受影響。

--- a/docs/plans/chat-level-prestige-acceptance.md
+++ b/docs/plans/chat-level-prestige-acceptance.md
@@ -81,6 +81,7 @@ yarn test 2>&1 | tail -40
 
 - [ ] **試煉首通**：`user_achievements` 新增 `prestige_departure`
 - [ ] **第 5 次轉生**：`prestige_awakening` + 對應 build 成就（`blessing_breeze` / `torrent` / `temperature` / `solitude`）依祝福組合解鎖
+  > **2026-08-28 更正**：`prestige_awakening` 實際由「通過 ★5 試煉」觸發，不是第 5 次轉生；兩者已脫鉤。第 5 次轉生對應的成就是 `prestige_5`「輪迴盡頭」。build 成就的部分不受影響。詳見 [2026-08-28-prestige-awakening-semantics.md](./2026-08-28-prestige-awakening-semantics.md)。
 - [ ] **batchEvaluate 改寫**：`chat_100 / chat_1000 / chat_5000` 改吃 `prestige_count * 27000 + current_exp`（手動跑 `node app/bin/AchievementCron.js` 看不會炸）
 
 ### G. M6 LIFF 前端

--- a/docs/plans/chat-level-prestige-impl.md
+++ b/docs/plans/chat-level-prestige-impl.md
@@ -162,6 +162,7 @@ Branch：`feat/chat-level-prestige`
   - （寫入 `achievements` / `achievement_definitions` 既有表，視現行 schema）
 - [ ] 觸發點：
   - PrestigeService 的試煉通過時 → `AchievementEngine.unlock(userId, 'prestige_departure')`（若是 ★1）或 `prestige_awakening`（若是 ★5 = 第 5 次轉生）
+    > **2026-08-28 更正**：「★5 = 第 5 次轉生」這個假設不成立。試煉是 opt-in 且不按星序，通過 ★5 只代表打完那一關，與 `prestige_count` 無關（線上 55 人有 `prestige_awakening`，但只有 2 人 `prestige_count=5`）。真正的轉生終態成就是 `prestige_5`「輪迴盡頭」。詳見 [2026-08-28-prestige-awakening-semantics.md](./2026-08-28-prestige-awakening-semantics.md)。
   - 第 5 次轉生（`prestige_count 4 → 5`）時檢查 `user_blessings` 組合 → 觸發隱藏 build 成就
 - [ ] 遷移腳本觸發 `prestige_pioneer` 一次性發放給 82 人（屬 M9）
 - [ ] **改寫 `AchievementEngine.batchEvaluate`**（`app/src/service/AchievementEngine.js:360-362`）：


### PR DESCRIPTION
## 背景

`docs/plans/chat-level-prestige*.md` 是 2026-04 的規劃文件。當初的設計假設是「通過 ★5 試煉 = 第 5 次轉生」，所以只設計了一個 `prestige_awakening` 成就。

**實作後兩者脫鉤了。**

## 為什麼脫鉤

試煉是 opt-in 且不強制按星級順序，玩家可以自由挑要打哪一關。而 ★5 的門檻定價失衡：

| star | slug | display_name | required_exp | 通過人數 |
|---|---|---|---|---|
| 1 | departure | 啟程 | 10000 | 65 |
| 2 | hardship | 刻苦 | 9000 | 26 |
| 3 | rhythm | 律動 | 12500 | 10 |
| 4 | solitude | 孤鳴 | 12500 | 15 |
| **5** | **awakening** | **覺悟** | **10000** | **55** |

★5「覺悟」只要 10000 XP，比 ★3 律動 / ★4 孤鳴 的 12500 還便宜。玩家自然挑最划算的打，於是 ★5 通過人數（55）遠高於 ★3（10）和 ★4（15）。

通過 ★5 只代表「打完那一關」，轉生要另外消耗一個已通過未使用的試煉才會 +1。線上 `prestige_count` 分布：0 → 22305、1 → 12、4 → 1、**5 → 2**。

所以「覺醒」實際上是兩個不同的東西：

| | 是什麼 | 觸發 | 線上人數 |
|---|---|---|---|
| `prestige_awakening`（成就） | ★5 試煉通關證明 | 通過 ★5 試煉 | **55** |
| `prestige_count = 5`（狀態） | 轉生封頂終態 | 累計 5 次轉生 | **2** |

## 改動

### 新增 `docs/plans/2026-08-28-prestige-awakening-semantics.md`

現況說明（非規劃文件），記錄：真實觸發點與 code 位置、`required_exp` 定價失衡導致脫鉤的完整資料、`prestige_5`「輪迴盡頭」的由來、門檻 5 為何寫在 code 而非 DB `condition`、讀舊文件時的對照方式。

### 兩處加註更正

- `chat-level-prestige-impl.md:164`
- `chat-level-prestige-acceptance.md:83`

這兩行把成就 `prestige_awakening` 綁到「第 5 次轉生」，是唯二真正寫錯觸發條件的地方。原文保留，底下加一行 blockquote 更正並指向新文件。

## 為什麼不全面改寫舊文件

`docs/plans/` 是有日期的歷史規劃文件，記錄的是當時的決定，改寫等於篡改設計紀錄。

而且 80 處「覺醒」裡**絕大多數指的是 `prestige_count = 5` 的遊戲終態概念，那些敘述仍然正確** —— 封頂規則、祝福鎖定、`✨ 覺醒者` 狀態顯示、覺醒廣播、build 成就檢查都沒問題。

`chat-level-prestige-m5.md:141`（「★5 trial 通過 → `unlockByKey("prestige_awakening")`」）也**沒有錯**，它描述的正是現行行為，故未動。

## 驗證

文件內所有引用都對照過線上 DB 與現行 code：

- 試煉表數據、通過人數、`prestige_count` 分布 → 線上 `Princess` DB 實查
- `PrestigeService.js:16` `PRESTIGE_CAP`、`:185` 覺醒之證、`:230-233` 試煉成就發放
- `AchievementEngine.js:110` 事件對應、`:249` `prestige_5` strategy、`:132-137` `conditionThreshold` 的 `minValue === undefined` 行為
- `Lv100CTA.js:34` 對玩家公開顯示「累計 5 次轉生」

純文件變更，無 code 改動。

## 已知未決（文件內有記錄，本 PR 不處理）

**★5 定價失衡** —— `required_exp = 10000` 低於 ★3/★4 的 12500，導致玩家跳過中段直攻 ★5。是否調整尚未討論；若調，會影響既有 55 名通過者的觀感。
