### PR TITLE
fix(janken): 扣款失敗時釋放 escrow lock，避免免費參賽

### DIFF
--- a/app/src/service/JankenService.js
+++ b/app/src/service/JankenService.js
@@ -124,7 +124,20 @@ exports.tryEscrowOnce = async function (matchId, userId, amount) {
   if (!locked) {
     return { alreadyEscrowed: true };
   }
-  const result = await exports.escrowBet(userId, amount, matchId);
+  // The lock means "this player already staked". If the debit did NOT happen, the lock is
+  // a lie and must go: leaving it lets the next click take the `alreadyEscrowed` branch,
+  // which callers read as "already paid" and wave through to submitChoice — a player with
+  // too few stones could click twice and play a bet match for free.
+  let result;
+  try {
+    result = await exports.escrowBet(userId, amount, matchId);
+  } catch (err) {
+    await redis.del(escrowKey);
+    throw err;
+  }
+  if (!result.success) {
+    await redis.del(escrowKey);
+  }
   return result;
 };
 

--- a/app/src/service/__tests__/JankenService.escrowRefund.test.js
+++ b/app/src/service/__tests__/JankenService.escrowRefund.test.js
@@ -245,6 +245,85 @@ describe("JankenService.isMatchAlive", () => {
   });
 });
 
+describe("JankenService.tryEscrowOnce releases the lock when the stake fails", () => {
+  const LOCK_KEY = "jankenDecide:escrow:m1:Uaaa";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redis.del.mockResolvedValue(1);
+  });
+
+  it("drops the lock when the player cannot afford the bet", async () => {
+    redis.set.mockResolvedValueOnce("OK");
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10 });
+
+    const result = await JankenService.tryEscrowOnce("m1", "Uaaa", 500);
+
+    expect(result).toEqual({ success: false, balance: 10 });
+    expect(redis.del).toHaveBeenCalledWith(LOCK_KEY);
+  });
+
+  it("drops the lock when escrowBet rolls back after a zAdd failure", async () => {
+    redis.set.mockResolvedValueOnce("OK");
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10000 });
+    redis.zAdd.mockRejectedValueOnce(new Error("redis down"));
+
+    const result = await JankenService.tryEscrowOnce("m1", "Uaaa", 500);
+
+    expect(result.success).toBe(false);
+    expect(redis.del).toHaveBeenCalledWith(LOCK_KEY);
+  });
+
+  it("drops the lock and rethrows when escrowBet throws", async () => {
+    redis.set.mockResolvedValueOnce("OK");
+    inventory.getUserMoney.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(JankenService.tryEscrowOnce("m1", "Uaaa", 500)).rejects.toThrow("db down");
+    expect(redis.del).toHaveBeenCalledWith(LOCK_KEY);
+  });
+
+  it("keeps the lock when the stake succeeds (isMatchAlive still works)", async () => {
+    redis.set.mockResolvedValueOnce("OK");
+    redis.zAdd.mockResolvedValueOnce(1);
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10000 });
+
+    const result = await JankenService.tryEscrowOnce("m1", "Uaaa", 500);
+
+    expect(result).toEqual({ success: true });
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+
+  // The free-ride regression: broke player clicks, is rejected, clicks again. Before the
+  // lock was released the retry returned `alreadyEscrowed: true`, which callers treat as
+  // "already paid" and pass through to submitChoice — letting them play without staking.
+  it("makes a retry re-attempt the debit instead of reporting alreadyEscrowed", async () => {
+    redis.set.mockResolvedValueOnce("OK");
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10 });
+    const first = await JankenService.tryEscrowOnce("m1", "Uaaa", 500);
+    expect(first.alreadyEscrowed).toBeUndefined();
+    expect(first.success).toBe(false);
+
+    // Lock was deleted, so the NX set succeeds again on the second click.
+    redis.set.mockResolvedValueOnce("OK");
+    inventory.getUserMoney.mockResolvedValueOnce({ amount: 10 });
+    const second = await JankenService.tryEscrowOnce("m1", "Uaaa", 500);
+
+    expect(second.alreadyEscrowed).toBeUndefined();
+    expect(second).toEqual({ success: false, balance: 10 });
+    expect(inventory.decreaseGodStone).not.toHaveBeenCalled();
+  });
+
+  it("still short-circuits a genuine duplicate of a successful stake", async () => {
+    redis.set.mockResolvedValueOnce(null);
+
+    const result = await JankenService.tryEscrowOnce("m1", "Uaaa", 500);
+
+    expect(result).toEqual({ alreadyEscrowed: true });
+    expect(inventory.getUserMoney).not.toHaveBeenCalled();
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+});
+
 describe("JankenService.resolveMatch clears pending escrows", () => {
   beforeEach(() => {
     jest.restoreAllMocks();


### PR DESCRIPTION
## Summary

`tryEscrowOnce` 先寫 NX lock 才扣款，但扣款失敗時沒有把 lock 收回，導致餘額不足的玩家可以免費參加賭注對局。

攻擊路徑（p2）：

1. 第一次點出拳 → NX lock 寫入 → `escrowBet` 因餘額不足回傳 `success: false` → 回覆「女神石不足」並 return，**lock 留在 Redis**
2. 第二次點同一顆按鈕 → NX 失敗 → 回傳 `alreadyEscrowed: true`
3. 呼叫端把 `alreadyEscrowed` 解讀為「已經押注過」，走空分支直接放行 → `submitChoice` → `resolveMatch` → 領走獎金

全程沒有押上任何女神石。

p1 不受影響：每場 duel 都會產生新的 uuid（`JankenController.js:141`），NX lock 必定成功，`alreadyEscrowed` 分支對 p1 不可達。只有重複點擊同一個 matchId 的 p2 會踩到。

### 修法

修在共用函式 `tryEscrowOnce`，一處補完所有呼叫端（p1 duel、p2 decide、auto-fate 都走這裡）：

- `escrowBet` 回傳 `success: false` → 刪掉 lock
- `escrowBet` 直接 throw → 刪掉 lock 後原樣 rethrow
- 扣款成功 → 保留 lock，`isMatchAlive` 的存活探針行為完全不變

修好之後 `alreadyEscrowed: true` 才真正代表「這個人確實已經押注成功」，兩個呼叫端原本的「已處理，跳過」語意才成立。

### 線上實證

兩場對局同時滿足四項獨立證據：

| 對局 | 白吃者 | 下注前餘額 | 賭金 | Redis escrow lock | inventory 扣款 | 領走 |
|---|---|---|---|---|---|---|
| `54d5c0db` | `Ud904092d…` | 3,988 | 10,000 | 仍存活 | 無 | 18,000 |
| `c1cbcbb7` | `U4c6f2d89…` | 13,283 | 21,988 | 仍存活 | 無 | 39,579 + bounty 2,635 |

兩人都是 p2、都付不起賭金、lock 都還躺在 Redis（正是這個 bug 的殘留狀態）、且對手的 lock 都不存在（舊版 p1 走 `escrowBet` 不寫 lock）。

用 79 把存活的 escrow lock 以 matchId 直接對帳 MySQL（不使用任何金額配對啟發法），確定命中就是這 2 筆。

另有 645 筆符合特徵（已付款 + p2 未扣款 + p2 付不起，約 3.99M 女神石）與 304 筆無法解釋（p2 付得起）的估計值，因為缺少 matchId 級別的證據，本 PR 不據此追討，僅止血。

PR #801 把 `MATCH_WINDOW_SECONDS` 從 7 天縮到 1 小時，等於把這個漏洞的可用窗口從 7 天壓到 1 小時，但沒有關門。

## Test plan

- [x] 新增 6 個測試鎖住不變式：餘額不足刪 lock、zAdd 失敗 rollback 後刪 lock、throw 後刪 lock 並 rethrow、成功時保留 lock、**重試必須重新扣款而非回報 `alreadyEscrowed`**（免費參賽的迴歸測試）、成功押注的真正重複點擊仍正確短路
- [x] `yarn test -- JankenService` → 73 passed（原 67）
- [x] `yarn test` 全套 → 144 suites / 1748 tests 全綠
- [x] `eslint` exit 0、`prettier --check` 通過
- [ ] 部署後觀察是否還有「已結算但單邊未扣款」的新增案例

## 部署注意

無新 migration、無新環境變數、無新依賴、無 config 變更。`redive-bot` 與 `redive-worker` 共用 `ghcr.io/hanshino/redive_backend:latest`，host 上的 `stack-deploy.timer`（每 5 分鐘 `docker compose pull` + `up -d`）會在 image 更新後自動重建，無需手動操作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
