### PR TITLE
feat(worldboss): 重新設計世界王 Flex Message 為深色戰報卡

### DIFF
--- a/app/src/templates/application/WorldBoss.js
+++ b/app/src/templates/application/WorldBoss.js
@@ -1,21 +1,62 @@
-const { FEATURE, SEMANTIC, SURFACE } = require("../common/theme");
+const { PALETTE } = require("../common/theme");
 
 const MAX_BOSS_DESCRIPTION_BYTES = 2048;
 const MAX_IMAGE_URL_LENGTH = 2000;
-const ACCENT = FEATURE.worldBoss;
-// White veil over a cleared boss's art. LINE accepts #RRGGBBAA, so the alpha does the
-// fading without needing an image filter (Flex images have no opacity property).
-const CLEARED_VEIL = `${SURFACE.bg}B3`;
+// A 1% sliver is invisible at kilo width, so a live boss always keeps a readable stub.
+const MIN_HP_BAR_PERCENT = 2;
 
-function textNode(text, extra = {}) {
-  return { type: "text", text, color: SURFACE.text, wrap: true, size: "sm", ...extra };
+/**
+ * "戰報卡" palette. These are dark-surface values with alpha channels that the shared
+ * light-surface tokens don't carry, so they live here rather than in theme.js — this
+ * template is their only consumer. Values that do exist in the shared palette are
+ * referenced from it so the red / green / amber stay in sync with the rest of the bot.
+ */
+const C = {
+  surface: "#131822",
+  text: "#E8EDF5",
+  textMuted: "#8A98AD",
+  textFaint: "#7C8AA0",
+  white: PALETTE.white,
+
+  chipBg: "#000000A6",
+  scrimEnd: "#13182200",
+  clearedVeil: "#0A0F16D9",
+
+  cleared: "#34D399",
+  clearedStampBg: "#04170FA6",
+  clearedPanelBg: "#0E2D1FCC",
+  clearedPanelBorder: "#1E5E42",
+  clearedPanelMuted: "#6E8A7E",
+
+  track: "#FFFFFF14",
+  outline: "#FFFFFF29",
+
+  attack: PALETTE.red600,
+  skill: "#273246",
+  link: "#8CC6FF",
+  stripEnd: PALETTE.amber500,
+};
+
+/**
+ * HP tiers double as the card's status read: green is safe, amber is halfway, rose is
+ * nearly down. Ordered high to low; the last entry catches 0% on a boss that is still
+ * alive (a rounding artefact on a huge HP pool), which must not fall through.
+ */
+const HP_TIERS = [
+  { above: 60, text: PALETTE.green400, from: "#15803D", to: PALETTE.green400 },
+  { above: 30, text: PALETTE.amber400, from: "#B45309", to: PALETTE.amber400 },
+  { above: -Infinity, text: "#FB7185", from: "#9F1239", to: "#FB7185" },
+];
+
+function hpTier(percent) {
+  return HP_TIERS.find(tier => percent > tier.above);
 }
 
 function formatNumber(value) {
   if (typeof value === "number") {
     return Number.isFinite(value) ? new Intl.NumberFormat("en-US").format(value) : String(value);
   }
-  if (typeof value === "bigint") return value.toLocaleString("en-US");
+  if (typeof value === "bigint") return new Intl.NumberFormat("en-US").format(value);
   if (typeof value !== "string" || !/^-?\d+$/.test(value)) return String(value);
 
   const negative = value.startsWith("-");
@@ -51,43 +92,6 @@ function httpsImageUrl(value) {
     return null;
   }
   return url.protocol === "https:" ? url.toString() : null;
-}
-
-/**
- * Boss art comes from the season snapshot (`round.image`), never the live catalog,
- * so a bubble always shows the boss as it was when the season opened.
- */
-function bossHero(image, cleared) {
-  const url = httpsImageUrl(image);
-  if (!url) return null;
-
-  const hero = {
-    type: "image",
-    url,
-    size: "full",
-    aspectRatio: "20:13",
-    aspectMode: "cover",
-  };
-  if (!cleared) return hero;
-
-  // Keep the art on cleared cards but push it back behind a translucent overlay.
-  return {
-    type: "box",
-    layout: "vertical",
-    paddingAll: "none",
-    contents: [
-      hero,
-      {
-        type: "box",
-        layout: "vertical",
-        position: "absolute",
-        width: "100%",
-        height: "100%",
-        backgroundColor: CLEARED_VEIL,
-        contents: [],
-      },
-    ],
-  };
 }
 
 function truncateUtf8(value, maxBytes) {
@@ -126,113 +130,364 @@ function validateRound(round) {
   return { maxHp, currentHp };
 }
 
+/** Bottom-up scrim so the boss name stays legible over any artwork. */
+function heroScrim() {
+  return {
+    type: "box",
+    layout: "vertical",
+    position: "absolute",
+    offsetStart: "0px",
+    offsetEnd: "0px",
+    offsetBottom: "0px",
+    height: "64%",
+    background: {
+      type: "linearGradient",
+      angle: "0deg",
+      startColor: C.surface,
+      endColor: C.scrimEnd,
+    },
+    contents: [],
+  };
+}
+
+/** Cycle + slot badge, pinned top-left. `flex: 0` keeps the pill hugging its label. */
+function heroChip(label) {
+  return {
+    type: "box",
+    layout: "horizontal",
+    position: "absolute",
+    offsetTop: "8px",
+    offsetStart: "8px",
+    offsetEnd: "8px",
+    contents: [
+      {
+        type: "box",
+        layout: "vertical",
+        flex: 0,
+        backgroundColor: C.chipBg,
+        cornerRadius: "4px",
+        paddingTop: "3px",
+        paddingBottom: "3px",
+        paddingStart: "7px",
+        paddingEnd: "7px",
+        contents: [{ type: "text", text: label, size: "xxs", color: C.white }],
+      },
+      { type: "filler" },
+    ],
+  };
+}
+
+function heroName(name) {
+  return {
+    type: "text",
+    text: name,
+    position: "absolute",
+    offsetStart: "12px",
+    offsetEnd: "12px",
+    offsetBottom: "8px",
+    size: "xl",
+    weight: "bold",
+    color: C.white,
+  };
+}
+
+function clearedStamp() {
+  return {
+    type: "box",
+    layout: "vertical",
+    position: "absolute",
+    offsetTop: "0px",
+    offsetBottom: "0px",
+    offsetStart: "0px",
+    offsetEnd: "0px",
+    justifyContent: "center",
+    alignItems: "center",
+    contents: [
+      {
+        type: "box",
+        layout: "vertical",
+        borderWidth: "2px",
+        borderColor: C.cleared,
+        cornerRadius: "4px",
+        backgroundColor: C.clearedStampBg,
+        paddingTop: "7px",
+        paddingBottom: "7px",
+        paddingStart: "16px",
+        paddingEnd: "16px",
+        contents: [{ type: "text", text: "已擊破", size: "md", weight: "bold", color: C.cleared }],
+      },
+    ],
+  };
+}
+
+/**
+ * Boss art comes from the season snapshot (`round.image`), never the live catalog,
+ * so a bubble always shows the boss as it was when the season opened. The cycle label
+ * and boss name ride on top of the art; when the url is unusable the whole hero is
+ * dropped and `bodyTitle` carries them instead.
+ */
+function bossHero({ image, cleared, label, name }) {
+  const url = httpsImageUrl(image);
+  if (!url) return null;
+
+  return {
+    type: "box",
+    layout: "vertical",
+    paddingAll: "none",
+    contents: [
+      { type: "image", url, size: "full", aspectRatio: "20:13", aspectMode: "cover" },
+      // Flex images have no opacity property, so a cleared boss is dimmed by a real box.
+      ...(cleared
+        ? [
+            {
+              type: "box",
+              layout: "vertical",
+              position: "absolute",
+              width: "100%",
+              height: "100%",
+              backgroundColor: C.clearedVeil,
+              contents: [],
+            },
+          ]
+        : []),
+      heroScrim(),
+      heroChip(label),
+      heroName(name),
+      ...(cleared ? [clearedStamp()] : []),
+    ],
+  };
+}
+
+/** Fallback header for bubbles that lost their hero to an unusable snapshot url. */
+function bodyTitle(label, name) {
+  return [
+    { type: "text", text: label, size: "xxs", color: C.textMuted },
+    {
+      type: "text",
+      text: name,
+      size: "xl",
+      weight: "bold",
+      color: C.text,
+      wrap: true,
+      margin: "xs",
+    },
+  ];
+}
+
+function hpBlock({ currentHp, maxHp, percent }) {
+  const tier = hpTier(percent);
+
+  return {
+    type: "box",
+    layout: "vertical",
+    contents: [
+      {
+        type: "box",
+        layout: "horizontal",
+        alignItems: "flex-end",
+        contents: [
+          {
+            type: "text",
+            size: "3xl",
+            weight: "bold",
+            flex: 0,
+            contents: [
+              {
+                type: "span",
+                text: String(percent),
+                size: "3xl",
+                weight: "bold",
+                color: tier.text,
+              },
+              { type: "span", text: "%", size: "sm", weight: "bold", color: tier.text },
+            ],
+          },
+          {
+            type: "text",
+            text: `${formatNumber(currentHp)}\n/ ${formatNumber(maxHp)}`,
+            size: "xxs",
+            color: C.textFaint,
+            align: "end",
+            gravity: "bottom",
+            wrap: true,
+            flex: 1,
+          },
+        ],
+      },
+      {
+        type: "box",
+        layout: "vertical",
+        height: "14px",
+        cornerRadius: "7px",
+        backgroundColor: C.track,
+        margin: "md",
+        contents: [
+          {
+            type: "box",
+            layout: "vertical",
+            width: `${Math.max(percent, MIN_HP_BAR_PERCENT)}%`,
+            height: "14px",
+            cornerRadius: "7px",
+            background: {
+              type: "linearGradient",
+              angle: "90deg",
+              startColor: tier.from,
+              endColor: tier.to,
+            },
+            backgroundColor: tier.from,
+            contents: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function clearedPanel(maxHp) {
+  return {
+    type: "box",
+    layout: "horizontal",
+    alignItems: "center",
+    backgroundColor: C.clearedPanelBg,
+    borderWidth: "1px",
+    borderColor: C.clearedPanelBorder,
+    cornerRadius: "6px",
+    paddingTop: "9px",
+    paddingBottom: "9px",
+    paddingStart: "11px",
+    paddingEnd: "11px",
+    contents: [
+      { type: "text", text: "✓ 討伐完成", size: "sm", weight: "bold", color: C.cleared, flex: 0 },
+      {
+        type: "text",
+        text: `0 / ${formatNumber(maxHp)}`,
+        size: "xxs",
+        color: C.clearedPanelMuted,
+        align: "end",
+        gravity: "center",
+        flex: 1,
+      },
+    ],
+  };
+}
+
+/** A `link` button has no border of its own, so an outline box supplies one. */
+function outlineButton(label, uri) {
+  return {
+    type: "box",
+    layout: "vertical",
+    borderWidth: "1px",
+    borderColor: C.outline,
+    cornerRadius: "6px",
+    contents: [
+      {
+        type: "button",
+        style: "link",
+        color: C.link,
+        height: "sm",
+        action: { type: "uri", label, uri },
+      },
+    ],
+  };
+}
+
+function attackRow(roundId) {
+  return {
+    type: "box",
+    layout: "horizontal",
+    spacing: "sm",
+    contents: [
+      ["⚔️ 攻擊", "standard", C.attack, 3],
+      ["✨ 技能", "skill", C.skill, 2],
+    ].map(([label, attackType, color, flex]) => ({
+      type: "button",
+      style: "primary",
+      color,
+      height: "sm",
+      flex,
+      action: {
+        type: "postback",
+        label,
+        data: JSON.stringify({ action: "worldBossAttack", roundId, attackType }),
+      },
+    })),
+  };
+}
+
 /**
  * A public group card. Every field here is shared world state — season, cycle, boss
  * snapshot, HP, cleared. No viewer-specific data (quota, EXP, rewards, personal
  * damage) may be added; the LIFF board is where personal state belongs.
+ *
+ * `season` is still accepted by the caller but is deliberately not rendered: the
+ * carousel shows five cards of the same season, so repeating its name five times
+ * spends the card's largest type on the least useful word.
  */
-function generateBattleStatusBubble({ season, round, boss, liffUri, attackEnabled = false }) {
+function generateBattleStatusBubble({ round, boss, liffUri, attackEnabled = false }) {
   const { maxHp, currentHp } = validateRound(round);
   const hpPercent = roundedPercent(currentHp, maxHp);
   const description = truncateUtf8(boss.description, MAX_BOSS_DESCRIPTION_BYTES);
   const cleared = currentHp === 0n || Boolean(round.cleared_at);
-  const hero = bossHero(boss.image, cleared);
+  const label = `第 ${round.cycle_no} 輪 · ${boss.position} 號`;
+  const hero = bossHero({ image: boss.image, cleared, label, name: boss.name });
+  const boardUri = worldBossUri(liffUri);
 
   return {
     type: "bubble",
     size: "kilo",
-    ...(hero ? { hero } : {}),
-    header: {
-      type: "box",
-      layout: "vertical",
-      backgroundColor: ACCENT.main,
-      paddingAll: "md",
-      contents: cleared
-        ? [textNode("已擊破", { color: SEMANTIC.success.main, weight: "bold", align: "center" })]
-        : [
-            textNode("世界王討伐中", { color: ACCENT.contrast, weight: "bold", size: "md" }),
-            textNode(season.name, { color: ACCENT.contrast, size: "xs", margin: "xs" }),
-          ],
+    styles: {
+      body: { backgroundColor: C.surface },
+      footer: { backgroundColor: C.surface, separator: false },
     },
+    ...(hero ? { hero } : {}),
     body: {
       type: "box",
       layout: "vertical",
-      paddingAll: "lg",
-      spacing: "sm",
+      backgroundColor: C.surface,
+      paddingAll: "12px",
+      paddingBottom: "16px",
+      spacing: "lg",
       contents: [
-        textNode(`第 ${round.cycle_no} 輪 · ${boss.position} 號 · ${boss.name}`, {
-          weight: "bold",
-          size: "lg",
-        }),
-        ...(description ? [textNode(description, { color: SURFACE.textMuted, size: "xs" })] : []),
-        textNode(`HP ${formatNumber(currentHp)} / ${formatNumber(maxHp)}（${hpPercent}%）`, {
-          margin: "md",
-          weight: "bold",
-          color: ACCENT.main,
-        }),
-        {
-          type: "box",
-          layout: "vertical",
-          height: "8px",
-          backgroundColor: SURFACE.bgMuted,
-          cornerRadius: "4px",
-          contents: [
-            {
-              type: "box",
-              layout: "vertical",
-              width: `${hpPercent}%`,
-              height: "8px",
-              backgroundColor: ACCENT.main,
-              cornerRadius: "4px",
-              contents: [],
-            },
-          ],
-        },
+        ...(hero
+          ? []
+          : [{ type: "box", layout: "vertical", contents: bodyTitle(label, boss.name) }]),
+        ...(description
+          ? [
+              {
+                type: "text",
+                text: description,
+                size: "xs",
+                color: C.textMuted,
+                wrap: true,
+                maxLines: 2,
+              },
+            ]
+          : []),
+        cleared ? clearedPanel(maxHp) : hpBlock({ currentHp, maxHp, percent: hpPercent }),
       ],
     },
     footer: {
       type: "box",
       layout: "vertical",
-      paddingAll: "md",
+      backgroundColor: C.surface,
+      paddingTop: "8px",
+      paddingBottom: "12px",
+      paddingStart: "12px",
+      paddingEnd: "12px",
       spacing: "sm",
-      contents: cleared
-        ? [textNode("已擊破", { color: SEMANTIC.success.main, weight: "bold", align: "center" })]
-        : [
-            ...(attackEnabled
-              ? [
-                  {
-                    type: "box",
-                    layout: "horizontal",
-                    spacing: "sm",
-                    contents: [
-                      ["⚔️ 攻擊", "standard"],
-                      ["✨ 技能", "skill"],
-                    ].map(([label, attackType]) => ({
-                      type: "button",
-                      style: "primary",
-                      color: ACCENT.main,
-                      height: "sm",
-                      action: {
-                        type: "postback",
-                        label,
-                        data: JSON.stringify({
-                          action: "worldBossAttack",
-                          roundId: round.id,
-                          attackType,
-                        }),
-                      },
-                    })),
-                  },
-                ]
-              : []),
-            {
-              type: "button",
-              style: "primary",
-              color: ACCENT.main,
-              height: "sm",
-              action: { type: "uri", label: "開啟戰況板", uri: worldBossUri(liffUri) },
-            },
-          ],
+      contents:
+        !cleared && attackEnabled
+          ? [
+              attackRow(round.id),
+              {
+                type: "button",
+                style: "link",
+                color: C.link,
+                height: "sm",
+                action: { type: "uri", label: "開啟戰況板", uri: boardUri },
+              },
+            ]
+          : [outlineButton("開啟戰況板", boardUri)],
     },
   };
 }
@@ -244,29 +499,53 @@ function generateNoActiveSeasonBubble({ ended, liffUri }) {
   return {
     type: "bubble",
     size: "kilo",
+    styles: {
+      body: { backgroundColor: C.surface },
+      footer: { backgroundColor: C.surface, separator: false },
+    },
     body: {
       type: "box",
       layout: "vertical",
-      paddingAll: "lg",
-      spacing: "sm",
+      backgroundColor: C.surface,
+      paddingAll: "0px",
       contents: [
-        textNode(headline, { weight: "bold", size: "lg", color: SURFACE.text }),
-        textNode(detail, { color: SURFACE.textMuted, size: "sm" }),
+        {
+          type: "box",
+          layout: "vertical",
+          height: "4px",
+          background: {
+            type: "linearGradient",
+            angle: "90deg",
+            startColor: C.attack,
+            endColor: C.stripEnd,
+          },
+          backgroundColor: C.attack,
+          contents: [],
+        },
+        {
+          type: "box",
+          layout: "vertical",
+          paddingTop: "16px",
+          paddingBottom: "20px",
+          paddingStart: "12px",
+          paddingEnd: "12px",
+          spacing: "sm",
+          contents: [
+            { type: "text", text: headline, size: "md", weight: "bold", color: C.text, wrap: true },
+            { type: "text", text: detail, size: "xs", color: C.textMuted, wrap: true },
+          ],
+        },
       ],
     },
     footer: {
       type: "box",
       layout: "vertical",
-      paddingAll: "md",
-      contents: [
-        {
-          type: "button",
-          style: "link",
-          color: SEMANTIC.info.main,
-          height: "sm",
-          action: { type: "uri", label: "查看世界王戰況", uri: worldBossUri(liffUri) },
-        },
-      ],
+      backgroundColor: C.surface,
+      paddingTop: "8px",
+      paddingBottom: "12px",
+      paddingStart: "12px",
+      paddingEnd: "12px",
+      contents: [outlineButton("查看世界王戰況", worldBossUri(liffUri))],
     },
   };
 }

--- a/app/src/templates/application/__tests__/WorldBoss.test.js
+++ b/app/src/templates/application/__tests__/WorldBoss.test.js
@@ -27,6 +27,26 @@ function images(node) {
   return [...(node.type === "image" ? [node] : []), ...Object.values(node).flatMap(images)];
 }
 
+function nodesOfType(node, type) {
+  if (Array.isArray(node)) return node.flatMap(child => nodesOfType(child, type));
+  if (!node || typeof node !== "object") return [];
+  return [
+    ...(node.type === type ? [node] : []),
+    ...Object.values(node).flatMap(child => nodesOfType(child, type)),
+  ];
+}
+
+function gradients(node) {
+  return nodesOfType(node, "linearGradient");
+}
+
+/** The single text node that carries the big HP percentage, built from two spans. */
+function percentNode(node) {
+  return nodesOfType(node, "text").find(
+    item => Array.isArray(item.contents) && item.contents.some(span => span.text === "%")
+  );
+}
+
 const LIFF = "https://liff.line.me/world-boss-liff?source=line";
 const latestReward = {
   rewardId: 42,
@@ -64,6 +84,32 @@ function makeStatus({ cleared = [], image = () => null } = {}) {
 
 const httpsImage = position => `https://cdn.example.com/boss/${position}.png`;
 
+function makeRound(overrides = {}) {
+  return {
+    id: 21,
+    cycle_no: 3,
+    position: 1,
+    name: "王1",
+    image: httpsImage(1),
+    description: "描述",
+    max_hp: "12000",
+    current_hp: "6000",
+    cleared_at: null,
+    ...overrides,
+  };
+}
+
+function bubbleFor(overrides = {}, options = {}) {
+  const round = makeRound(overrides);
+  return WorldBoss.generateBattleStatusBubble({
+    season: { id: 9, name: "盛夏世界王" },
+    round,
+    boss: round,
+    liffUri: LIFF,
+    ...options,
+  });
+}
+
 describe("WorldBoss Flex production contract", () => {
   it("renders exactly five public bubbles in position order with only the shared LIFF uri", () => {
     const reply = WorldBoss.generateWorldBossReply({
@@ -73,11 +119,19 @@ describe("WorldBoss Flex production contract", () => {
     expect(reply.type).toBe("carousel");
     expect(reply.contents).toHaveLength(5);
     expect(reply.contents.map(bubble => text(bubble).find(value => value.includes("號")))).toEqual([
-      "第 3 輪 · 1 號 · 王1",
-      "第 3 輪 · 2 號 · 王2",
-      "第 3 輪 · 3 號 · 王3",
-      "第 3 輪 · 4 號 · 王4",
-      "第 3 輪 · 5 號 · 王5",
+      "第 3 輪 · 1 號",
+      "第 3 輪 · 2 號",
+      "第 3 輪 · 3 號",
+      "第 3 輪 · 4 號",
+      "第 3 輪 · 5 號",
+    ]);
+    // 名稱與輪次標籤拆開後，名稱仍必須跟著自己的位置走。
+    expect(reply.contents.map(bubble => text(bubble).find(value => /^王\d$/.test(value)))).toEqual([
+      "王1",
+      "王2",
+      "王3",
+      "王4",
+      "王5",
     ]);
     // 預設關閉時群組卡不得有 postback。
     expect(actions(reply)).toEqual([]);
@@ -110,6 +164,21 @@ describe("WorldBoss Flex production contract", () => {
       });
       expect(uriActions(bubble)).toHaveLength(1);
     });
+  });
+
+  it("weights the attack button above the skill button in the same row", () => {
+    const footer = bubbleFor({}, { attackEnabled: true }).footer;
+    const [row, board] = footer.contents;
+
+    expect(row.layout).toBe("horizontal");
+    expect(
+      row.contents.map(button => [button.style, button.color, button.height, button.flex])
+    ).toEqual([
+      ["primary", "#DC2626", "sm", 3],
+      ["primary", "#273246", "sm", 2],
+    ]);
+    // 戰況板是第三層級：純文字連結，不與兩顆攻擊鈕搶視覺權重。
+    expect(board).toMatchObject({ type: "button", style: "link", color: "#8CC6FF" });
   });
 
   it("excludes every personal field from the public board", () => {
@@ -147,18 +216,37 @@ describe("WorldBoss Flex production contract", () => {
     expect(text(reply).join("|")).not.toContain("春季世界王");
   });
 
-  it("shows cleared bosses without any action at all", () => {
+  it("shows cleared bosses with the board link but never an attack action", () => {
     const reply = WorldBoss.generateWorldBossReply({
       status: makeStatus({ cleared: [2, 5] }),
       liffUri: LIFF,
+      attackEnabled: true,
     });
-    expect(reply.contents[1]).toMatchObject({ type: "bubble" });
-    expect(reply.contents[1].footer.contents).toEqual(
-      expect.arrayContaining([expect.objectContaining({ text: "已擊破" })])
-    );
-    expect(actions(reply.contents[1])).toHaveLength(0);
-    expect(uriActions(reply.contents[1])).toHaveLength(0);
-    expect(uriActions(reply.contents[0])).toHaveLength(1);
+    const cleared = reply.contents[1];
+
+    expect(cleared).toMatchObject({ type: "bubble" });
+    expect(text(cleared)).toContain("✓ 討伐完成");
+    expect(actions(cleared)).toHaveLength(0);
+    // 已擊破仍保留戰況板入口，玩家才看得到後續戰況。
+    expect(uriActions(cleared)).toHaveLength(1);
+    expect(cleared.footer.contents).toHaveLength(1);
+    expect(cleared.footer.contents[0]).toMatchObject({ type: "box", borderWidth: "1px" });
+    // 已擊破卡不再顯示血條或百分比。
+    expect(percentNode(cleared)).toBeUndefined();
+    expect(text(cleared).some(value => value.startsWith("0 / "))).toBe(true);
+  });
+
+  it("wraps the lone board link in an outline box when attacking is disabled", () => {
+    const footer = bubbleFor({}, { attackEnabled: false }).footer;
+
+    expect(footer.contents).toHaveLength(1);
+    expect(footer.contents[0]).toMatchObject({
+      type: "box",
+      borderWidth: "1px",
+      borderColor: "#FFFFFF29",
+      cornerRadius: "6px",
+    });
+    expect(footer.contents[0].contents[0]).toMatchObject({ type: "button", style: "link" });
   });
 
   it("falls back to the no-season bubble instead of a reward bubble", () => {
@@ -171,6 +259,38 @@ describe("WorldBoss Flex production contract", () => {
     ).toContain("世界王賽季已結束");
   });
 
+  it("gives the no-season bubble a gradient rule and an outlined board link", () => {
+    const bubble = WorldBoss.generateNoActiveSeasonBubble({ ended: false, liffUri: LIFF });
+
+    expect(bubble).not.toHaveProperty("hero");
+    expect(bubble.body.contents[0]).toMatchObject({ height: "4px" });
+    expect(gradients(bubble.body.contents[0])[0]).toMatchObject({
+      angle: "90deg",
+      startColor: "#DC2626",
+      endColor: "#F59E0B",
+    });
+    expect(text(bubble)).toContain("敬請期待下一次全服討伐。");
+    expect(bubble.footer.contents[0]).toMatchObject({ type: "box", borderColor: "#FFFFFF29" });
+    expect(uriActions(bubble)).toHaveLength(1);
+  });
+
+  it("paints every surface dark so no bubble falls back to a white block", () => {
+    const reply = WorldBoss.generateWorldBossReply({
+      status: makeStatus({ image: httpsImage }),
+      liffUri: LIFF,
+      attackEnabled: true,
+    });
+
+    [...reply.contents, WorldBoss.generateNoActiveSeasonBubble({ liffUri: LIFF })].forEach(
+      bubble => {
+        expect(bubble.styles.body.backgroundColor).toBe("#131822");
+        expect(bubble.styles.footer.backgroundColor).toBe("#131822");
+        expect(bubble.body.backgroundColor).toBe("#131822");
+        expect(bubble.footer.backgroundColor).toBe("#131822");
+      }
+    );
+  });
+
   it("gives each bubble the hero image from its own snapshot url", () => {
     const reply = WorldBoss.generateWorldBossReply({
       status: makeStatus({ image: httpsImage }),
@@ -178,18 +298,47 @@ describe("WorldBoss Flex production contract", () => {
     });
 
     expect(reply.contents).toHaveLength(5);
-    expect(reply.contents.map(bubble => bubble.hero.url)).toEqual([1, 2, 3, 4, 5].map(httpsImage));
+    expect(reply.contents.map(bubble => images(bubble.hero)[0].url)).toEqual(
+      [1, 2, 3, 4, 5].map(httpsImage)
+    );
     reply.contents.forEach(bubble => {
-      expect(bubble.hero).toMatchObject({ type: "image", size: "full", aspectMode: "cover" });
+      expect(images(bubble.hero)[0]).toMatchObject({
+        type: "image",
+        size: "full",
+        aspectRatio: "20:13",
+        aspectMode: "cover",
+      });
     });
     // Position order still holds, so art and name never belong to different bosses.
     expect(reply.contents.map(bubble => text(bubble).find(value => value.includes("號")))).toEqual([
-      "第 3 輪 · 1 號 · 王1",
-      "第 3 輪 · 2 號 · 王2",
-      "第 3 輪 · 3 號 · 王3",
-      "第 3 輪 · 4 號 · 王4",
-      "第 3 輪 · 5 號 · 王5",
+      "第 3 輪 · 1 號",
+      "第 3 輪 · 2 號",
+      "第 3 輪 · 3 號",
+      "第 3 輪 · 4 號",
+      "第 3 輪 · 5 號",
     ]);
+  });
+
+  it("overlays the cycle label, boss name and a readability scrim on the hero art", () => {
+    const hero = bubbleFor().hero;
+    const overlays = hero.contents.slice(1);
+
+    expect(hero.contents[0].type).toBe("image");
+    expect(overlays.every(node => node.position === "absolute")).toBe(true);
+    expect(gradients(hero)[0]).toMatchObject({
+      angle: "0deg",
+      startColor: "#131822",
+      endColor: "#13182200",
+    });
+    expect(text(hero)).toEqual(expect.arrayContaining(["第 3 輪 · 1 號", "王1"]));
+    // 名稱是卡面上最大的一行字。
+    expect(nodesOfType(hero, "text").find(node => node.text === "王1")).toMatchObject({
+      size: "xl",
+      weight: "bold",
+      color: "#FFFFFF",
+    });
+    // 沒有 hero 時標題才會回到 body，有 hero 就不該重複。
+    expect(text(bubbleFor().body).filter(value => value === "王1")).toHaveLength(0);
   });
 
   it("keeps a cleared boss's art while dimming it, and leaves live bosses undimmed", () => {
@@ -200,11 +349,79 @@ describe("WorldBoss Flex production contract", () => {
     const clearedHero = reply.contents[1].hero;
 
     expect(images(clearedHero).map(image => image.url)).toEqual([httpsImage(2)]);
-    expect(clearedHero.contents.some(node => node.backgroundColor)).toBe(true);
+    expect(clearedHero.contents.some(node => node.backgroundColor === "#0A0F16D9")).toBe(true);
     // Flex images have no opacity property; the veil must be a real box.
     expect(images(clearedHero).every(image => image.opacity === undefined)).toBe(true);
+    expect(text(clearedHero)).toContain("已擊破");
     expect(actions(reply.contents[1])).toHaveLength(0);
-    expect(reply.contents[0].hero).toMatchObject({ type: "image", url: httpsImage(1) });
+
+    const liveHero = reply.contents[0].hero;
+    expect(liveHero.contents.some(node => node.backgroundColor === "#0A0F16D9")).toBe(false);
+    expect(text(liveHero)).not.toContain("已擊破");
+  });
+
+  it.each([
+    [100, "#4ADE80", "#15803D"],
+    [61, "#4ADE80", "#15803D"],
+    [60, "#FBBF24", "#B45309"],
+    [31, "#FBBF24", "#B45309"],
+    [30, "#FB7185", "#9F1239"],
+    [1, "#FB7185", "#9F1239"],
+  ])("colors the %s%% hp bar by tier", (percent, textColor, gradientFrom) => {
+    const bubble = bubbleFor({ max_hp: "100", current_hp: String(percent) });
+    const spans = percentNode(bubble).contents;
+
+    expect(spans.map(span => span.text)).toEqual([String(percent), "%"]);
+    expect(spans.map(span => [span.size, span.color])).toEqual([
+      ["3xl", textColor],
+      ["sm", textColor],
+    ]);
+    expect(gradients(bubble.body)[0]).toMatchObject({ angle: "90deg", startColor: gradientFrom });
+  });
+
+  it("keeps a sliver of hp bar visible for a boss that is nearly dead but still alive", () => {
+    const bubble = bubbleFor({ max_hp: "100000", current_hp: "1" });
+    const [track] = nodesOfType(bubble.body, "box").filter(node => node.height === "14px");
+
+    expect(percentNode(bubble).contents[0].text).toBe("0");
+    expect(track.contents[0].width).toBe("2%");
+    // 還活著就不能顯示已討伐完成。
+    expect(text(bubble)).not.toContain("✓ 討伐完成");
+    expect(nodesOfType(bubble.body, "box").find(node => node.width === "50%")).toBeUndefined();
+  });
+
+  it("computes the hp percentage with BigInt so string columns keep full precision", () => {
+    const bubble = bubbleFor({
+      max_hp: "10000000000000000001",
+      current_hp: "2500000000000000000",
+    });
+
+    expect(percentNode(bubble).contents[0].text).toBe("25");
+    expect(text(bubble)).toContain("2,500,000,000,000,000,000\n/ 10,000,000,000,000,000,001");
+  });
+
+  it("truncates an oversized boss description and drops an empty one", () => {
+    const long = "描".repeat(1000);
+    const bubble = bubbleFor({ description: long });
+    const description = nodesOfType(bubble.body, "text").find(node =>
+      node.text?.startsWith("描描")
+    );
+
+    expect(Buffer.byteLength(description.text, "utf8")).toBeLessThanOrEqual(2048);
+    expect(description.text.endsWith("…")).toBe(true);
+    expect(description).toMatchObject({ wrap: true, maxLines: 2, size: "xs", color: "#8A98AD" });
+
+    // 沒有描述時整個 text node 不能存在，否則會多出一塊空白。
+    const empty = bubbleFor({ description: "" });
+    expect(nodesOfType(empty.body, "text")).toHaveLength(2);
+  });
+
+  it("treats a cleared_at timestamp as cleared even when hp is above zero", () => {
+    const bubble = bubbleFor({ current_hp: "6000", cleared_at: new Date() });
+
+    expect(text(bubble)).toContain("✓ 討伐完成");
+    expect(percentNode(bubble)).toBeUndefined();
+    expect(actions(bubble)).toHaveLength(0);
   });
 
   it.each([
@@ -230,8 +447,8 @@ describe("WorldBoss Flex production contract", () => {
       expect(bubble).not.toHaveProperty("hero");
       expect(images(bubble)).toEqual([]);
     });
-    // The text card still renders in full, so nothing is lost by dropping the image.
-    expect(text(reply.contents[0]).some(value => value.includes("王1"))).toBe(true);
+    // 圖片被丟掉時，輪次與名稱必須退回 body，資訊不能跟著圖片一起消失。
+    expect(text(reply.contents[0])).toEqual(expect.arrayContaining(["第 3 輪 · 1 號", "王1"]));
   });
 
   it("renders a mixed roster where only some bosses have usable art", () => {
@@ -242,12 +459,20 @@ describe("WorldBoss Flex production contract", () => {
       liffUri: LIFF,
     });
 
-    expect(reply.contents.map(bubble => bubble.hero?.url)).toEqual([
+    expect(reply.contents.map(bubble => images(bubble)[0]?.url)).toEqual([
       httpsImage(1),
       undefined,
       httpsImage(3),
       undefined,
       httpsImage(5),
+    ]);
+    // 有圖沒圖的卡都必須讀得到名稱。
+    expect(reply.contents.map(bubble => text(bubble).find(value => /^王\d$/.test(value)))).toEqual([
+      "王1",
+      "王2",
+      "王3",
+      "王4",
+      "王5",
     ]);
   });
 
@@ -255,6 +480,7 @@ describe("WorldBoss Flex production contract", () => {
     const reply = WorldBoss.generateWorldBossReply({
       status: makeStatus({ image: position => `${httpsImage(position)}?${"v".repeat(200)}` }),
       liffUri: LIFF,
+      attackEnabled: true,
     });
 
     expect(reply.type).toBe("carousel");
@@ -264,6 +490,42 @@ describe("WorldBoss Flex production contract", () => {
     // Every image node must be a well-formed https url, or LINE rejects the message.
     images(reply).forEach(image => {
       expect(new URL(image.url).protocol).toBe("https:");
+    });
+  });
+
+  it("uses only components and layouts that LINE Flex actually supports", () => {
+    const payloads = [
+      WorldBoss.generateWorldBossReply({
+        status: makeStatus({ cleared: [3], image: httpsImage }),
+        liffUri: LIFF,
+        attackEnabled: true,
+      }),
+      WorldBoss.generateNoActiveSeasonBubble({ ended: true, liffUri: LIFF }),
+    ];
+    const allowed = ["box", "text", "image", "button", "separator", "filler", "span", "icon"];
+
+    nodesOfType(payloads, "box").forEach(box => {
+      expect(["vertical", "horizontal", "baseline"]).toContain(box.layout);
+      expect(Array.isArray(box.contents)).toBe(true);
+      box.contents.forEach(child => expect(allowed).toContain(child.type));
+      if (box.position === "absolute") expect(box.width).not.toBe("");
+    });
+    nodesOfType(payloads, "button").forEach(button => {
+      expect(["primary", "secondary", "link"]).toContain(button.style);
+      expect(["sm", "md"]).toContain(button.height);
+      expect(button.action.type === "postback" || button.action.type === "uri").toBe(true);
+    });
+    // span 只能掛在 text.contents 底下，而且 text 不能同時給 text 與 contents。
+    nodesOfType(payloads, "text").forEach(node => {
+      if (node.contents) {
+        expect(node.text).toBeUndefined();
+        node.contents.forEach(span => expect(span.type).toBe("span"));
+      }
+    });
+    gradients(payloads).forEach(gradient => {
+      expect(gradient.angle).toMatch(/^\d+deg$/);
+      expect(gradient.startColor).toMatch(/^#[0-9A-Fa-f]{6,8}$/);
+      expect(gradient.endColor).toMatch(/^#[0-9A-Fa-f]{6,8}$/);
     });
   });
 });


### PR DESCRIPTION
## 背景

現況的世界王卡片有幾個問題：紅色 header 佔掉整張卡最強的視覺權重，內容卻只有「討伐中」三個字；三顆一模一樣的紅按鈕分不出主次；輪次、編號、名稱擠在同一行 lg 文字裡，Boss 名稱沒被凸顯；8px 的 HP bar 太細看不出剩多少。

先在 Open Design 出了兩個方向的 mockup，選定方向 A「深色戰報卡」實作。

## 改了什麼

**版面**
- 移除紅色 header 色塊。輪次與編號縮成左上角 `#000000A6` 小標籤，Boss 名稱以 `xl` 壓在圖片下緣的 `linearGradient` 漸層上，成為卡面最大的一行字
- 賽季名稱一併移除 — carousel 五張卡同賽季，重複五次佔掉最大字級卻是最沒資訊量的一行

**HP 呈現**
- 改用 `3xl` 大數字百分比當視覺重心（單一 text + 兩個 span：數字 `3xl` bold、`%` `sm`），右側對齊實際數值
- 血條從 8px 加粗到 14px，用 `linearGradient` angle 90deg，顏色隨血量分級：>60% 綠、>30% 琥珀、其餘玫瑰紅

**已擊破**
- 遮罩從白色 `#FFFFFFB3` 改為深色 `#0A0F16D9`，中央加綠框「已擊破」印章
- body 的 HP 區塊換成「✓ 討伐完成」面板

**按鈕層級**
- 攻擊：primary `#DC2626`，`flex: 3`
- 技能：primary `#273246`，`flex: 2`
- 開啟戰況板：`link` style
- 不可攻擊與已擊破時，戰況板按鈕包在 `borderWidth: 1px` 的 outline box 裡保留下來（現況已擊破時完全沒有按鈕，玩家進不了 LIFF）

**無賽季卡**
- 頂部加一條 4px 的紅→琥珀漸層裝飾條，整體改為深色卡面

## 沒有改的部分

資料介面完全不動。三個 export function 簽名維持原狀，controller / service / model / migration / frontend 都沒碰。

所有既有防護邏輯原樣保留並有測試覆蓋：
- image URL 驗證（非 HTTPS / 超長 / 無法解析時丟棄 hero）
- description UTF-8 2048 bytes 截斷
- BigInt 計算 HP 百分比（`max_hp` / `current_hp` 從 driver 可能是 string）
- 五王數量 guard 與 `position` 排序
- 卡片不含任何玩家個人資料（群組公開訊息原則）

## 新增的 fallback

圖片 URL 不合法而丟棄 hero 時，輪次標籤與 Boss 名稱本來壓在圖上會一起消失，現在改由 body 頂端承接，否則那張卡完全認不出是哪隻王。

## 因 LINE Flex 限制偏離 mockup 之處

| mockup | 實作 |
|---|---|
| `line-clamp: 2` 漸隱 | `maxLines: 2` 直接截斷，無省略號 |
| `justify-content: space-between` | 左側 `flex: 0` + 右側 `flex: 1` 搭 `align: end` |
| `<br>` 換行 | `\n` 搭 `wrap: true` |
| 等寬字型數字 | Flex 不能自訂字型，用預設字型 |
| `gap: 6px` | 只能用關鍵字，血條用 `margin: md`（8px）近似 |

## 驗證

- `yarn test -- src/templates/application/__tests__/WorldBoss.test.js` → 37 passed（原 20 個，補了已擊破 footer、血量分級配色、hero fallback 等新分支）
- WorldBoss 相關 11 個 suite 全過 → 339 passed
- ESLint + Prettier clean
- 輸出的 JSON 逐屬性比對過 `@line/bot-sdk@9.9.0` 的 type definitions，確認 `text.maxLines`、`span`、`button.flex`、`styles.body/footer.backgroundColor`、`box.borderWidth` 搭 `position: absolute`、`linearGradient` 都真實存在且值合法

## 建議的人工驗證

合併前建議用 `make cf-go` 開 tunnel，在實機群組打 `#世界王` 看一次，重點確認深色卡面在 LINE 淺色與深色模式下的對比，以及 `flex: 3 / 2` 的按鈕比例在窄螢幕上的實際表現。