### PR TITLE
feat(worldboss): 職業分工機制與計分模型重構

### DIFF
--- a/app/migrations/20260829211941_add_world_boss_score_and_effect_tables.js
+++ b/app/migrations/20260829211941_add_world_boss_score_and_effect_tables.js
@@ -1,0 +1,122 @@
+// NOT EXISTS makes the legacy backfill idempotent. Re-run it after deployment if
+// contributions arrive during the migration-to-release gap.
+const BACKFILL_LEGACY_DIRECT_SQL = `
+INSERT INTO world_boss_score_event
+  (season_id, round_id, contribution_id, effect_id, beneficiary_user_id, kind, points, created_at, updated_at)
+SELECT c.season_id, c.round_id, c.id, NULL, c.user_id, 'direct', c.damage, c.created_at, c.updated_at
+FROM world_boss_contribution c
+WHERE c.damage > 0
+  AND NOT EXISTS (
+    SELECT 1 FROM world_boss_score_event e
+    WHERE e.contribution_id = c.id
+      AND e.kind = 'direct'
+      AND e.beneficiary_user_id = c.user_id
+  );
+`;
+
+exports.BACKFILL_LEGACY_DIRECT_SQL = BACKFILL_LEGACY_DIRECT_SQL;
+
+exports.up = async knex => {
+  await knex.schema.alterTable("world_boss_contribution", table => {
+    table.bigInteger("raw_damage").unsigned().nullable();
+    table.bigInteger("effect_damage").unsigned().notNullable().defaultTo(0);
+    table.string("job_key", 32).nullable();
+  });
+  await knex.schema.alterTable("world_boss_season_reward", table => {
+    table.bigInteger("total_score").unsigned().nullable();
+  });
+
+  await knex.schema.createTable("world_boss_round_effect", table => {
+    table.bigIncrements("id").primary();
+    table.bigInteger("season_id").unsigned().notNullable();
+    table.bigInteger("round_id").unsigned().notNullable();
+    table.bigInteger("source_contribution_id").unsigned().notNullable();
+    table.string("source_user_id", 33).notNullable();
+    table.string("effect_type", 16).notNullable();
+    table.bigInteger("value").unsigned().notNullable();
+    table.bigInteger("consumed_by_contribution_id").unsigned().nullable();
+    table.timestamps(true, true);
+    table.unique(["source_contribution_id"], "uq_wbre_source_contribution");
+    table.unique(["consumed_by_contribution_id"], "uq_wbre_consumed_contribution");
+    table.index(["round_id", "consumed_by_contribution_id", "id"], "idx_wbre_round_consumed_id");
+    table.index(["season_id", "source_user_id"], "idx_wbre_season_source_user");
+    table
+      .foreign("season_id", "fk_wbre_season")
+      .references("id")
+      .inTable("world_boss_season")
+      .onDelete("RESTRICT");
+    table
+      .foreign("round_id", "fk_wbre_round")
+      .references("id")
+      .inTable("world_boss_round")
+      .onDelete("RESTRICT");
+    table
+      .foreign("source_contribution_id", "fk_wbre_source_contribution")
+      .references("id")
+      .inTable("world_boss_contribution")
+      .onDelete("RESTRICT");
+    table
+      .foreign("consumed_by_contribution_id", "fk_wbre_consumed_contribution")
+      .references("id")
+      .inTable("world_boss_contribution")
+      .onDelete("RESTRICT");
+    table.check("?? > 0", ["value"], "chk_wbre_value_positive");
+  });
+
+  await knex.schema.createTable("world_boss_score_event", table => {
+    table.bigIncrements("id").primary();
+    table.bigInteger("season_id").unsigned().notNullable();
+    table.bigInteger("round_id").unsigned().notNullable();
+    table.bigInteger("contribution_id").unsigned().notNullable();
+    table.bigInteger("effect_id").unsigned().nullable();
+    table.string("beneficiary_user_id", 33).notNullable();
+    table.string("kind", 16).notNullable();
+    table.bigInteger("points").unsigned().notNullable();
+    table.timestamps(true, true);
+    table.unique(
+      ["contribution_id", "kind", "beneficiary_user_id"],
+      "uq_wbse_contribution_kind_user"
+    );
+    table.unique(["effect_id", "kind", "beneficiary_user_id"], "uq_wbse_effect_kind_user");
+    table.index(["season_id", "beneficiary_user_id"], "idx_wbse_season_beneficiary");
+    table.index(["round_id"], "idx_wbse_round");
+    table.index(["contribution_id"], "idx_wbse_contribution");
+    table
+      .foreign("season_id", "fk_wbse_season")
+      .references("id")
+      .inTable("world_boss_season")
+      .onDelete("RESTRICT");
+    table
+      .foreign("round_id", "fk_wbse_round")
+      .references("id")
+      .inTable("world_boss_round")
+      .onDelete("RESTRICT");
+    table
+      .foreign("contribution_id", "fk_wbse_contribution")
+      .references("id")
+      .inTable("world_boss_contribution")
+      .onDelete("RESTRICT");
+    table
+      .foreign("effect_id", "fk_wbse_effect")
+      .references("id")
+      .inTable("world_boss_round_effect")
+      .onDelete("RESTRICT");
+    table.check("?? > 0", ["points"], "chk_wbse_points_positive");
+  });
+
+  await knex.raw(BACKFILL_LEGACY_DIRECT_SQL);
+};
+
+exports.down = async knex => {
+  // Do not run in production after v2 data exists; local round-trip tests only.
+  await knex.schema.dropTableIfExists("world_boss_score_event");
+  await knex.schema.dropTableIfExists("world_boss_round_effect");
+  await knex.schema.alterTable("world_boss_season_reward", table => {
+    table.dropColumn("total_score");
+  });
+  await knex.schema.alterTable("world_boss_contribution", table => {
+    table.dropColumn("raw_damage");
+    table.dropColumn("effect_damage");
+    table.dropColumn("job_key");
+  });
+};

--- a/app/src/__tests__/helpers/worldBossFixture.js
+++ b/app/src/__tests__/helpers/worldBossFixture.js
@@ -118,6 +118,8 @@ function whereLiteralPrefix(query, column, prefix) {
 
 async function deleteSeasonTree(mysql, ids) {
   if (!ids.length) return;
+  await mysql("world_boss_score_event").whereIn("season_id", ids).del();
+  await mysql("world_boss_round_effect").whereIn("season_id", ids).del();
   await mysql("world_boss_season_reward").whereIn("season_id", ids).del();
   await mysql("world_boss_contribution").whereIn("season_id", ids).del();
   const roster = await mysql("world_boss_season_boss").whereIn("season_id", ids).select("id");

--- a/app/src/handler/WorldBoss/__tests__/handlers.test.js
+++ b/app/src/handler/WorldBoss/__tests__/handlers.test.js
@@ -12,17 +12,23 @@ jest.mock("../../../service/WorldBossSeasonService", () => ({
   openSeason: jest.fn(),
   getBattleStatus: jest.fn(),
   getRanking: jest.fn(),
-  getUserTotalDamage: jest.fn(),
+  getUserSeasonStats: jest.fn(),
   getLatestSettledResult: jest.fn(),
 }));
 jest.mock("../../../service/WorldBossBattleService", () => ({
   getRemainingDailyCost: jest.fn(),
 }));
 jest.mock("../../../service/WorldBossAttackService", () => ({ attack: jest.fn() }));
+jest.mock("../../../model/application/WorldBossRoundEffect", () => ({
+  listSeasonHistoryBySource: jest.fn(),
+}));
+jest.mock("../../../model/application/UserModel", () => ({ getDisplayNames: jest.fn() }));
 const CatalogService = require("../../../service/WorldBossCatalogService");
 const SeasonService = require("../../../service/WorldBossSeasonService");
 const BattleService = require("../../../service/WorldBossBattleService");
 const AttackService = require("../../../service/WorldBossAttackService");
+const WorldBossRoundEffect = require("../../../model/application/WorldBossRoundEffect");
+const UserModel = require("../../../model/application/UserModel");
 const express = require("express");
 const supertest = require("supertest");
 const admin = require("../admin");
@@ -93,6 +99,7 @@ const latestReward = {
   seasonId: 7,
   seasonName: "S1",
   ranking: 1,
+  totalScore: "1200",
   totalDamage: "500",
   stoneAmount: 100,
   titleKey: "worldboss_annihilator",
@@ -101,20 +108,61 @@ const latestReward = {
   settledAt: new Date("2026-07-19T12:00:00.000Z"),
 };
 
+// Mirrors WorldBossSeasonService.getUserSeasonStats after Lane D: score and damage are
+// two separate ledgers, every BIGINT is a decimal string.
+const seasonStats = {
+  seasonId: "8",
+  totalScore: "700",
+  score: { direct: "500", assist: "150", relay: "50" },
+  damage: { raw: "500", effect: "100", effective: "550", overkill: "50" },
+};
+
+// Mirrors the BattleService attack DTO after Lane C. `damage` / `wastedDamage` are gone;
+// keeping them here is what made the old handler test green against a dead field.
 const attackResult = {
-  damage: 500,
-  effectiveDamage: "100",
-  wastedDamage: "400",
+  rawDamage: "500",
+  effectDamage: "100",
+  effectiveDamage: "400",
+  overkillDamage: "200",
+  scoreGained: { direct: "500", assist: "100", relay: "0" },
+  consumedEffect: { id: "31", type: "seal", value: "100", sourceUserId: "Usource" },
+  createdEffect: { id: "32", type: "banner", value: "125", sourceUserId: "Uworldboss" },
   cost: 15,
   cleared: true,
   cycleAdvanced: false,
   attackedCycleNo: 3,
   cycleNo: 3,
+  round: { id: 21, position: 2, current_hp: "0", max_hp: "400" },
   boss: { id: 2, position: 2, name: "王2" },
+  rounds: status.rounds,
   levelResult: { levelUp: true, newLevel: 9, newExp: 3 },
-  seasonTotalDamage: "9007199254740993",
+  seasonTotalScore: "9007199254740993",
+  seasonTotalDamage: "9007199254740991",
   daily: { limit: 100, used: 35, remaining: 65 },
 };
+
+const effectHistoryRows = [
+  {
+    id: "31",
+    round_id: "21",
+    effect_type: "seal",
+    value: "100",
+    created_at: new Date("2026-07-20T02:00:00.000Z"),
+    consumed_by_user_id: "Utaker",
+    consumed_at: new Date("2026-07-20T02:05:00.000Z"),
+  },
+  {
+    id: "30",
+    round_id: "20",
+    effect_type: "banner",
+    value: "25",
+    created_at: new Date("2026-07-20T01:30:00.000Z"),
+    consumed_by_user_id: null,
+    consumed_at: null,
+  },
+];
+
+const displayNames = { Utaker: "接棒者", Usource: "留效果的人" };
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -129,11 +177,20 @@ beforeEach(() => {
   SeasonService.openSeason.mockResolvedValue({ seasonId: 8, cycleNo: 3, rounds: status.rounds });
   SeasonService.getBattleStatus.mockResolvedValue(status);
   SeasonService.getRanking.mockResolvedValue([
-    { user_id: "Uone", total_damage: "500", ranking: 1 },
+    { user_id: "Uone", display_name: "玩家甲", total_score: "500", ranking: 1 },
   ]);
   SeasonService.getLatestSettledResult.mockResolvedValue(latestReward);
   BattleService.getRemainingDailyCost.mockResolvedValue({ limit: 100, used: 20, remaining: 80 });
-  SeasonService.getUserTotalDamage.mockResolvedValue("500");
+  SeasonService.getUserSeasonStats.mockResolvedValue(seasonStats);
+  WorldBossRoundEffect.listSeasonHistoryBySource.mockResolvedValue(effectHistoryRows);
+  UserModel.getDisplayNames.mockImplementation(
+    async ids =>
+      new Map(
+        [...new Set(ids)]
+          .filter(id => Object.hasOwn(displayNames, id))
+          .map(id => [id, displayNames[id]])
+      )
+  );
   AttackService.attack.mockResolvedValue({
     result: attackResult,
     announcementQueued: true,
@@ -440,13 +497,37 @@ describe("World Boss public handlers", () => {
     expect(SeasonService.getRanking).toHaveBeenCalledWith("8", expected);
     expect(res.json).toHaveBeenCalledWith({
       seasonId: "8",
-      rows: [{ user_id: "Uone", total_damage: "500", ranking: 1 }],
+      rows: [{ user_id: "Uone", display_name: "玩家甲", total_score: "500", ranking: 1 }],
     });
   });
 
-  it("passes display_name through in the leaderboard DTO", async () => {
+  it("ranks the leaderboard by total_score and never exposes total_damage", async () => {
+    // Guards the exact false-green Lane D found: the service stopped producing
+    // `total_damage`, but the handler forwarded rows verbatim, so the test stayed green
+    // while the board rendered blanks. A stray damage column must not survive the DTO.
     SeasonService.getRanking.mockResolvedValue([
-      { user_id: "Uone", display_name: "玩家甲", total_damage: "500", ranking: 1 },
+      {
+        user_id: "Uone",
+        display_name: "玩家甲",
+        total_score: "900",
+        ranking: 1,
+        total_damage: "7",
+      },
+    ]);
+    const res = response();
+
+    await publicHandler.leaderboard(request(), res);
+
+    const [payload] = res.json.mock.calls[0];
+    expect(payload.rows).toEqual([
+      { user_id: "Uone", display_name: "玩家甲", total_score: "900", ranking: 1 },
+    ]);
+    expect(Object.keys(payload.rows[0])).not.toContain("total_damage");
+  });
+
+  it("defaults a missing leaderboard display_name to null", async () => {
+    SeasonService.getRanking.mockResolvedValue([
+      { user_id: "Uone", display_name: null, total_score: "500", ranking: 1 },
     ]);
     const res = response();
 
@@ -454,7 +535,7 @@ describe("World Boss public handlers", () => {
 
     expect(res.json).toHaveBeenCalledWith({
       seasonId: "8",
-      rows: [{ user_id: "Uone", display_name: "玩家甲", total_damage: "500", ranking: 1 }],
+      rows: [{ user_id: "Uone", display_name: null, total_score: "500", ranking: 1 }],
     });
   });
 
@@ -488,8 +569,9 @@ describe("World Boss public handlers", () => {
     await publicHandler.me(request({ userId: "Ume" }), res);
 
     expect(SeasonService.getLatestSettledResult).toHaveBeenCalledWith("Ume");
-    expect(SeasonService.getUserTotalDamage).not.toHaveBeenCalled();
+    expect(SeasonService.getUserSeasonStats).not.toHaveBeenCalled();
     expect(BattleService.getRemainingDailyCost).not.toHaveBeenCalled();
+    expect(WorldBossRoundEffect.listSeasonHistoryBySource).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith({
       current: null,
       latestReward: {
@@ -507,45 +589,165 @@ describe("World Boss public handlers", () => {
     expect(SeasonService.getRanking).toHaveBeenCalledWith("8", 50);
     expect(leaderboardRes.json).toHaveBeenCalledWith({
       seasonId: "8",
-      rows: [{ user_id: "Uone", total_damage: "500", ranking: 1 }],
+      rows: [{ user_id: "Uone", display_name: "玩家甲", total_score: "500", ranking: 1 }],
     });
 
     const meRes = response();
     await publicHandler.me(request({ userId: "Ume" }), meRes);
-    expect(SeasonService.getUserTotalDamage).toHaveBeenCalledWith("8", "Ume");
+    expect(SeasonService.getUserSeasonStats).toHaveBeenCalledWith("8", "Ume");
     expect(meRes.json.mock.calls[0][0].current).toMatchObject({
       seasonId: "8",
-      totalDamage: "500",
+      totalScore: "700",
     });
   });
 
-  it("returns exact current damage outside the top 100 and latest reward independently", async () => {
-    SeasonService.getRanking.mockResolvedValue(
-      Array.from({ length: 100 }, (_, index) => ({
-        user_id: `Uranked${index + 1}`,
-        total_damage: 1000 - index,
-        ranking: index + 1,
-      }))
-    );
-    SeasonService.getUserTotalDamage.mockResolvedValue("500");
+  it("returns the full score breakdown and damage stats for the caller", async () => {
     const res = response();
 
     await publicHandler.me(request({ userId: "Ume" }), res);
 
     expect(SeasonService.getRanking).not.toHaveBeenCalled();
-    expect(SeasonService.getUserTotalDamage).toHaveBeenCalledWith("8", "Ume");
+    expect(SeasonService.getUserSeasonStats).toHaveBeenCalledWith("8", "Ume");
     expect(BattleService.getRemainingDailyCost).toHaveBeenCalledWith("Ume");
-    expect(res.json.mock.calls[0][0]).toEqual({
-      current: {
-        seasonId: "8",
-        totalDamage: "500",
-        daily: { limit: 100, used: 20, remaining: 80 },
+    expect(res.json.mock.calls[0][0].current).toEqual({
+      seasonId: "8",
+      totalScore: "700",
+      score: { direct: "500", assist: "150", relay: "50" },
+      damage: { raw: "500", effect: "100", effective: "550", overkill: "50" },
+      daily: { limit: 100, used: 20, remaining: 80 },
+      effects: [
+        {
+          effectId: "31",
+          type: "seal",
+          value: "100",
+          roundId: "21",
+          createdAt: "2026-07-20T02:00:00.000Z",
+          consumedAt: "2026-07-20T02:05:00.000Z",
+          consumedBy: { userId: "Utaker", displayName: "接棒者" },
+        },
+        {
+          effectId: "30",
+          type: "banner",
+          value: "25",
+          roundId: "20",
+          createdAt: "2026-07-20T01:30:00.000Z",
+          consumedAt: null,
+          consumedBy: null,
+        },
+      ],
+    });
+    expect(res.json.mock.calls[0][0].latestReward).toMatchObject({
+      totalScore: "1200",
+      totalDamage: "500",
+    });
+  });
+
+  it("reads its subject only from the authenticated profile", async () => {
+    const res = response();
+
+    // Every possible way to name a different subject: body, params and query.
+    await publicHandler.me(
+      {
+        body: { userId: "Uvictim" },
+        params: { userId: "Uvictim" },
+        query: { userId: "Uvictim", user_id: "Uvictim" },
+        profile: { userId: "Ureal" },
       },
-      latestReward: {
-        ...latestReward,
-        paidAt: "2026-07-19T12:00:00.000Z",
-        settledAt: "2026-07-19T12:00:00.000Z",
+      res
+    );
+
+    expect(SeasonService.getLatestSettledResult).toHaveBeenCalledWith("Ureal");
+    expect(SeasonService.getUserSeasonStats).toHaveBeenCalledWith("8", "Ureal");
+    expect(BattleService.getRemainingDailyCost).toHaveBeenCalledWith("Ureal");
+    expect(WorldBossRoundEffect.listSeasonHistoryBySource).toHaveBeenCalledWith({
+      seasonId: "8",
+      userId: "Ureal",
+      limit: 50,
+    });
+    for (const call of [
+      ...SeasonService.getUserSeasonStats.mock.calls,
+      ...SeasonService.getLatestSettledResult.mock.calls,
+      ...WorldBossRoundEffect.listSeasonHistoryBySource.mock.calls,
+    ]) {
+      expect(JSON.stringify(call)).not.toContain("Uvictim");
+    }
+  });
+
+  it("tolerates a v1 latestReward whose totalScore is null", async () => {
+    SeasonService.getLatestSettledResult.mockResolvedValue({ ...latestReward, totalScore: null });
+    const res = response();
+
+    await publicHandler.me(request({ userId: "Ume" }), res);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].latestReward).toMatchObject({
+      totalScore: null,
+      totalDamage: "500",
+    });
+    expect(() => JSON.stringify(res.json.mock.calls[0][0])).not.toThrow();
+  });
+
+  it("caps effect history at the newest 50 rows and never queries names per row", async () => {
+    const rows = Array.from({ length: 50 }, (_, index) => ({
+      id: String(500 - index),
+      round_id: "21",
+      effect_type: index % 2 ? "banner" : "seal",
+      value: "10",
+      created_at: new Date("2026-07-20T02:00:00.000Z"),
+      consumed_by_user_id: index % 2 ? "Utaker" : null,
+      consumed_at: index % 2 ? new Date("2026-07-20T02:05:00.000Z") : null,
+    }));
+    WorldBossRoundEffect.listSeasonHistoryBySource.mockResolvedValue(rows);
+    const res = response();
+
+    await publicHandler.me(request({ userId: "Ume" }), res);
+
+    expect(WorldBossRoundEffect.listSeasonHistoryBySource).toHaveBeenCalledTimes(1);
+    expect(WorldBossRoundEffect.listSeasonHistoryBySource).toHaveBeenCalledWith({
+      seasonId: "8",
+      userId: "Ume",
+      limit: 50,
+    });
+    // One batched name lookup for 25 consumers — not one per row.
+    expect(UserModel.getDisplayNames).toHaveBeenCalledTimes(1);
+    expect(UserModel.getDisplayNames).toHaveBeenCalledWith(new Array(25).fill("Utaker"));
+    const { effects } = res.json.mock.calls[0][0].current;
+    expect(effects).toHaveLength(50);
+    expect(effects.map(row => row.effectId)).toEqual(rows.map(row => String(row.id)));
+    expect(effects[0].effectId).toBe("500");
+    expect(effects.at(-1).effectId).toBe("451");
+  });
+
+  it("returns an empty effect history without any name lookup", async () => {
+    WorldBossRoundEffect.listSeasonHistoryBySource.mockResolvedValue([]);
+    const res = response();
+
+    await publicHandler.me(request({ userId: "Ume" }), res);
+
+    expect(res.json.mock.calls[0][0].current.effects).toEqual([]);
+    expect(UserModel.getDisplayNames).toHaveBeenCalledWith([]);
+    expect(UserModel.getDisplayNames).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps consumedBy.displayName null when the consumer has no stored profile", async () => {
+    WorldBossRoundEffect.listSeasonHistoryBySource.mockResolvedValue([
+      {
+        id: "31",
+        round_id: "21",
+        effect_type: "banner",
+        value: "25",
+        created_at: new Date("2026-07-20T02:00:00.000Z"),
+        consumed_by_user_id: "Unameless",
+        consumed_at: new Date("2026-07-20T02:05:00.000Z"),
       },
+    ]);
+    const res = response();
+
+    await publicHandler.me(request({ userId: "Ume" }), res);
+
+    expect(res.json.mock.calls[0][0].current.effects[0].consumedBy).toEqual({
+      userId: "Unameless",
+      displayName: null,
     });
   });
 
@@ -555,36 +757,51 @@ describe("World Boss public handlers", () => {
       ...status,
       season: { ...status.season, id: exactSeasonId },
     });
+    SeasonService.getUserSeasonStats.mockResolvedValue({
+      ...seasonStats,
+      seasonId: exactSeasonId,
+    });
     const leaderboardRes = response();
 
     await publicHandler.leaderboard(request(), leaderboardRes);
     expect(SeasonService.getRanking).toHaveBeenCalledWith(exactSeasonId, 50);
     expect(leaderboardRes.json).toHaveBeenCalledWith({
       seasonId: exactSeasonId,
-      rows: [{ user_id: "Uone", total_damage: "500", ranking: 1 }],
+      rows: [{ user_id: "Uone", display_name: "玩家甲", total_score: "500", ranking: 1 }],
     });
 
     const meRes = response();
     await publicHandler.me(request({ userId: "Uexact" }), meRes);
-    expect(SeasonService.getUserTotalDamage).toHaveBeenCalledWith(exactSeasonId, "Uexact");
+    expect(SeasonService.getUserSeasonStats).toHaveBeenCalledWith(exactSeasonId, "Uexact");
     expect(meRes.json.mock.calls[0][0].current).toMatchObject({ seasonId: exactSeasonId });
   });
 
-  it("serializes exact ids and damage strings without JSON BigInt", async () => {
+  it("serializes exact ids, scores and damage as strings without JSON BigInt", async () => {
     const seasonId = "9007199254740993";
     SeasonService.getBattleStatus.mockResolvedValue({
       ...status,
       season: { ...status.season, id: seasonId },
     });
     SeasonService.getRanking.mockResolvedValue([
-      { user_id: "Uexact", total_damage: "9007199254740993", ranking: 1 },
-      { user_id: "Ulower", total_damage: "9007199254740992", ranking: 2 },
+      { user_id: "Uexact", display_name: null, total_score: "9007199254740993", ranking: 1 },
+      { user_id: "Ulower", display_name: null, total_score: "9007199254740992", ranking: 2 },
     ]);
-    SeasonService.getUserTotalDamage.mockResolvedValue("9007199254740993");
+    SeasonService.getUserSeasonStats.mockResolvedValue({
+      seasonId,
+      totalScore: "9007199254740993",
+      score: { direct: "9007199254740991", assist: "1", relay: "1" },
+      damage: {
+        raw: "9007199254740993",
+        effect: "9007199254740994",
+        effective: "9007199254740995",
+        overkill: "9007199254740992",
+      },
+    });
     SeasonService.getLatestSettledResult.mockResolvedValue({
       ...latestReward,
       seasonId,
-      totalDamage: "9007199254740993",
+      totalScore: "9007199254740993",
+      totalDamage: "9007199254740991",
     });
 
     const leaderboardRes = response();
@@ -593,19 +810,34 @@ describe("World Boss public handlers", () => {
     expect(leaderboardRes.json).toHaveBeenCalledWith({
       seasonId,
       rows: [
-        { user_id: "Uexact", total_damage: "9007199254740993", ranking: 1 },
-        { user_id: "Ulower", total_damage: "9007199254740992", ranking: 2 },
+        { user_id: "Uexact", display_name: null, total_score: "9007199254740993", ranking: 1 },
+        { user_id: "Ulower", display_name: null, total_score: "9007199254740992", ranking: 2 },
       ],
     });
 
     const meRes = response();
     await publicHandler.me(request({ userId: "Uexact" }), meRes);
-    expect(SeasonService.getUserTotalDamage).toHaveBeenCalledWith(seasonId, "Uexact");
-    expect(meRes.json.mock.calls[0][0]).toMatchObject({
-      current: { seasonId, totalDamage: "9007199254740993" },
-      latestReward: { seasonId, totalDamage: "9007199254740993" },
+    const [payload] = meRes.json.mock.calls[0];
+    expect(payload).toMatchObject({
+      current: {
+        seasonId,
+        totalScore: "9007199254740993",
+        damage: { effective: "9007199254740995" },
+      },
+      latestReward: { seasonId, totalScore: "9007199254740993", totalDamage: "9007199254740991" },
     });
-    expect(() => JSON.stringify(meRes.json.mock.calls[0][0])).not.toThrow();
+    // Every BIGINT-bearing field must be a string, or JSON.parse would round it.
+    for (const value of [
+      payload.current.totalScore,
+      ...Object.values(payload.current.score),
+      ...Object.values(payload.current.damage),
+      payload.latestReward.totalScore,
+      payload.latestReward.totalDamage,
+      ...leaderboardRes.json.mock.calls[0][0].rows.map(row => row.total_score),
+    ]) {
+      expect(typeof value).toBe("string");
+    }
+    expect(() => JSON.stringify(payload)).not.toThrow();
   });
 
   it("maps service validation errors and unexpected failures centrally", async () => {
@@ -714,17 +946,30 @@ describe("World Boss attack handler", () => {
       attack: {
         roundId: "21",
         attackType: "standard",
-        damage: 500,
-        effectiveDamage: "100",
-        wastedDamage: "400",
+        rawDamage: "500",
+        effectDamage: "100",
+        effectiveDamage: "400",
+        overkillDamage: "200",
+        scoreGained: { direct: "500", assist: "100", relay: "0" },
+        consumedEffect: {
+          id: "31",
+          type: "seal",
+          value: "100",
+          sourceUserId: "Usource",
+          sourceDisplayName: "留效果的人",
+        },
+        createdEffect: { id: "32", type: "banner", value: "125", sourceUserId: "Uworldboss" },
         cost: 15,
         cleared: true,
         cycleAdvanced: false,
         attackedCycleNo: 3,
         cycleNo: 3,
+        round: { id: 21, position: 2, current_hp: "0", max_hp: "400" },
         boss: { id: 2, position: 2, name: "王2" },
+        rounds: expect.any(Array),
         levelResult: { levelUp: true, newLevel: 9, newExp: 3 },
-        seasonTotalDamage: "9007199254740993",
+        seasonTotalScore: "9007199254740993",
+        seasonTotalDamage: "9007199254740991",
         daily: { limit: 100, used: 35, remaining: 65 },
       },
       announcementQueued: true,
@@ -732,6 +977,115 @@ describe("World Boss attack handler", () => {
       status: expect.objectContaining({ season: expect.any(Object) }),
     });
     expect(() => JSON.stringify(res.json.mock.calls[0][0])).not.toThrow();
+  });
+
+  it("keeps the three damage layers consistent and BIGINT-exact as strings", async () => {
+    // raw + effect - effective === overkill, at magnitudes a JS number would round.
+    AttackService.attack.mockResolvedValue({
+      result: {
+        ...attackResult,
+        rawDamage: "9007199254740993",
+        effectDamage: "9007199254740993",
+        effectiveDamage: "9007199254740991",
+        overkillDamage: "9007199254740995",
+        seasonTotalScore: "18014398509481986",
+        seasonTotalDamage: "9007199254740991",
+      },
+      announcementQueued: false,
+      latestReward: null,
+    });
+    const res = response();
+
+    await publicHandler.attack(request({ body }), res);
+
+    const { attack } = res.json.mock.calls[0][0];
+    for (const field of [
+      "rawDamage",
+      "effectDamage",
+      "effectiveDamage",
+      "overkillDamage",
+      "seasonTotalScore",
+      "seasonTotalDamage",
+    ]) {
+      expect(typeof attack[field]).toBe("string");
+    }
+    expect(
+      BigInt(attack.rawDamage) + BigInt(attack.effectDamage) - BigInt(attack.effectiveDamage)
+    ).toBe(BigInt(attack.overkillDamage));
+    expect(JSON.parse(JSON.stringify(attack)).seasonTotalScore).toBe("18014398509481986");
+  });
+
+  it("forwards each scoreGained kind and each effect slot verbatim when null", async () => {
+    AttackService.attack.mockResolvedValue({
+      result: {
+        ...attackResult,
+        scoreGained: { direct: "300", assist: "0", relay: "0" },
+        consumedEffect: null,
+        createdEffect: null,
+      },
+      announcementQueued: false,
+      latestReward: null,
+    });
+    const res = response();
+
+    await publicHandler.attack(request({ body }), res);
+
+    const { attack } = res.json.mock.calls[0][0];
+    expect(attack.scoreGained).toEqual({ direct: "300", assist: "0", relay: "0" });
+    expect(attack.consumedEffect).toBeNull();
+    expect(attack.createdEffect).toBeNull();
+    // No consumed effect means no name lookup at all.
+    expect(UserModel.getDisplayNames).not.toHaveBeenCalled();
+  });
+
+  it("resolves a banner relay's assist and consumed effect source name in one lookup", async () => {
+    AttackService.attack.mockResolvedValue({
+      result: {
+        ...attackResult,
+        scoreGained: { direct: "200", assist: "7", relay: "7" },
+        consumedEffect: { id: "9", type: "banner", value: "7", sourceUserId: "Usource" },
+      },
+      announcementQueued: false,
+      latestReward: null,
+    });
+    const res = response();
+
+    await publicHandler.attack(request({ body }), res);
+
+    const { attack } = res.json.mock.calls[0][0];
+    expect(attack.scoreGained).toEqual({ direct: "200", assist: "7", relay: "7" });
+    expect(attack.consumedEffect).toEqual({
+      id: "9",
+      type: "banner",
+      value: "7",
+      sourceUserId: "Usource",
+      sourceDisplayName: "留效果的人",
+    });
+    expect(UserModel.getDisplayNames).toHaveBeenCalledTimes(1);
+    expect(UserModel.getDisplayNames).toHaveBeenCalledWith(["Usource"]);
+  });
+
+  it("degrades a consumed effect to a null display name when the profile read fails", async () => {
+    UserModel.getDisplayNames.mockRejectedValue(new Error("db down"));
+    const res = response();
+
+    await publicHandler.attack(request({ body }), res);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].attack.consumedEffect).toMatchObject({
+      sourceUserId: "Usource",
+      sourceDisplayName: null,
+    });
+  });
+
+  it("never exposes the removed damage / wastedDamage aliases", async () => {
+    const res = response();
+
+    await publicHandler.attack(request({ body }), res);
+
+    const { attack } = res.json.mock.calls[0][0];
+    expect(Object.keys(attack)).not.toContain("damage");
+    expect(Object.keys(attack)).not.toContain("wastedDamage");
   });
 
   it("still returns 200 with announcementQueued false when nothing was enqueued", async () => {
@@ -756,7 +1110,7 @@ describe("World Boss attack handler", () => {
 
     expect(res.status).not.toHaveBeenCalled();
     expect(res.json.mock.calls[0][0].status).toBeNull();
-    expect(res.json.mock.calls[0][0].attack.effectiveDamage).toBe("100");
+    expect(res.json.mock.calls[0][0].attack.effectiveDamage).toBe("400");
   });
 
   it.each([

--- a/app/src/handler/WorldBoss/public.js
+++ b/app/src/handler/WorldBoss/public.js
@@ -1,13 +1,18 @@
 const SeasonService = require("../../service/WorldBossSeasonService");
 const BattleService = require("../../service/WorldBossBattleService");
 const AttackService = require("../../service/WorldBossAttackService");
-const { canonicalPositiveInteger } = require("../../util/decimalInteger");
+const WorldBossRoundEffect = require("../../model/application/WorldBossRoundEffect");
+const UserModel = require("../../model/application/UserModel");
+const { canonicalPositiveInteger, canonicalUnsignedInteger } = require("../../util/decimalInteger");
 const { toApiDto, respondError, fail, parseLeaderboardLimit } = require(".");
 
 const ATTACK_TYPES = new Set(["standard", "skill"]);
 // Group ids only. Rooms (R…) are not a supported announcement destination, so a
 // room id is rejected at the trust boundary rather than silently ignored later.
 const GROUP_ID = /^C[0-9a-f]{32}$/;
+// ponytail: fixed newest-50 window instead of a pagination route. The board only ever
+// shows "who took my effects lately"; add a cursor route when someone asks to scroll.
+const EFFECT_HISTORY_LIMIT = 50;
 
 function activeSeasonId(status) {
   return status && status.season ? canonicalPositiveInteger(status.season.id) : null;
@@ -33,6 +38,61 @@ function parseAttackBody(body) {
   return { roundId, attackType: input.attackType, groupId: groupId ? String(groupId) : null };
 }
 
+/**
+ * Ranking is scored by `total_score`; `total_damage` is deliberately not projected, so a
+ * future extra column on the service row can never silently become the displayed score.
+ */
+function leaderboardRow(row) {
+  return {
+    user_id: row.user_id,
+    display_name: row.display_name ?? null,
+    total_score: canonicalUnsignedInteger(row.total_score),
+    ranking: row.ranking,
+  };
+}
+
+/**
+ * "Who took the effects I left." Two queries regardless of row count: one windowed read
+ * of the effect ledger, then one batched name lookup for the consumers that exist.
+ */
+async function effectHistory(seasonId, userId) {
+  const rows = await WorldBossRoundEffect.listSeasonHistoryBySource({
+    seasonId,
+    userId,
+    limit: EFFECT_HISTORY_LIMIT,
+  });
+  const nameByUserId = await UserModel.getDisplayNames(
+    rows.map(row => row.consumed_by_user_id).filter(Boolean)
+  );
+  return rows.map(row => ({
+    effectId: canonicalPositiveInteger(row.id),
+    type: row.effect_type,
+    value: canonicalPositiveInteger(row.value),
+    roundId: canonicalPositiveInteger(row.round_id),
+    createdAt: row.created_at ?? null,
+    consumedAt: row.consumed_at ?? null,
+    consumedBy: row.consumed_by_user_id
+      ? {
+          userId: row.consumed_by_user_id,
+          displayName: nameByUserId.get(row.consumed_by_user_id) ?? null,
+        }
+      : null,
+  }));
+}
+
+/**
+ * The consumed effect belongs to someone else, so the board needs a name to render
+ * "you took X's banner". At most one effect is consumed per attack — this is a single
+ * lookup, not a per-row one — and a missing profile degrades to null rather than failing
+ * an attack that already committed.
+ */
+async function consumedEffectDto(consumedEffect) {
+  if (!consumedEffect) return null;
+  const { sourceUserId } = consumedEffect;
+  const nameByUserId = await UserModel.getDisplayNames([sourceUserId]).catch(() => new Map());
+  return { ...consumedEffect, sourceDisplayName: nameByUserId.get(sourceUserId) ?? null };
+}
+
 exports.status = async function (req, res) {
   try {
     res.json(toApiDto(await SeasonService.getBattleStatus()));
@@ -47,12 +107,16 @@ exports.leaderboard = async function (req, res) {
     const status = await SeasonService.getBattleStatus();
     const seasonId = activeSeasonId(status);
     const rows = seasonId ? await SeasonService.getRanking(seasonId, limit) : [];
-    res.json(toApiDto({ seasonId, rows }));
+    res.json(toApiDto({ seasonId, rows: rows.map(leaderboardRow) }));
   } catch (error) {
     respondError(res, error);
   }
 };
 
+/**
+ * Strictly the caller's own view: every read is keyed by `req.profile.userId`, and no
+ * request input selects a subject.
+ */
 exports.me = async function (req, res) {
   try {
     const { userId } = req.profile;
@@ -63,14 +127,18 @@ exports.me = async function (req, res) {
     const seasonId = activeSeasonId(status);
     let current = null;
     if (seasonId) {
-      const [totalDamage, daily] = await Promise.all([
-        SeasonService.getUserTotalDamage(seasonId, userId),
+      const [stats, daily, effects] = await Promise.all([
+        SeasonService.getUserSeasonStats(seasonId, userId),
         BattleService.getRemainingDailyCost(userId),
+        effectHistory(seasonId, userId),
       ]);
       current = {
-        seasonId,
-        totalDamage,
+        seasonId: stats.seasonId,
+        totalScore: stats.totalScore,
+        score: stats.score,
+        damage: stats.damage,
         daily,
+        effects,
       };
     }
     res.json(toApiDto({ current, latestReward: latestReward || null }));
@@ -94,23 +162,35 @@ exports.attack = async function (req, res) {
       groupId,
       displayName,
     });
-    const status = await SeasonService.getBattleStatus().catch(() => null);
+    const [status, consumedEffect] = await Promise.all([
+      SeasonService.getBattleStatus().catch(() => null),
+      consumedEffectDto(result.consumedEffect),
+    ]);
 
     res.json(
       toApiDto({
+        // Field-by-field on purpose: spreading the battle result would publish every
+        // internal field the transaction happens to return, forever.
         attack: {
           roundId,
           attackType,
-          damage: result.damage,
+          rawDamage: result.rawDamage,
+          effectDamage: result.effectDamage,
           effectiveDamage: result.effectiveDamage,
-          wastedDamage: result.wastedDamage,
+          overkillDamage: result.overkillDamage,
+          scoreGained: result.scoreGained,
+          consumedEffect,
+          createdEffect: result.createdEffect,
           cost: result.cost,
           cleared: Boolean(result.cleared),
           cycleAdvanced: Boolean(result.cycleAdvanced),
           attackedCycleNo: result.attackedCycleNo,
           cycleNo: result.cycleNo,
+          round: result.round,
           boss: result.boss,
+          rounds: result.rounds,
           levelResult: result.levelResult,
+          seasonTotalScore: result.seasonTotalScore,
           seasonTotalDamage: result.seasonTotalDamage,
           daily: result.daily,
         },

--- a/app/src/model/application/RPGCharacter.js
+++ b/app/src/model/application/RPGCharacter.js
@@ -147,14 +147,15 @@ class Adventurer {
   }
 
   getSkillOneDamage() {
-    return this.getStandardDamage();
+    return Math.floor(this.getNormalDamage() * this.skillOne.rate);
   }
 
   get skillOne() {
     return {
       name: "普通攻擊",
       description: "冒險者的普通攻擊",
-      cost: 10,
+      cost: 8,
+      rate: 1.2,
     };
   }
 
@@ -190,11 +191,9 @@ class Swordman extends Adventurer {
   get skillOne() {
     return {
       name: "震地斬擊",
-      description: "穩定的重擊，造成 2.2 倍傷害",
+      description: "穩定的重擊，造成 1.8 倍傷害",
       cost: 10,
-      rate: 2.2,
-      criticalRate: 8,
-      criticalConfig: [makeCriticalConfig(1.2, 1.4, 100)],
+      rate: 1.8,
     };
   }
 
@@ -219,7 +218,7 @@ class Mage extends Adventurer {
       name: "元素之力",
       description: "低消耗的魔法攻擊，容易產生爆擊",
       cost: 7,
-      rate: 1.0,
+      rate: 0.7,
       criticalRate: 25,
       criticalConfig: [
         makeCriticalConfig(1.8, 2.2, 60),
@@ -257,7 +256,7 @@ class Thief extends Adventurer {
       name: "致命一擊",
       description: "高風險高回報的攻擊，有機會造成巨額傷害",
       cost: 20,
-      rate: 1.5,
+      rate: 2.1,
       criticalRate: 50,
       criticalConfig: [
         makeCriticalConfig(1.2, 1.5, 10),

--- a/app/src/model/application/UserModel.js
+++ b/app/src/model/application/UserModel.js
@@ -52,6 +52,21 @@ exports.getProfile = async platformId => {
 };
 
 /**
+ * 批次取顯示名稱，回 Map<platformId, displayName|null>。
+ *
+ * 存在的理由只有一個：讓「一批 user id → 一批名字」是一次查詢。呼叫端拿到 Map 之後就地
+ * 查表，不要在迴圈裡呼叫 getProfile。查無或空字串一律 null，讓呼叫端只有一種缺值型態。
+ */
+exports.getDisplayNames = async platformIds => {
+  const ids = [...new Set(platformIds.filter(id => typeof id === "string" && id))];
+  if (!ids.length) return new Map();
+  const rows = await mysql(USER_TABLE)
+    .whereIn("platform_id", ids)
+    .select("platform_id", "display_name");
+  return new Map(rows.map(row => [row.platform_id, row.display_name?.trim() || null]));
+};
+
+/**
  * 確保用戶存在，不存在則自動建立
  * @param {String} platformId 平台ID
  * @param {String} platform 平台名稱 (預設 "line")

--- a/app/src/model/application/WorldBossContribution.js
+++ b/app/src/model/application/WorldBossContribution.js
@@ -3,32 +3,8 @@ const { canonicalUnsignedInteger } = require("../../util/decimalInteger");
 
 const TABLE = "world_boss_contribution";
 
-function fail(code) {
-  const error = new Error(code);
-  error.code = code;
-  return error;
-}
-
-function withCompetitionRank(rows) {
-  let previousDamage = null;
-  let previousRank = 0;
-  return rows.map((row, index) => {
-    const damage = canonicalUnsignedInteger(row.total_damage);
-    const ranking = previousDamage === damage ? previousRank : index + 1;
-    previousDamage = damage;
-    previousRank = ranking;
-    return { ...row, total_damage: damage, ranking };
-  });
-}
-
-function rankingQuery(db, seasonId) {
-  return db(TABLE)
-    .where({ season_id: seasonId })
-    .select("user_id")
-    .sum({ total_damage: "damage" })
-    .groupBy("user_id")
-    .orderBy("total_damage", "desc")
-    .orderBy("user_id", "asc");
+function sumOrZero(value) {
+  return value === null || value === undefined ? "0" : canonicalUnsignedInteger(value);
 }
 
 exports.sumCostInRange = async function (userId, startUtc, endUtc, trx) {
@@ -42,26 +18,67 @@ exports.sumCostInRange = async function (userId, startUtc, endUtc, trx) {
   return Number(row.total_cost) || 0;
 };
 
-exports.seasonRanking = async function (seasonId, limit, trx) {
-  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
-    throw fail("INVALID_RANKING_LIMIT");
-  }
-  const db = trx || mysql;
-  return withCompetitionRank(await rankingQuery(db, seasonId).limit(limit));
-};
-
-exports.seasonRankingAll = async function (seasonId, trx) {
-  const db = trx || mysql;
-  return withCompetitionRank(await rankingQuery(db, seasonId));
-};
-
 exports.sumSeasonDamage = async function (seasonId, userId, trx) {
   const db = trx || mysql;
   const row = await db(TABLE)
     .where({ season_id: seasonId, user_id: userId })
     .sum({ total: "damage" })
     .first();
-  return row.total === null || row.total === undefined ? "0" : canonicalUnsignedInteger(row.total);
+  return sumOrZero(row.total);
 };
 
-exports.withCompetitionRank = withCompetitionRank;
+/**
+ * 整季每位玩家的實際扣血總和，key 為 user_id。
+ *
+ * 排名已改由 world_boss_score_event 決定（見 WorldBossScoreEvent.seasonRanking），這裡
+ * 只剩結算時要寫進 ledger 的統計欄位，所以刻意不回傳名次，避免有人誤用傷害排名。
+ */
+exports.seasonDamageByUser = async function (seasonId, trx) {
+  const db = trx || mysql;
+  const rows = await db(TABLE)
+    .where({ season_id: seasonId })
+    .select("user_id")
+    .sum({ total_damage: "damage" })
+    .groupBy("user_id");
+  return new Map(rows.map(row => [row.user_id, sumOrZero(row.total_damage)]));
+};
+
+/**
+ * 個人賽季傷害統計（全部為 decimal string）。
+ *
+ * v1 舊資料的辨識子是 `raw_damage IS NULL`：那時候沒有 raw / effect 的概念，用 damage
+ * 代入會讓統計失真，所以 raw / effect / overkill 一律只計 v2 列。effective 是實際扣掉的
+ * 血量，對 v1、v2 都成立，因此涵蓋全部列。
+ *
+ * overkill = Σ(raw + effect) − Σ(v2 的 damage)：逐列都是 raw+effect−min(raw+effect, hp)，
+ * 恆為非負，所以聚合後相減不會出現負值，也不必冒 BIGINT UNSIGNED 相減溢位的風險。
+ */
+exports.seasonDamageStats = async function (seasonId, userId, trx) {
+  const db = trx || mysql;
+  const row = await db(TABLE)
+    .where({ season_id: seasonId, user_id: userId })
+    .select(
+      db.raw("SUM(??) AS ??", ["damage", "effective"]),
+      // SUM 略過 NULL，所以 raw 天生只計 v2 列。
+      db.raw("SUM(??) AS ??", ["raw_damage", "raw"]),
+      db.raw("SUM(CASE WHEN ?? IS NULL THEN 0 ELSE ?? END) AS ??", [
+        "raw_damage",
+        "effect_damage",
+        "effect",
+      ]),
+      db.raw("SUM(CASE WHEN ?? IS NULL THEN 0 ELSE ?? END) AS ??", [
+        "raw_damage",
+        "damage",
+        "effective_v2",
+      ])
+    )
+    .first();
+  const raw = sumOrZero(row.raw);
+  const effect = sumOrZero(row.effect);
+  return {
+    raw,
+    effect,
+    effective: sumOrZero(row.effective),
+    overkill: (BigInt(raw) + BigInt(effect) - BigInt(sumOrZero(row.effective_v2))).toString(),
+  };
+};

--- a/app/src/model/application/WorldBossRoundEffect.js
+++ b/app/src/model/application/WorldBossRoundEffect.js
@@ -1,0 +1,141 @@
+const mysql = require("../../util/mysql");
+const { canonicalPositiveInteger } = require("../../util/decimalInteger");
+
+const TABLE = "world_boss_round_effect";
+
+// 只有兩種效果，所以這是一張表加兩個常數，不是一套 buff engine：沒有 DSL、沒有
+// handler registry、沒有 stack/duration/priority。要加第三種再說。
+const TYPES = { BANNER: "banner", SEAL: "seal" };
+
+// 哪個職業在攻擊後留下什麼效果。swordman / thief 不在表內 = 不留效果。
+const EFFECT_BY_JOB = {
+  adventurer: { effect_type: TYPES.BANNER, percent: 25n },
+  mage: { effect_type: TYPES.SEAL, percent: 50n },
+};
+
+function fail(code) {
+  return Object.assign(new Error(code), { code });
+}
+
+/**
+ * 本次攻擊應該留下的效果，null 代表不留。
+ *
+ * 回傳 null 有兩種原因，呼叫端不需要分辨：職業本來就不留效果，或算出來的 value 是 0
+ * （極低等級玩家真的會發生）—— 後者不能 INSERT，會撞 CHECK(value > 0)。
+ */
+exports.planFor = function (jobKey, rawDamage) {
+  const spec = EFFECT_BY_JOB[jobKey];
+  if (!spec) return null;
+  // BigInt 除法向零截斷，rawDamage 恆為正，等同 floor。
+  const value = (BigInt(canonicalPositiveInteger(rawDamage)) * spec.percent) / 100n;
+  return value > 0n ? { effect_type: spec.effect_type, value } : null;
+};
+
+/**
+ * 下一筆可被這名玩家消耗的效果（FIFO）。
+ *
+ * `source_user_id <> ?` 必須留在 SQL：若先取最舊的一筆、再於 application code 發現是
+ * 本人然後放棄，攻擊者自己留下的舊效果會永久擋住排在它後面、其他玩家留下的可消耗效果。
+ */
+exports.findConsumableForUpdate = async function (trx, { roundId, userId }) {
+  return trx(TABLE)
+    .where({ round_id: roundId })
+    .whereNull("consumed_by_contribution_id")
+    .whereNot({ source_user_id: userId })
+    .orderBy("id", "asc")
+    .forUpdate()
+    .first();
+};
+
+exports.insert = async function (trx, row) {
+  const [id] = await trx(TABLE).insert(row);
+  return id;
+};
+
+/**
+ * 條件式消耗。affected rows 不等於 1 就丟 error 讓整筆 transaction rollback。
+ *
+ * 目前每次攻擊都先鎖住 active season，效果的選取與消耗已經被全域序列化，所以這裡永遠
+ * 不該踩到 —— 它是 invariant backstop，不是可回復的競態，因此故意不做重試。
+ */
+exports.consume = async function (trx, { effectId, contributionId, now }) {
+  const affected = await trx(TABLE)
+    .where({ id: effectId })
+    .whereNull("consumed_by_contribution_id")
+    .update({ consumed_by_contribution_id: contributionId, updated_at: now });
+  if (affected !== 1) throw fail("EFFECT_ALREADY_CONSUMED");
+};
+
+exports.toDto = function (effect) {
+  return {
+    id: canonicalPositiveInteger(effect.id),
+    type: effect.effect_type,
+    value: canonicalPositiveInteger(effect.value),
+    sourceUserId: effect.source_user_id,
+  };
+};
+
+exports.listUnconsumedByRound = async function (roundId, trx) {
+  const db = trx || mysql;
+  return db(TABLE)
+    .where({ round_id: roundId })
+    .whereNull("consumed_by_contribution_id")
+    .orderBy("id", "asc");
+};
+
+/**
+ * 玩家自己留下的效果，以及它最後被誰接走（單一 query，含未被接走的）。
+ *
+ * `consumed_at` 取消耗方 contribution 的 created_at，而不是 effect.updated_at：後者只是
+ * 「這列最後被改動的時間」，任何之後的維護性 UPDATE 都會把它蓋掉。
+ *
+ * 來源端不 join contribution —— source_user_id 已經反正規化在本表上，join 回去只會拿到
+ * 同一個值。過濾條件 (season_id, source_user_id) 正好走 idx_wbre_season_source_user。
+ * 顯示名稱刻意不在這裡 join：呼叫端只需要對「被接走的那幾筆」做一次批次查詢，join 進來
+ * 反而會讓每列都帶一份 user 資料。
+ */
+exports.listSeasonHistoryBySource = async function ({ seasonId, userId, limit }, trx) {
+  const db = trx || mysql;
+  return db(`${TABLE} as effect`)
+    .leftJoin(
+      "world_boss_contribution as consumer",
+      "effect.consumed_by_contribution_id",
+      "consumer.id"
+    )
+    .where({ "effect.season_id": seasonId, "effect.source_user_id": userId })
+    .orderBy("effect.id", "desc")
+    .limit(limit)
+    .select(
+      "effect.id as id",
+      "effect.round_id as round_id",
+      "effect.effect_type as effect_type",
+      "effect.value as value",
+      "effect.created_at as created_at",
+      "consumer.user_id as consumed_by_user_id",
+      "consumer.created_at as consumed_at"
+    );
+};
+
+/** Count pending effects for all supplied rounds with one grouped query. */
+exports.countPendingByRounds = async function (roundIds, trx) {
+  const result = new Map();
+  if (!roundIds.length) return result;
+  const db = trx || mysql;
+  const rows = await db(TABLE)
+    .whereIn("round_id", roundIds)
+    .whereNull("consumed_by_contribution_id")
+    .select("round_id", "effect_type")
+    .count({ count: "id" })
+    .groupBy("round_id", "effect_type");
+  for (const row of rows) {
+    const counts = result.get(String(row.round_id)) || { banner: 0, seal: 0 };
+    if (row.effect_type === TYPES.BANNER || row.effect_type === TYPES.SEAL) {
+      counts[row.effect_type] = Number(row.count);
+    }
+    result.set(String(row.round_id), counts);
+  }
+  return result;
+};
+
+exports.TABLE = TABLE;
+exports.TYPES = TYPES;

--- a/app/src/model/application/WorldBossScoreEvent.js
+++ b/app/src/model/application/WorldBossScoreEvent.js
@@ -1,0 +1,103 @@
+const mysql = require("../../util/mysql");
+const { canonicalUnsignedInteger } = require("../../util/decimalInteger");
+
+const TABLE = "world_boss_score_event";
+
+// direct = 自己打出的 raw damage；assist = 留下效果的人；relay = 接棒引爆 banner 的人。
+const KINDS = { DIRECT: "direct", ASSIST: "assist", RELAY: "relay" };
+
+function fail(code) {
+  return Object.assign(new Error(code), { code });
+}
+
+/**
+ * Competition ranking：同分同名次，下一名跳號（1,1,3）。rows 必須已按 `total_score`
+ * 遞減、user_id 遞增排好；名次只由分數決定，不受 limit 截斷影響。
+ */
+function withCompetitionRank(rows) {
+  let previousScore = null;
+  let previousRank = 0;
+  return rows.map((row, index) => {
+    const totalScore = canonicalUnsignedInteger(row.total_score);
+    const ranking = previousScore === totalScore ? previousRank : index + 1;
+    previousScore = totalScore;
+    previousRank = ranking;
+    return { ...row, total_score: totalScore, ranking };
+  });
+}
+
+exports.insertMany = async function (trx, rows) {
+  if (!rows.length) return;
+  await trx(TABLE).insert(rows);
+};
+
+/**
+ * 賽季總分。SUM(points) 交給 MySQL 算，回字串 —— BIGINT 加總會超過 Number.MAX_SAFE_INTEGER。
+ */
+exports.sumSeasonScore = async function (seasonId, userId, trx) {
+  const db = trx || mysql;
+  const row = await db(TABLE)
+    .where({ season_id: seasonId, beneficiary_user_id: userId })
+    .sum({ total: "points" })
+    .first();
+  return row.total === null || row.total === undefined ? "0" : canonicalUnsignedInteger(row.total);
+};
+
+/**
+ * 個人賽季分數拆帳。缺席的 kind 回 "0" 而不是 null，呼叫端不必判空。
+ *
+ * v1 舊資料在 migration 被 backfill 成 legacy `direct`（points = contribution.damage），
+ * 所以舊玩家的 direct 是混合值：v1 的實際扣血 + v2 的 raw damage。這是刻意的，分數本來
+ * 就不該因為改版歸零。
+ */
+exports.seasonScoreByKind = async function (seasonId, userId, trx) {
+  const db = trx || mysql;
+  const rows = await db(TABLE)
+    .where({ season_id: seasonId, beneficiary_user_id: userId })
+    .select("kind")
+    .sum({ total: "points" })
+    .groupBy("kind");
+  const totals = { direct: "0", assist: "0", relay: "0" };
+  for (const row of rows) totals[row.kind] = canonicalUnsignedInteger(row.total);
+  return totals;
+};
+
+function rankingQuery(db, seasonId) {
+  return db(TABLE)
+    .where({ season_id: seasonId })
+    .select({ user_id: "beneficiary_user_id" })
+    .sum({ total_score: "points" })
+    .groupBy("beneficiary_user_id")
+    .orderBy("total_score", "desc")
+    .orderBy("beneficiary_user_id", "asc");
+}
+
+/**
+ * 排行榜。分數來源是 score event，不是 contribution.damage —— 兩者在 v2 之後不再相等
+ * （overkill 計分不扣血、assist/relay 的受益者不是出手的人）。
+ */
+exports.seasonRanking = async function (seasonId, limit, trx) {
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) throw fail("INVALID_RANKING_LIMIT");
+  const db = trx || mysql;
+  return withCompetitionRank(await rankingQuery(db, seasonId).limit(limit));
+};
+
+exports.seasonRankingAll = async function (seasonId, trx) {
+  const db = trx || mysql;
+  return withCompetitionRank(await rankingQuery(db, seasonId));
+};
+
+/**
+ * 一次攻擊產生的分數拆帳，供 DTO 使用。一次攻擊每個 kind 至多一筆，所以直接覆寫即可。
+ * 缺席的 kind 是 "0" 而不是 null，呼叫端不必判空。注意 assist 的受益者是留下效果的人，
+ * 不是攻擊者本人。
+ */
+exports.breakdown = function (rows) {
+  const totals = { direct: "0", assist: "0", relay: "0" };
+  for (const row of rows) totals[row.kind] = canonicalUnsignedInteger(row.points);
+  return totals;
+};
+
+exports.TABLE = TABLE;
+exports.KINDS = KINDS;
+exports.withCompetitionRank = withCompetitionRank;

--- a/app/src/model/application/WorldBossSeasonReward.js
+++ b/app/src/model/application/WorldBossSeasonReward.js
@@ -31,6 +31,7 @@ exports.findLatestSettledByUser = async function (userId, trx) {
       "reward.season_id as seasonId",
       "season.name as seasonName",
       "reward.ranking as ranking",
+      "reward.total_score as totalScore",
       "reward.total_damage as totalDamage",
       "reward.stone_amount as stoneAmount",
       "reward.title_key as titleKey",
@@ -46,6 +47,9 @@ exports.findLatestSettledByUser = async function (userId, trx) {
         ...row,
         rewardId: canonicalPositiveInteger(row.rewardId),
         seasonId: canonicalPositiveInteger(row.seasonId),
+        // v2 之前結算的 ledger 沒有 total_score（欄位是後加的 NULLable），維持 null 表示
+        // 「這個賽季不是用分數排的」，不要用 total_damage 冒充。
+        totalScore: row.totalScore === null ? null : canonicalUnsignedInteger(row.totalScore),
         totalDamage: canonicalUnsignedInteger(row.totalDamage),
       }
     : row;

--- a/app/src/model/application/__tests__/WorldBossModels.test.js
+++ b/app/src/model/application/__tests__/WorldBossModels.test.js
@@ -14,6 +14,8 @@ const WorldBossSeasonBoss = require("../WorldBossSeasonBoss");
 const WorldBossRound = require("../WorldBossRound");
 const WorldBossContribution = require("../WorldBossContribution");
 const WorldBossSeasonReward = require("../WorldBossSeasonReward");
+const WorldBossRoundEffect = require("../WorldBossRoundEffect");
+const WorldBossScoreEvent = require("../WorldBossScoreEvent");
 
 describe("World Boss v2 models", () => {
   const prefix = `${PREFIX}models_`;
@@ -254,52 +256,41 @@ describe("World Boss v2 models", () => {
     ).rejects.toMatchObject({ code: "ER_DUP_ENTRY" });
   });
 
-  test("aggregates, bounds, orders, and competition-ranks season contributions", async () => {
+  test("aggregates season contribution damage per user without ranking it", async () => {
     const seasonId = await createSeason({ name: `${prefix}ranking-season` });
     const roster = await createRoster(seasonId, await createBosses("ranking"));
     const [round] = await createCycle(seasonId, roster, 1);
     const roundId = round.id;
-    const rows = [
-      { user_id: `${prefix}u-b`, damage: 500, cost: 10 },
-      { user_id: `${prefix}u-a`, damage: 500, cost: 20 },
-      { user_id: `${prefix}u-c`, damage: 300, cost: 30 },
-    ];
-    for (let index = 0; index < 101; index += 1) {
-      rows.push({
-        user_id: `${prefix}rank-${String(index).padStart(3, "0")}`,
-        damage: 200 - index,
-        cost: 1,
-      });
-    }
     await mysql("world_boss_contribution").insert(
-      rows.map(row => ({ season_id: seasonId, round_id: roundId, ...row }))
-    );
-
-    const publicRows = await WorldBossContribution.seasonRanking(seasonId, 100);
-    expect(publicRows).toHaveLength(100);
-    expect(publicRows.slice(0, 3).map(row => [row.user_id, row.total_damage, row.ranking])).toEqual(
       [
-        [`${prefix}u-a`, "500", 1],
-        [`${prefix}u-b`, "500", 1],
-        [`${prefix}u-c`, "300", 3],
-      ]
+        { user_id: `${prefix}u-b`, damage: 500, cost: 10 },
+        { user_id: `${prefix}u-a`, damage: 300, cost: 20 },
+        { user_id: `${prefix}u-a`, damage: 200, cost: 20 },
+        { user_id: `${prefix}u-c`, damage: 300, cost: 30 },
+      ].map(row => ({ season_id: seasonId, round_id: roundId, ...row }))
     );
 
-    const allRows = await WorldBossContribution.seasonRankingAll(seasonId);
-    expect(allRows).toHaveLength(104);
-    expect(allRows.find(row => row.ranking === 101)).toBeTruthy();
-    expect(await WorldBossContribution.sumSeasonDamage(seasonId, `${prefix}u-a`)).toBe("500");
+    // Damage is a private statistic now — the model must not hand out a damage leaderboard.
+    expect(WorldBossContribution.seasonRanking).toBeUndefined();
+    expect(WorldBossContribution.seasonRankingAll).toBeUndefined();
+    expect(WorldBossContribution.withCompetitionRank).toBeUndefined();
 
-    for (const limit of [0, 101, 1.5, Number.NaN]) {
-      await expect(WorldBossContribution.seasonRanking(seasonId, limit)).rejects.toMatchObject({
-        code: "INVALID_RANKING_LIMIT",
-      });
-    }
-    await expect(WorldBossContribution.seasonRanking(seasonId, 1)).resolves.toHaveLength(1);
-    await expect(WorldBossContribution.seasonRanking(seasonId, 100)).resolves.toHaveLength(100);
+    await expect(WorldBossContribution.sumSeasonDamage(seasonId, `${prefix}u-a`)).resolves.toBe(
+      "500"
+    );
+    await expect(WorldBossContribution.sumSeasonDamage(seasonId, `${prefix}nobody`)).resolves.toBe(
+      "0"
+    );
+    const byUser = await WorldBossContribution.seasonDamageByUser(seasonId);
+    expect([...byUser.entries()].sort()).toEqual([
+      [`${prefix}u-a`, "500"],
+      [`${prefix}u-b`, "500"],
+      [`${prefix}u-c`, "300"],
+    ]);
+    await expect(WorldBossContribution.seasonDamageByUser(999999999)).resolves.toEqual(new Map());
   });
 
-  test("preserves exact aggregate damage for ordering, ties, and user totals", async () => {
+  test("preserves exact aggregate damage for user totals beyond Number.MAX_SAFE_INTEGER", async () => {
     const seasonId = await createSeason({ name: `${prefix}exact-ranking-season` });
     const roster = await createRoster(seasonId, await createBosses("exact"));
     const [round] = await createCycle(seasonId, roster, 1);
@@ -310,21 +301,47 @@ describe("World Boss v2 models", () => {
         { user_id: `${prefix}exact-a`, damage: half },
         { user_id: `${prefix}exact-a`, damage: "4503599627370497" },
         { user_id: `${prefix}exact-b`, damage: half },
-        { user_id: `${prefix}exact-b`, damage: "4503599627370497" },
-        { user_id: `${prefix}exact-c`, damage: half },
-        { user_id: `${prefix}exact-c`, damage: half },
+        { user_id: `${prefix}exact-b`, damage: half },
       ].map(row => ({ season_id: seasonId, round_id: roundId, cost: 1, ...row }))
     );
 
-    const ranking = await WorldBossContribution.seasonRanking(seasonId, 100);
-    expect(ranking.map(row => [row.user_id, row.total_damage, row.ranking])).toEqual([
-      [`${prefix}exact-a`, "9007199254740993", 1],
-      [`${prefix}exact-b`, "9007199254740993", 1],
-      [`${prefix}exact-c`, "9007199254740992", 3],
-    ]);
     await expect(WorldBossContribution.sumSeasonDamage(seasonId, `${prefix}exact-a`)).resolves.toBe(
       "9007199254740993"
     );
+    await expect(WorldBossContribution.seasonDamageByUser(seasonId)).resolves.toEqual(
+      new Map([
+        [`${prefix}exact-a`, "9007199254740993"],
+        [`${prefix}exact-b`, "9007199254740992"],
+      ])
+    );
+  });
+
+  test("excludes v1 rows from raw/effect/overkill stats but keeps them in effective", async () => {
+    const seasonId = await createSeason({ name: `${prefix}stats-season` });
+    const roster = await createRoster(seasonId, await createBosses("stats"));
+    const [round] = await createCycle(seasonId, roster, 1);
+    const userId = `${prefix}stats-user`;
+    await mysql("world_boss_contribution").insert(
+      [
+        // v1: raw_damage IS NULL. Its 700 damage is real HP removed, so it counts as
+        // effective — but nothing may be inferred about raw / effect / overkill.
+        { raw_damage: null, effect_damage: 0, job_key: null, damage: 700 },
+        // v2 with an overkill tail: 100 + 50 swung, only 30 landed.
+        { raw_damage: 100, effect_damage: 50, job_key: "mage", damage: 30 },
+        // v2 with no waste at all.
+        { raw_damage: 40, effect_damage: 0, job_key: "thief", damage: 40 },
+      ].map(row => ({ season_id: seasonId, round_id: round.id, user_id: userId, cost: 1, ...row }))
+    );
+
+    await expect(WorldBossContribution.seasonDamageStats(seasonId, userId)).resolves.toEqual({
+      raw: "140",
+      effect: "50",
+      effective: "770",
+      overkill: "120",
+    });
+    await expect(
+      WorldBossContribution.seasonDamageStats(seasonId, `${prefix}nobody`)
+    ).resolves.toEqual({ raw: "0", effect: "0", effective: "0", overkill: "0" });
   });
 
   test("sums cost using a half-open UTC range at the Taipei midnight boundary", async () => {
@@ -402,6 +419,7 @@ describe("World Boss v2 models", () => {
       season_id: settledSeasonId,
       user_id: userId,
       ranking: 1,
+      total_score: 1200,
       total_damage: 999,
       stone_amount: 500,
       title_key: title.key,
@@ -430,6 +448,7 @@ describe("World Boss v2 models", () => {
       seasonId: String(settledSeasonId),
       seasonName: `${prefix}settled-season`,
       ranking: 1,
+      totalScore: "1200",
       totalDamage: "999",
       stoneAmount: 500,
       titleKey: title.key,
@@ -438,5 +457,458 @@ describe("World Boss v2 models", () => {
     expect(Number(latest.rewardId)).toBeGreaterThan(0);
     expect(new Date(latest.paidAt).toISOString()).toBe("2026-07-01T01:00:00.000Z");
     expect(new Date(latest.settledAt).toISOString()).toBe("2026-07-01T00:00:00.000Z");
+
+    // A pre-v2 ledger has no total_score; it must stay null rather than borrow total_damage.
+    const legacyUserId = `${prefix}reward-legacy`;
+    await WorldBossSeasonReward.tryInsert({
+      ...payload,
+      user_id: legacyUserId,
+      total_score: null,
+    });
+    await expect(
+      WorldBossSeasonReward.findLatestSettledByUser(legacyUserId)
+    ).resolves.toMatchObject({ totalScore: null, totalDamage: "999" });
+  });
+
+  describe("effect and score ledgers", () => {
+    let seasonId;
+    let rounds;
+
+    async function addContribution(userId, overrides = {}) {
+      const [id] = await mysql("world_boss_contribution").insert({
+        season_id: seasonId,
+        round_id: rounds[0].id,
+        user_id: userId,
+        raw_damage: "100",
+        effect_damage: "0",
+        job_key: "mage",
+        damage: "100",
+        cost: 1,
+        ...overrides,
+      });
+      return id;
+    }
+
+    async function addEffect(overrides = {}) {
+      const sourceContributionId =
+        overrides.source_contribution_id ?? (await addContribution(`${prefix}fx-src`));
+      const [id] = await mysql("world_boss_round_effect").insert({
+        season_id: seasonId,
+        round_id: rounds[0].id,
+        source_contribution_id: sourceContributionId,
+        source_user_id: `${prefix}fx-src`,
+        effect_type: "seal",
+        value: "50",
+        consumed_by_contribution_id: null,
+        ...overrides,
+      });
+      return id;
+    }
+
+    function scoreRow(overrides = {}) {
+      return {
+        season_id: seasonId,
+        round_id: rounds[0].id,
+        effect_id: null,
+        beneficiary_user_id: `${prefix}score-user`,
+        kind: "direct",
+        points: "100",
+        ...overrides,
+      };
+    }
+
+    beforeEach(async () => {
+      seasonId = await createSeason({
+        name: `${prefix}ledger-season`,
+        status: "active",
+        active_slot: activeSlot,
+      });
+      const roster = await createRoster(seasonId, await createBosses("ledger"));
+      rounds = await createCycle(seasonId, roster, 1);
+    });
+
+    test("allows at most one effect per source contribution", async () => {
+      const contributionId = await addContribution(`${prefix}fx-src`);
+      await addEffect({ source_contribution_id: contributionId });
+
+      await expect(addEffect({ source_contribution_id: contributionId })).rejects.toMatchObject({
+        code: "ER_DUP_ENTRY",
+      });
+    });
+
+    test("allows at most one effect consumed by the same contribution", async () => {
+      const consumerId = await addContribution(`${prefix}fx-consumer`);
+      const first = await addEffect();
+      const second = await addEffect();
+      await mysql("world_boss_round_effect")
+        .where({ id: first })
+        .update({ consumed_by_contribution_id: consumerId });
+
+      // One attack may detonate at most one effect — two rows pointing at the same
+      // contribution would mean a hit silently consumed two.
+      await expect(
+        mysql("world_boss_round_effect")
+          .where({ id: second })
+          .update({ consumed_by_contribution_id: consumerId })
+      ).rejects.toMatchObject({ code: "ER_DUP_ENTRY" });
+      // Many unconsumed effects may coexist: NULL is not "the same value" to a UNIQUE index.
+      await expect(
+        mysql("world_boss_round_effect").where({ consumed_by_contribution_id: null })
+      ).resolves.toHaveLength(1);
+    });
+
+    test("rejects a zero-value effect", async () => {
+      await expect(addEffect({ value: "0" })).rejects.toMatchObject({
+        code: "ER_CHECK_CONSTRAINT_VIOLATED",
+      });
+    });
+
+    test("planFor skips a zero-value effect instead of writing an illegal row", async () => {
+      // floor(3 * 25 / 100) === 0 for a very low level adventurer.
+      expect(WorldBossRoundEffect.planFor("adventurer", 3)).toBeNull();
+      expect(WorldBossRoundEffect.planFor("mage", 1)).toBeNull();
+      expect(WorldBossRoundEffect.planFor("adventurer", 4)).toEqual({
+        effect_type: "banner",
+        value: 1n,
+      });
+      expect(WorldBossRoundEffect.planFor("mage", 501)).toEqual({
+        effect_type: "seal",
+        value: 250n,
+      });
+      // Swordman and thief leave nothing behind at any damage.
+      expect(WorldBossRoundEffect.planFor("swordman", 1000000)).toBeNull();
+      expect(WorldBossRoundEffect.planFor("thief", 1000000)).toBeNull();
+      // BIGINT stays exact: a JS Number would round this to ...992.
+      expect(WorldBossRoundEffect.planFor("mage", "18014398509481985").value).toBe(
+        9007199254740992n
+      );
+    });
+
+    test("rejects a zero-point score event", async () => {
+      const contributionId = await addContribution(`${prefix}score-user`);
+      await expect(
+        mysql("world_boss_score_event").insert(
+          scoreRow({ contribution_id: contributionId, points: "0" })
+        )
+      ).rejects.toMatchObject({ code: "ER_CHECK_CONSTRAINT_VIOLATED" });
+    });
+
+    test("rejects a duplicate (contribution, kind, beneficiary) score event", async () => {
+      const contributionId = await addContribution(`${prefix}score-user`);
+      const row = scoreRow({ contribution_id: contributionId });
+      await mysql("world_boss_score_event").insert(row);
+
+      await expect(mysql("world_boss_score_event").insert(row)).rejects.toMatchObject({
+        code: "ER_DUP_ENTRY",
+      });
+      // A different kind for the same contribution and user is legitimate.
+      await expect(
+        mysql("world_boss_score_event").insert({ ...row, kind: "relay" })
+      ).resolves.toBeDefined();
+    });
+
+    test("rejects a duplicate (effect, kind, beneficiary) score event", async () => {
+      const effectId = await addEffect();
+      const first = await addContribution(`${prefix}score-a`);
+      const second = await addContribution(`${prefix}score-b`);
+      const base = {
+        effect_id: effectId,
+        kind: "assist",
+        beneficiary_user_id: `${prefix}fx-src`,
+      };
+      await mysql("world_boss_score_event").insert(scoreRow({ ...base, contribution_id: first }));
+
+      // One effect may only ever pay one assist, even from a different contribution.
+      await expect(
+        mysql("world_boss_score_event").insert(scoreRow({ ...base, contribution_id: second }))
+      ).rejects.toMatchObject({ code: "ER_DUP_ENTRY" });
+    });
+
+    test("lets many effect_id NULL direct events coexist", async () => {
+      const first = await addContribution(`${prefix}score-user`);
+      const second = await addContribution(`${prefix}score-user`);
+      const third = await addContribution(`${prefix}score-user`);
+
+      // UNIQUE(effect_id, kind, beneficiary) must not collapse every direct event of one
+      // player into one row: MySQL treats each NULL as distinct, which is the design.
+      await mysql("world_boss_score_event").insert([
+        scoreRow({ contribution_id: first }),
+        scoreRow({ contribution_id: second }),
+        scoreRow({ contribution_id: third }),
+      ]);
+
+      await expect(
+        mysql("world_boss_score_event").where({ season_id: seasonId, effect_id: null })
+      ).resolves.toHaveLength(3);
+    });
+
+    test("blocks deleting a contribution or effect that a ledger row still references", async () => {
+      const effectId = await addEffect();
+      const sourceContributionId = (
+        await mysql("world_boss_round_effect").where({ id: effectId }).first()
+      ).source_contribution_id;
+      const scored = await addContribution(`${prefix}score-user`);
+      await mysql("world_boss_score_event").insert(
+        scoreRow({ contribution_id: scored, effect_id: effectId, kind: "assist" })
+      );
+
+      await expect(
+        mysql("world_boss_contribution").where({ id: sourceContributionId }).del()
+      ).rejects.toMatchObject({ code: "ER_ROW_IS_REFERENCED_2" });
+      await expect(
+        mysql("world_boss_contribution").where({ id: scored }).del()
+      ).rejects.toMatchObject({ code: "ER_ROW_IS_REFERENCED_2" });
+      await expect(
+        mysql("world_boss_round_effect").where({ id: effectId }).del()
+      ).rejects.toMatchObject({ code: "ER_ROW_IS_REFERENCED_2" });
+    });
+
+    test("sums and ranks BIGINT score points beyond Number.MAX_SAFE_INTEGER exactly", async () => {
+      const half = "4503599627370496";
+      const users = [`${prefix}sc-a`, `${prefix}sc-b`, `${prefix}sc-c`];
+      const rows = [];
+      for (const [index, user] of users.entries()) {
+        const points = index === 2 ? [half, half] : [half, "4503599627370497"];
+        for (const value of points) {
+          const contributionId = await addContribution(user);
+          rows.push(
+            scoreRow({ contribution_id: contributionId, beneficiary_user_id: user, points: value })
+          );
+        }
+      }
+      await mysql("world_boss_score_event").insert(rows);
+
+      await expect(WorldBossScoreEvent.sumSeasonScore(seasonId, users[0])).resolves.toBe(
+        "9007199254740993"
+      );
+      const ranking = await WorldBossScoreEvent.seasonRanking(seasonId, 100);
+      expect(ranking.map(row => [row.user_id, row.total_score, row.ranking])).toEqual([
+        [users[0], "9007199254740993", 1],
+        [users[1], "9007199254740993", 1],
+        [users[2], "9007199254740992", 3],
+      ]);
+      await expect(WorldBossScoreEvent.seasonRankingAll(seasonId)).resolves.toHaveLength(3);
+      for (const limit of [0, 101, 1.5, Number.NaN]) {
+        await expect(WorldBossScoreEvent.seasonRanking(seasonId, limit)).rejects.toMatchObject({
+          code: "INVALID_RANKING_LIMIT",
+        });
+      }
+      await expect(WorldBossScoreEvent.sumSeasonScore(seasonId, `${prefix}nobody`)).resolves.toBe(
+        "0"
+      );
+    });
+
+    test("bounds the public leaderboard and ranks every contributor internally", async () => {
+      const rows = [];
+      for (let index = 0; index < 104; index += 1) {
+        const user = `${prefix}rank-${String(index).padStart(3, "0")}`;
+        const contributionId = await addContribution(user);
+        rows.push(
+          scoreRow({
+            contribution_id: contributionId,
+            beneficiary_user_id: user,
+            points: String(500 - index),
+          })
+        );
+      }
+      // Two ties inserted in reverse user_id order: the tie-break must come from the query,
+      // not from insertion order.
+      for (const user of [`${prefix}tie-z`, `${prefix}tie-a`]) {
+        const contributionId = await addContribution(user);
+        rows.push(
+          scoreRow({ contribution_id: contributionId, beneficiary_user_id: user, points: "500" })
+        );
+      }
+      await mysql("world_boss_score_event").insert(rows);
+
+      await expect(WorldBossScoreEvent.seasonRanking(seasonId, 1)).resolves.toHaveLength(1);
+      await expect(WorldBossScoreEvent.seasonRanking(seasonId, 100)).resolves.toHaveLength(100);
+      const all = await WorldBossScoreEvent.seasonRankingAll(seasonId);
+      expect(all).toHaveLength(106);
+      expect(all.slice(0, 3).map(row => [row.user_id, row.total_score, row.ranking])).toEqual([
+        [`${prefix}rank-000`, "500", 1],
+        [`${prefix}tie-a`, "500", 1],
+        [`${prefix}tie-z`, "500", 1],
+      ]);
+      expect(all[3]).toMatchObject({ user_id: `${prefix}rank-001`, ranking: 4 });
+      expect(all.find(row => row.ranking === 103)).toBeTruthy();
+    });
+
+    test("ranks a legacy v1 backfill and v2 kinds on one mixed leaderboard", async () => {
+      const legacyUser = `${prefix}mix-legacy`;
+      const mixedUser = `${prefix}mix-both`;
+      const v2User = `${prefix}mix-v2`;
+      const rows = [];
+      // v1 player: only a backfilled legacy direct event, whose contribution has no raw_damage.
+      const legacyContribution = await addContribution(legacyUser, {
+        raw_damage: null,
+        effect_damage: 0,
+        job_key: null,
+        damage: "300",
+      });
+      rows.push(
+        scoreRow({
+          contribution_id: legacyContribution,
+          beneficiary_user_id: legacyUser,
+          points: "300",
+        })
+      );
+      // Returning player: legacy direct 300 + v2 direct 100 + assist 50 + relay 50 = 500.
+      const mixedLegacy = await addContribution(mixedUser, {
+        raw_damage: null,
+        effect_damage: 0,
+        job_key: null,
+        damage: "300",
+      });
+      rows.push(
+        scoreRow({ contribution_id: mixedLegacy, beneficiary_user_id: mixedUser, points: "300" })
+      );
+      const mixedV2 = await addContribution(mixedUser);
+      const effectId = await addEffect();
+      rows.push(
+        scoreRow({ contribution_id: mixedV2, beneficiary_user_id: mixedUser, points: "100" }),
+        scoreRow({
+          contribution_id: mixedV2,
+          effect_id: effectId,
+          beneficiary_user_id: mixedUser,
+          kind: "assist",
+          points: "50",
+        }),
+        scoreRow({
+          contribution_id: mixedV2,
+          effect_id: effectId,
+          beneficiary_user_id: mixedUser,
+          kind: "relay",
+          points: "50",
+        })
+      );
+      // Pure v2 player, tied with the returning player on 500.
+      const v2Contribution = await addContribution(v2User, { raw_damage: "500", damage: "500" });
+      rows.push(
+        scoreRow({ contribution_id: v2Contribution, beneficiary_user_id: v2User, points: "500" })
+      );
+      await mysql("world_boss_score_event").insert(rows);
+
+      await expect(WorldBossScoreEvent.sumSeasonScore(seasonId, mixedUser)).resolves.toBe("500");
+      await expect(WorldBossScoreEvent.seasonScoreByKind(seasonId, mixedUser)).resolves.toEqual({
+        direct: "400",
+        assist: "50",
+        relay: "50",
+      });
+      await expect(WorldBossScoreEvent.seasonScoreByKind(seasonId, legacyUser)).resolves.toEqual({
+        direct: "300",
+        assist: "0",
+        relay: "0",
+      });
+      const ranking = await WorldBossScoreEvent.seasonRankingAll(seasonId);
+      expect(
+        ranking
+          .filter(row => row.user_id.startsWith(`${prefix}mix-`))
+          .map(row => [row.user_id, row.total_score, row.ranking])
+      ).toEqual([
+        [mixedUser, "500", 1],
+        [v2User, "500", 1],
+        [legacyUser, "300", 3],
+      ]);
+    });
+
+    test("lists a player's own effects newest first with the consumer joined in one query", async () => {
+      const source = `${prefix}hist-src`;
+      const taker = `${prefix}hist-taker`;
+      const stranger = `${prefix}hist-other`;
+      const consumedAt = new Date("2026-07-20T03:00:00.000Z");
+      const consumerId = await addContribution(taker, { created_at: consumedAt });
+      const takenId = await addEffect({
+        source_user_id: source,
+        effect_type: "banner",
+        value: "25",
+        consumed_by_contribution_id: consumerId,
+      });
+      const pendingId = await addEffect({ source_user_id: source, effect_type: "seal" });
+      // Someone else's effect and another season's effect must both stay out.
+      await addEffect({ source_user_id: stranger });
+      const otherSeasonId = await createSeason({ name: `${prefix}hist-other-season` });
+
+      const rows = await WorldBossRoundEffect.listSeasonHistoryBySource({
+        seasonId,
+        userId: source,
+        limit: 50,
+      });
+
+      expect(rows.map(row => String(row.id))).toEqual([String(pendingId), String(takenId)]);
+      expect(rows[0]).toMatchObject({
+        effect_type: "seal",
+        value: 50,
+        consumed_by_user_id: null,
+        consumed_at: null,
+      });
+      expect(rows[1]).toMatchObject({
+        effect_type: "banner",
+        value: 25,
+        consumed_by_user_id: taker,
+      });
+      expect(Number(rows[1].round_id)).toBe(Number(rounds[0].id));
+      // consumed_at comes from the consuming contribution, not the effect's updated_at.
+      expect(new Date(rows[1].consumed_at).toISOString()).toBe(consumedAt.toISOString());
+      expect(rows[1].created_at).toBeInstanceOf(Date);
+
+      await expect(
+        WorldBossRoundEffect.listSeasonHistoryBySource({ seasonId, userId: source, limit: 1 })
+      ).resolves.toHaveLength(1);
+      await expect(
+        WorldBossRoundEffect.listSeasonHistoryBySource({
+          seasonId: otherSeasonId,
+          userId: source,
+          limit: 50,
+        })
+      ).resolves.toEqual([]);
+      await expect(
+        WorldBossRoundEffect.listSeasonHistoryBySource({
+          seasonId,
+          userId: `${prefix}nobody`,
+          limit: 50,
+        })
+      ).resolves.toEqual([]);
+    });
+
+    test("finds the oldest consumable effect and never the caller's own", async () => {
+      const mine = await addEffect({ source_user_id: `${prefix}me` });
+      const theirs = await addEffect({ source_user_id: `${prefix}them` });
+      const consumerId = await addContribution(`${prefix}me`);
+
+      await mysql.transaction(async trx => {
+        // The exclusion is a SQL predicate, so my own older effect is skipped rather than
+        // returned and then discarded — otherwise it would block `theirs` forever.
+        const picked = await WorldBossRoundEffect.findConsumableForUpdate(trx, {
+          roundId: rounds[0].id,
+          userId: `${prefix}me`,
+        });
+        expect(Number(picked.id)).toBe(Number(theirs));
+        // Someone else sees the true oldest.
+        const other = await WorldBossRoundEffect.findConsumableForUpdate(trx, {
+          roundId: rounds[0].id,
+          userId: `${prefix}stranger`,
+        });
+        expect(Number(other.id)).toBe(Number(mine));
+
+        await WorldBossRoundEffect.consume(trx, {
+          effectId: theirs,
+          contributionId: consumerId,
+          now: new Date("2026-07-20T00:00:00.000Z"),
+        });
+        // Second consume of the same row affects 0 rows and must abort, not silently pass.
+        await expect(
+          WorldBossRoundEffect.consume(trx, {
+            effectId: theirs,
+            contributionId: consumerId,
+            now: new Date("2026-07-20T00:00:00.000Z"),
+          })
+        ).rejects.toMatchObject({ code: "EFFECT_ALREADY_CONSUMED" });
+      });
+
+      await expect(WorldBossRoundEffect.listUnconsumedByRound(rounds[0].id)).resolves.toHaveLength(
+        1
+      );
+    });
   });
 });

--- a/app/src/service/WorldBossAttackService.js
+++ b/app/src/service/WorldBossAttackService.js
@@ -48,7 +48,8 @@ function attackInput({ progress, bonuses, attackType }) {
   const expBonus = nonNegativeFinite(bonuses.exp_bonus);
 
   return {
-    damage: Math.floor(baseDamage * (1 + atkPercent)),
+    rawDamage: Math.floor(baseDamage * (1 + atkPercent)),
+    jobKey: progress.job_key,
     cost: Math.max(1, baseCost - costReduction),
     exp: PER_HIT_EXP + expBonus,
   };
@@ -167,7 +168,7 @@ async function attack({ userId, roundId, attackType, groupId, displayName }) {
     EquipmentService.getEquipmentBonuses(userId),
   ]);
   const progress = storedProgress || { level: 1, job_key: "adventurer" };
-  const { damage, cost, exp } = attackInput({ progress, bonuses, attackType });
+  const { rawDamage, jobKey, cost, exp } = attackInput({ progress, bonuses, attackType });
 
   let result;
   try {
@@ -175,7 +176,8 @@ async function attack({ userId, roundId, attackType, groupId, displayName }) {
       userId,
       attackType,
       roundId: canonicalRoundId,
-      damage,
+      rawDamage,
+      jobKey,
       cost,
       exp,
     });

--- a/app/src/service/WorldBossBattleService.js
+++ b/app/src/service/WorldBossBattleService.js
@@ -5,12 +5,15 @@ const WorldBossSeason = require("../model/application/WorldBossSeason");
 const WorldBossSeasonBoss = require("../model/application/WorldBossSeasonBoss");
 const WorldBossRound = require("../model/application/WorldBossRound");
 const WorldBossContribution = require("../model/application/WorldBossContribution");
+const WorldBossRoundEffect = require("../model/application/WorldBossRoundEffect");
+const WorldBossScoreEvent = require("../model/application/WorldBossScoreEvent");
 const { canonicalPositiveInteger } = require("../util/decimalInteger");
 
 const DAILY_COST_LIMIT = config.get("worldboss.daily_cost_limit");
 const HP_TIERS = config.get("worldboss.hp_tiers");
 const DEFAULT_PROGRESS = { level: 1, exp: 0 };
 const ATTACK_TYPES = new Set(["standard", "skill"]);
+const JOB_KEYS = new Set(["adventurer", "swordman", "mage", "thief"]);
 const ROSTER_SIZE = WorldBossSeasonBoss.ROSTER_SIZE;
 const TAIPEI_OFFSET_MS = 8 * 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -50,7 +53,16 @@ function nonNegativeInteger(value) {
 
 function validateAttack(input) {
   if (!input || !ATTACK_TYPES.has(input.attackType)) throw fail("INVALID_ATTACK_TYPE");
-  for (const field of ["damage", "cost", "exp"]) {
+  // rawDamage is the player's own uncapped output; it is BIGINT in the schema, so it is
+  // validated as a canonical decimal integer rather than a JS number.
+  let rawDamage;
+  try {
+    rawDamage = BigInt(canonicalPositiveInteger(input.rawDamage));
+  } catch {
+    throw fail("INVALID_RAW_DAMAGE");
+  }
+  if (!JOB_KEYS.has(input.jobKey)) throw fail("INVALID_JOB_KEY");
+  for (const field of ["cost", "exp"]) {
     if (!positiveSafeInteger(input[field])) throw fail(`INVALID_${field.toUpperCase()}`);
   }
   let roundId;
@@ -59,7 +71,7 @@ function validateAttack(input) {
   } catch {
     throw fail("INVALID_ROUND_ID");
   }
-  return roundId;
+  return { roundId, rawDamage };
 }
 
 function isExpired(season, now) {
@@ -225,14 +237,62 @@ function createBattleService({ activeSlot = 1, clock = () => new Date(), hooks =
     return dailyFor(userId, clock());
   }
 
+  /**
+   * Builds the score ledger for one attack. Three layers, three rules:
+   *  - direct  : always, to the attacker, worth the UNCAPPED raw damage. Overkill is
+   *              discarded from HP but never from score, otherwise the last hit on a
+   *              boss would be worth less than the same hit one second earlier.
+   *  - assist  : to whoever left the effect, worth the effect's value.
+   *  - relay   : only for a banner, to the attacker. A seal already paid the attacker
+   *              in HP damage, so paying a relay on top would double-count it.
+   */
+  function scoreRowsFor({ season, round, contributionId, userId, rawDamage, effect, now }) {
+    const base = {
+      season_id: season.id,
+      round_id: round.id,
+      contribution_id: contributionId,
+      created_at: now,
+      updated_at: now,
+    };
+    const rows = [
+      {
+        ...base,
+        effect_id: null,
+        beneficiary_user_id: userId,
+        kind: WorldBossScoreEvent.KINDS.DIRECT,
+        points: rawDamage.toString(),
+      },
+    ];
+    if (!effect) return rows;
+
+    const points = canonicalPositiveInteger(effect.value);
+    rows.push({
+      ...base,
+      effect_id: effect.id,
+      beneficiary_user_id: effect.source_user_id,
+      kind: WorldBossScoreEvent.KINDS.ASSIST,
+      points,
+    });
+    if (effect.effect_type === WorldBossRoundEffect.TYPES.BANNER) {
+      rows.push({
+        ...base,
+        effect_id: effect.id,
+        beneficiary_user_id: userId,
+        kind: WorldBossScoreEvent.KINDS.RELAY,
+        points,
+      });
+    }
+    return rows;
+  }
+
   async function attack(input) {
-    const roundId = validateAttack(input);
-    const { userId, damage, cost, exp } = input;
+    const { roundId, rawDamage } = validateAttack(input);
+    const { userId, jobKey, cost, exp } = input;
     await onAttackStarted({ userId });
     return mysql.transaction(async trx => {
       // The season row is the single global serializer for every attack; every later
-      // lock (roster, rounds, user) is only ever taken while holding it, so no attack
-      // pair can deadlock on ordering.
+      // lock (roster, rounds, user, effects) is only ever taken while holding it, so no
+      // attack pair can deadlock on ordering.
       const season = await WorldBossSeason.findActiveForUpdate(activeSlot, trx);
       if (!season) throw fail("NO_ACTIVE_SEASON");
       const now = clock();
@@ -257,8 +317,21 @@ function createBattleService({ activeSlot = 1, clock = () => new Date(), hooks =
       const beforeDaily = await dailyFor(userId, now, trx);
       if (beforeDaily.used + cost > DAILY_COST_LIMIT) throw fail("DAILY_LIMIT_EXCEEDED");
 
-      // Overkill is discarded: only the damage that actually removed HP is credited.
-      const requestedDamage = BigInt(damage);
+      // Consume before creating, or an adventurer/mage would detonate the effect it just
+      // left in this very hit. The "not my own effect" filter lives in SQL — see the model.
+      const effect = await WorldBossRoundEffect.findConsumableForUpdate(trx, {
+        roundId: round.id,
+        userId,
+      });
+      // A banner is pure score: it pays an assist and a relay but removes no HP. A seal is
+      // stored damage: it detonates into the HP pool and therefore into the overkill cap.
+      const effectDamage =
+        effect && effect.effect_type === WorldBossRoundEffect.TYPES.SEAL
+          ? BigInt(canonicalPositiveInteger(effect.value))
+          : 0n;
+
+      // Overkill removes no HP, but it is still credited as score — only the HP ledger caps.
+      const requestedDamage = rawDamage + effectDamage;
       const effectiveDamage = requestedDamage > currentHp ? currentHp : requestedDamage;
       const remainingHp = currentHp - effectiveDamage;
       const cleared = remainingHp === 0n;
@@ -268,6 +341,61 @@ function createBattleService({ activeSlot = 1, clock = () => new Date(), hooks =
           current_hp: remainingHp.toString(),
           cleared_at: cleared ? now : null,
         });
+
+      const [contributionId] = await trx("world_boss_contribution").insert({
+        season_id: season.id,
+        round_id: round.id,
+        user_id: userId,
+        raw_damage: rawDamage.toString(),
+        effect_damage: effectDamage.toString(),
+        job_key: jobKey,
+        damage: effectiveDamage.toString(),
+        cost,
+        created_at: now,
+        updated_at: now,
+      });
+
+      if (effect) {
+        await WorldBossRoundEffect.consume(trx, {
+          effectId: effect.id,
+          contributionId,
+          now,
+        });
+      }
+      const scoreRows = scoreRowsFor({
+        season,
+        round,
+        contributionId,
+        userId,
+        rawDamage,
+        effect,
+        now,
+      });
+      await WorldBossScoreEvent.insertMany(trx, scoreRows);
+
+      // A dead boss can never be attacked again, so an effect left on this hit could never
+      // be consumed — do not create data that is unreachable by construction.
+      const plan = cleared ? null : WorldBossRoundEffect.planFor(jobKey, rawDamage.toString());
+      let createdEffect = null;
+      if (plan) {
+        const createdId = await WorldBossRoundEffect.insert(trx, {
+          season_id: season.id,
+          round_id: round.id,
+          source_contribution_id: contributionId,
+          source_user_id: userId,
+          effect_type: plan.effect_type,
+          value: plan.value.toString(),
+          consumed_by_contribution_id: null,
+          created_at: now,
+          updated_at: now,
+        });
+        createdEffect = WorldBossRoundEffect.toDto({
+          id: createdId,
+          effect_type: plan.effect_type,
+          value: plan.value.toString(),
+          source_user_id: userId,
+        });
+      }
 
       const cycleRounds = await WorldBossRound.listCycleForUpdate(season.id, currentCycleNo, trx);
       const allCleared =
@@ -282,18 +410,10 @@ function createBattleService({ activeSlot = 1, clock = () => new Date(), hooks =
         rounds = opened.rounds;
       }
 
-      await trx("world_boss_contribution").insert({
-        season_id: season.id,
-        round_id: round.id,
-        user_id: userId,
-        damage: effectiveDamage.toString(),
-        cost,
-        created_at: now,
-        updated_at: now,
-      });
       const levelUnits = await trx("minigame_level_unit").select("level", "max_exp");
       const levelResult = await applyJobExp({ userId, progress, earnedExp: exp, levelUnits, trx });
       const seasonTotalDamage = await WorldBossContribution.sumSeasonDamage(season.id, userId, trx);
+      const seasonTotalScore = await WorldBossScoreEvent.sumSeasonScore(season.id, userId, trx);
       const daily = await dailyFor(userId, now, trx);
       const attackedRound = cycleRounds.find(row => String(row.id) === String(round.id));
 
@@ -306,12 +426,22 @@ function createBattleService({ activeSlot = 1, clock = () => new Date(), hooks =
         boss: bossOf(round),
         rounds,
         cleared,
-        damage,
+        rawDamage: rawDamage.toString(),
+        effectDamage: effectDamage.toString(),
+        // The HP actually removed — same semantics as the contribution.damage column.
         effectiveDamage: effectiveDamage.toString(),
-        wastedDamage: (requestedDamage - effectiveDamage).toString(),
+        overkillDamage: (requestedDamage - effectiveDamage).toString(),
+        // The whole ledger this attack wrote, not just the attacker's slice: `direct` and
+        // `relay` go to the attacker, `assist` goes to consumedEffect.sourceUserId. Filtering
+        // to the attacker would make `assist` a permanently-zero field, since a player can
+        // never consume their own effect.
+        scoreGained: WorldBossScoreEvent.breakdown(scoreRows),
+        consumedEffect: effect ? WorldBossRoundEffect.toDto(effect) : null,
+        createdEffect,
         cost,
         levelResult,
         seasonTotalDamage,
+        seasonTotalScore,
         daily,
       };
     });

--- a/app/src/service/WorldBossSeasonService.js
+++ b/app/src/service/WorldBossSeasonService.js
@@ -4,6 +4,8 @@ const WorldBossSeason = require("../model/application/WorldBossSeason");
 const WorldBossSeasonBoss = require("../model/application/WorldBossSeasonBoss");
 const WorldBossRound = require("../model/application/WorldBossRound");
 const WorldBossContribution = require("../model/application/WorldBossContribution");
+const WorldBossScoreEvent = require("../model/application/WorldBossScoreEvent");
+const WorldBossRoundEffect = require("../model/application/WorldBossRoundEffect");
 const WorldBossSeasonReward = require("../model/application/WorldBossSeasonReward");
 const { inventory } = require("../model/application/Inventory");
 const UserTitle = require("../model/application/UserTitle");
@@ -114,10 +116,17 @@ function rewardFor(ranking) {
     : { stone: 0, title_key: null };
 }
 
+/**
+ * 名次由 total_score 決定，但 ledger 兩個統計欄位都要核對：只比對其中一個，另一個被寫錯
+ * 或被舊版流程寫入時會靜默通過。
+ */
 function ledgerMatches(ledger, row, reward) {
   return (
     ledger.user_id === row.user_id &&
     Number(ledger.ranking) === row.ranking &&
+    ledger.total_score !== null &&
+    ledger.total_score !== undefined &&
+    canonicalUnsignedInteger(ledger.total_score) === row.total_score &&
     canonicalUnsignedInteger(ledger.total_damage) === row.total_damage &&
     Number(ledger.stone_amount) === reward.stone &&
     (ledger.title_key || null) === reward.title_key
@@ -126,6 +135,23 @@ function ledgerMatches(ledger, row, reward) {
 
 function settlementResult(seasonId, contributors, rewarded, zeroTier) {
   return { seasonId: canonicalUnsignedInteger(seasonId), contributors, rewarded, zeroTier };
+}
+
+/**
+ * 結算用的完整名次：名次與 total_score 來自 score event，total_damage 另外從 contribution
+ * 聚合後貼上，兩者都要寫進 ledger。
+ *
+ * 名單以 score event 為準。理論上每個受益者在同賽季都至少有一筆 contribution（assist 的
+ * 受益者必須先出手才留得下效果），但 legacy backfill 只搬了 `damage > 0` 的列，所以打出
+ * 0 傷害的 v1 玩家不在榜上 —— 他分數本來就是 0，屬於 zero tier，不影響任何獎勵。反向的
+ * 缺漏則以 "0" 補齊，不讓 ledger 寫入 undefined。
+ */
+async function scoreRankingWithDamage(seasonId, trx) {
+  const [ranking, damageByUser] = await Promise.all([
+    WorldBossScoreEvent.seasonRankingAll(seasonId, trx),
+    WorldBossContribution.seasonDamageByUser(seasonId, trx),
+  ]);
+  return ranking.map(row => ({ ...row, total_damage: damageByUser.get(row.user_id) || "0" }));
 }
 
 function createSeasonService({ activeSlot = 1, clock = () => new Date(), hooks = {} } = {}) {
@@ -234,6 +260,15 @@ function createSeasonService({ activeSlot = 1, clock = () => new Date(), hooks =
     if (!season) return null;
     const ended = isEnded(season, serviceNow());
     const { cycleNo, rounds } = await WorldBossRound.listCurrentCycle(season.id);
+    const pendingByRound = await WorldBossRoundEffect.countPendingByRounds(
+      rounds.map(round => round.id)
+    );
+    rounds.forEach(round => {
+      round.pending_effects =
+        round.cleared_at || BigInt(round.current_hp) === 0n
+          ? { banner: 0, seal: 0 }
+          : pendingByRound.get(String(round.id)) || { banner: 0, seal: 0 };
+    });
     return { season, cycleNo, rounds, ended };
   }
 
@@ -242,7 +277,7 @@ function createSeasonService({ activeSlot = 1, clock = () => new Date(), hooks =
   }
 
   async function getRanking(seasonId, limit) {
-    const ranking = await WorldBossContribution.seasonRanking(seasonId, limit);
+    const ranking = await WorldBossScoreEvent.seasonRanking(seasonId, limit);
     const userIds = ranking.map(row => row.user_id);
     const profiles = userIds.length
       ? await mysql("user").whereIn("platform_id", userIds).select("platform_id", "display_name")
@@ -255,6 +290,20 @@ function createSeasonService({ activeSlot = 1, clock = () => new Date(), hooks =
 
   async function getUserTotalDamage(seasonId, userId) {
     return WorldBossContribution.sumSeasonDamage(seasonId, userId);
+  }
+
+  /**
+   * 個人賽季統計。分數來自 score event、傷害來自 contribution —— 兩者在 v2 之後是不同的
+   * 帳本，不可互相推導。v1 舊資料（raw_damage IS NULL）不計入 damage.raw / effect /
+   * overkill，詳見 WorldBossContribution.seasonDamageStats。
+   */
+  async function getUserSeasonStats(seasonId, userId) {
+    const [totalScore, score, damage] = await Promise.all([
+      WorldBossScoreEvent.sumSeasonScore(seasonId, userId),
+      WorldBossScoreEvent.seasonScoreByKind(seasonId, userId),
+      WorldBossContribution.seasonDamageStats(seasonId, userId),
+    ]);
+    return { seasonId: canonicalUnsignedInteger(seasonId), totalScore, score, damage };
   }
 
   async function getLatestSettledResult(userId) {
@@ -272,6 +321,7 @@ function createSeasonService({ activeSlot = 1, clock = () => new Date(), hooks =
         season_id: seasonId,
         user_id: row.user_id,
         ranking: row.ranking,
+        total_score: row.total_score,
         total_damage: row.total_damage,
         stone_amount: reward.stone,
         title_key: reward.title_key,
@@ -315,7 +365,7 @@ function createSeasonService({ activeSlot = 1, clock = () => new Date(), hooks =
       if (season.status !== "active" || !isEnded(season, now)) {
         throw fail("SEASON_NOT_EXPIRED");
       }
-      const ranking = await WorldBossContribution.seasonRankingAll(season.id, trx);
+      const ranking = await scoreRankingWithDamage(season.id, trx);
       let rewarded = 0;
       let zeroTier = 0;
       for (const row of ranking) {
@@ -366,6 +416,7 @@ function createSeasonService({ activeSlot = 1, clock = () => new Date(), hooks =
     getSeasonRoster,
     getRanking,
     getUserTotalDamage,
+    getUserSeasonStats,
     getLatestSettledResult,
     settleSeason,
     settleExpiredSeasons,

--- a/app/src/service/__tests__/WorldBossAttackService.test.js
+++ b/app/src/service/__tests__/WorldBossAttackService.test.js
@@ -30,6 +30,7 @@ const broadcastQueue = require("../../util/broadcastQueue");
 const redis = require("../../util/redis");
 const { DefaultLogger } = require("../../util/Logger");
 const AttackService = require("../WorldBossAttackService");
+const ActualRPGCharacter = jest.requireActual("../../model/application/RPGCharacter");
 
 const USER = "Uattacker";
 const GROUP = `C${"a".repeat(32)}`;
@@ -46,9 +47,13 @@ function character({ standard = 100, skill = 200, skillCost = 7 } = {}) {
 
 function result(overrides = {}) {
   return {
-    damage: 100,
+    rawDamage: "100",
+    effectDamage: "0",
     effectiveDamage: "100",
-    wastedDamage: "0",
+    overkillDamage: "0",
+    scoreGained: { direct: "100", assist: "0", relay: "0" },
+    consumedEffect: null,
+    createdEffect: null,
     cost: 10,
     cleared: false,
     cycleAdvanced: false,
@@ -57,6 +62,7 @@ function result(overrides = {}) {
     boss: { id: 7, position: 2, name: "冰狼" },
     levelResult: { levelUp: false },
     seasonTotalDamage: "1000",
+    seasonTotalScore: "1000",
     daily: { limit: 100, used: 10, remaining: 90 },
     ...overrides,
   };
@@ -123,6 +129,69 @@ describe("WorldBossAttackService — input validation", () => {
 });
 
 describe("WorldBossAttackService — the shared attack seam", () => {
+  describe.each([
+    ["adventurer", 8, 1.2],
+    ["swordman", 10, 1.8],
+    ["mage", 7, 0.7],
+    ["thief", 20, 2.1],
+  ])("RPG skill contract — %s", (jobKey, expectedCost, expectedRate) => {
+    it("uses the adjusted cost and rate", () => {
+      const instance = ActualRPGCharacter.make(jobKey, { level: 100 });
+      expect(instance.skillOne).toEqual(
+        expect.objectContaining({
+          cost: expectedCost,
+          rate: expectedRate,
+        })
+      );
+    });
+
+    it("uses normal damage and does not add an unintended critical hit", () => {
+      const instance = ActualRPGCharacter.make(jobKey, { level: 100 });
+      jest.spyOn(instance, "getNormalDamage").mockReturnValue(1000);
+      const critical = jest.spyOn(instance, "isCritical").mockReturnValue(false);
+
+      expect(instance.getSkillOneDamage()).toBe(Math.floor(1000 * expectedRate));
+      if (jobKey === "swordman" || jobKey === "adventurer") {
+        expect(critical).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  it("keeps mage and thief critical settings unchanged", () => {
+    expect(ActualRPGCharacter.make("mage", { level: 100 }).skillOne).toEqual(
+      expect.objectContaining({
+        criticalRate: 25,
+        criticalConfig: [
+          { min: 1.8, max: 2.2, rate: 60 },
+          { min: 2.2, max: 2.6, rate: 25 },
+          { min: 2.6, max: 3.0, rate: 12 },
+          { min: 3.0, max: 3.5, rate: 3 },
+        ],
+      })
+    );
+    expect(ActualRPGCharacter.make("thief", { level: 100 }).skillOne).toEqual(
+      expect.objectContaining({
+        criticalRate: 50,
+        criticalConfig: [
+          { min: 1.2, max: 1.5, rate: 10 },
+          { min: 1.5, max: 2.0, rate: 25 },
+          { min: 2.0, max: 2.8, rate: 35 },
+          { min: 2.8, max: 3.8, rate: 25 },
+          { min: 3.8, max: 5.0, rate: 5 },
+        ],
+      })
+    );
+    expect(ActualRPGCharacter.make("swordman", { level: 100 }).skillOne).not.toHaveProperty(
+      "criticalRate"
+    );
+  });
+
+  it("keeps standard attacks independent from skill values", () => {
+    const instance = ActualRPGCharacter.make("mage", { level: 100 });
+    expect(instance.getStandardDamage()).toBe(11000);
+    expect(instance.attack()).toBe(11000);
+  });
+
   it("computes standard damage, base cost and exp from RPG + equipment exactly", async () => {
     const standard = character({ standard: 100, skill: 999, skillCost: 7 });
     RPGCharacter.make.mockReturnValue(standard);
@@ -142,10 +211,15 @@ describe("WorldBossAttackService — the shared attack seam", () => {
       userId: USER,
       attackType: "standard",
       roundId: "2",
-      damage: 125,
+      rawDamage: 125,
+      jobKey: "mage",
       cost: 8,
       exp: 125,
     });
+    // The transitional `damage` alias is gone: BattleService takes rawDamage + jobKey only.
+    // toHaveBeenCalledWith is exact, so an extra key would already fail — this asserts the
+    // intent explicitly so a future re-add is caught by name.
+    expect(BattleService.attack.mock.calls[0][0]).not.toHaveProperty("damage");
   });
 
   it("computes skill damage and skill cost with equipment bonuses exactly", async () => {
@@ -165,7 +239,8 @@ describe("WorldBossAttackService — the shared attack seam", () => {
       userId: USER,
       attackType: "skill",
       roundId: "2",
-      damage: 300,
+      rawDamage: 300,
+      jobKey: "swordman",
       cost: 5,
       exp: 123,
     });
@@ -182,7 +257,12 @@ describe("WorldBossAttackService — the shared attack seam", () => {
     await AttackService.attack({ userId: USER, roundId: 2, attackType: "standard" });
 
     expect(BattleService.attack).toHaveBeenCalledWith(
-      expect.objectContaining({ damage: 10, cost: 10, exp: 120 })
+      expect.objectContaining({
+        rawDamage: 10,
+        jobKey: "swordman",
+        cost: 10,
+        exp: 120,
+      })
     );
   });
 

--- a/app/src/service/__tests__/WorldBossBattleService.test.js
+++ b/app/src/service/__tests__/WorldBossBattleService.test.js
@@ -11,6 +11,7 @@ jest.mock("../../util/mysql", () => mysql);
 const MinigameLevel = require("../../model/application/MinigameLevel");
 const WorldBossSeasonBoss = require("../../model/application/WorldBossSeasonBoss");
 const WorldBossRound = require("../../model/application/WorldBossRound");
+const WorldBossRoundEffect = require("../../model/application/WorldBossRoundEffect");
 const { createBattleService } = require("../WorldBossBattleService");
 
 const prefix = `${PREFIX}battle_`;
@@ -68,6 +69,9 @@ async function cleanupOwned({ includeSentinels = false } = {}) {
     .select("id");
   const seasonIds = seasons.map(season => season.id);
   if (seasonIds.length) {
+    // FK RESTRICT: the score/effect ledgers point at contributions, so they must go first.
+    await mysql("world_boss_score_event").whereIn("season_id", seasonIds).del();
+    await mysql("world_boss_round_effect").whereIn("season_id", seasonIds).del();
     await mysql("world_boss_season_reward").whereIn("season_id", seasonIds).del();
     await mysql("world_boss_contribution").whereIn("season_id", seasonIds).del();
     const roster = await mysql("world_boss_season_boss")
@@ -152,6 +156,80 @@ async function createBattleFixture({
   return { userId, userDbId, bossIds, seasonId, roster, rounds, cycleNo };
 }
 
+function attackWith(service, overrides) {
+  return service.attack({
+    attackType: "standard",
+    jobKey: "swordman",
+    cost: 1,
+    exp: 1,
+    ...overrides,
+    roundId: String(overrides.roundId),
+  });
+}
+
+async function listContributions(seasonId) {
+  return mysql("world_boss_contribution").where({ season_id: seasonId }).orderBy("id");
+}
+
+async function listScoreEvents(seasonId) {
+  return mysql("world_boss_score_event").where({ season_id: seasonId }).orderBy("id");
+}
+
+async function listEffects(seasonId) {
+  return mysql("world_boss_round_effect").where({ season_id: seasonId }).orderBy("id");
+}
+
+/**
+ * The three ledgers of one contribution, as plain strings. Reading damage alone can no
+ * longer tell a seal detonation apart from a bigger raw hit, so every damage assertion
+ * checks raw / effect / HP-applied together plus the direct score.
+ */
+async function ledgerOf(contributionId) {
+  const row = await mysql("world_boss_contribution").where({ id: contributionId }).first();
+  const direct = await mysql("world_boss_score_event")
+    .where({ contribution_id: contributionId, kind: "direct" })
+    .first();
+  return {
+    raw_damage: String(row.raw_damage),
+    effect_damage: String(row.effect_damage),
+    damage: String(row.damage),
+    job_key: row.job_key,
+    direct_points: direct ? String(direct.points) : null,
+  };
+}
+
+/**
+ * An unconsumed effect left by `userId` on `roundId`. The FK to a source contribution is
+ * NOT NULL, so a seeded effect needs a seeded contribution to hang off — that contribution
+ * is deliberately given cost 0 so it cannot disturb a quota assertion.
+ */
+async function seedEffect({ seasonId, roundId, userId, type, value, at = now }) {
+  const [sourceContributionId] = await mysql("world_boss_contribution").insert({
+    season_id: seasonId,
+    round_id: roundId,
+    user_id: userId,
+    raw_damage: String(value),
+    effect_damage: "0",
+    job_key: type === "banner" ? "adventurer" : "mage",
+    damage: "0",
+    cost: 0,
+    created_at: at,
+    updated_at: at,
+  });
+  const [id] = await mysql("world_boss_round_effect").insert({
+    season_id: seasonId,
+    round_id: roundId,
+    source_contribution_id: sourceContributionId,
+    source_user_id: userId,
+    effect_type: type,
+    value: String(value),
+    consumed_by_contribution_id: null,
+    created_at: at,
+    updated_at: at,
+  });
+  return { id, sourceContributionId };
+}
+
 async function assertSentinelsPreserved() {
   await expect(
     mysql("user").where({ platform_id: sentinel.userId }).first()
@@ -203,21 +281,27 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(target.id),
       attackType: "standard",
-      damage: 25,
+      rawDamage: 25,
+      jobKey: "swordman",
       cost: 10,
       exp: 5,
     });
 
     expect(result).toMatchObject({
-      damage: 25,
+      rawDamage: "25",
+      effectDamage: "0",
       effectiveDamage: "25",
-      wastedDamage: "0",
+      overkillDamage: "0",
+      scoreGained: { direct: "25", assist: "0", relay: "0" },
+      consumedEffect: null,
+      createdEffect: null,
       cost: 10,
       cleared: false,
       cycleAdvanced: false,
       attackedCycleNo: 1,
       cycleNo: 1,
       seasonTotalDamage: "25",
+      seasonTotalScore: "25",
       daily: { limit: 100, used: 10, remaining: 90 },
       levelResult: { levelUp: false, newLevel: 1, newExp: 5, levelUpCount: 0, nextLevelExp: 24 },
     });
@@ -229,14 +313,29 @@ describe("WorldBossBattleService", () => {
     const rounds = await WorldBossRound.listCycle(fixture.seasonId, 1);
     expect(rounds.map(row => Number(row.current_hp))).toEqual([100, 100, 75, 100, 100]);
     expect(rounds.every(row => row.cleared_at === null)).toBe(true);
-    await expect(
-      mysql("world_boss_contribution").where({ season_id: fixture.seasonId }).first()
-    ).resolves.toMatchObject({
+    const [contribution] = await listContributions(fixture.seasonId);
+    expect(contribution).toMatchObject({
       user_id: fixture.userId,
       round_id: target.id,
       damage: 25,
       cost: 10,
     });
+    await expect(ledgerOf(contribution.id)).resolves.toEqual({
+      raw_damage: "25",
+      effect_damage: "0",
+      damage: "25",
+      job_key: "swordman",
+      direct_points: "25",
+    });
+    // Exactly one score event, and no effect written or consumed by a swordman.
+    const events = await listScoreEvents(fixture.seasonId);
+    expect(events.map(row => [row.kind, row.beneficiary_user_id, String(row.points)])).toEqual([
+      ["direct", fixture.userId, "25"],
+    ]);
+    expect(events[0].effect_id).toBeNull();
+    await expect(listEffects(fixture.seasonId)).resolves.toEqual([]);
+    // One attack, one quota charge.
+    expect(await listContributions(fixture.seasonId)).toHaveLength(1);
     await expect(
       mysql("minigame_level").where({ user_id: fixture.userDbId }).first()
     ).resolves.toMatchObject({ level: 1, exp: 5 });
@@ -252,7 +351,8 @@ describe("WorldBossBattleService", () => {
           userId: fixture.userId,
           roundId: String(round.id),
           attackType: "standard",
-          damage: 10,
+          rawDamage: 10,
+          jobKey: "swordman",
           cost: 1,
           exp: 1,
         })
@@ -279,22 +379,33 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(target.id),
       attackType: "skill",
-      damage: 45123,
+      rawDamage: 45123,
+      jobKey: "swordman",
       cost: 10,
       exp: 7,
     });
 
     expect(result).toMatchObject({
-      damage: 45123,
+      rawDamage: "45123",
+      effectDamage: "0",
       effectiveDamage: "100",
-      wastedDamage: "45023",
+      overkillDamage: "45023",
+      // Overkill is discarded from HP but not from score: direct is the full raw hit.
+      scoreGained: { direct: "45123", assist: "0", relay: "0" },
       cleared: true,
       cycleAdvanced: false,
       seasonTotalDamage: "100",
+      seasonTotalScore: "45123",
     });
-    await expect(
-      mysql("world_boss_contribution").where({ season_id: fixture.seasonId }).first()
-    ).resolves.toMatchObject({ damage: 100, cost: 10 });
+    const [contribution] = await listContributions(fixture.seasonId);
+    expect(contribution).toMatchObject({ damage: 100, cost: 10 });
+    await expect(ledgerOf(contribution.id)).resolves.toEqual({
+      raw_damage: "45123",
+      effect_damage: "0",
+      damage: "100",
+      job_key: "swordman",
+      direct_points: "45123",
+    });
     const rounds = await WorldBossRound.listCycle(fixture.seasonId, 1);
     expect(Number(rounds[0].current_hp)).toBe(0);
     expect(rounds[0].cleared_at).toBeInstanceOf(Date);
@@ -314,7 +425,8 @@ describe("WorldBossBattleService", () => {
         userId: fixture.userId,
         roundId: String(round.id),
         attackType: "standard",
-        damage: 10,
+        rawDamage: 10,
+        jobKey: "swordman",
         cost: 1,
         exp: 1,
       });
@@ -340,7 +452,8 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(survivor.id),
       attackType: "skill",
-      damage: 10,
+      rawDamage: 10,
+      jobKey: "swordman",
       cost: 5,
       exp: 5,
     });
@@ -392,7 +505,8 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(fixture.rounds[4].id),
       attackType: "standard",
-      damage: 10,
+      rawDamage: 10,
+      jobKey: "swordman",
       cost: 1,
       exp: 1,
     });
@@ -423,7 +537,8 @@ describe("WorldBossBattleService", () => {
         userId: fixture.userId,
         roundId: String(fixture.rounds[0].id),
         attackType: "standard",
-        damage: 10,
+        rawDamage: 10,
+        jobKey: "swordman",
         cost: 10,
         exp: 10,
       })
@@ -454,7 +569,8 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(fixture.rounds[4].id),
       attackType: "standard",
-      damage: 10,
+      rawDamage: 10,
+      jobKey: "swordman",
       cost: 1,
       exp: 1,
     });
@@ -471,7 +587,8 @@ describe("WorldBossBattleService", () => {
           userId: fixture.userId,
           roundId: String(round.id),
           attackType: "standard",
-          damage: 5,
+          rawDamage: 5,
+          jobKey: "swordman",
           cost: 10,
           exp: 10,
         })
@@ -504,7 +621,8 @@ describe("WorldBossBattleService", () => {
         userId: newPlayer,
         roundId: String(foreign.rounds[0].id),
         attackType: "standard",
-        damage: 10,
+        rawDamage: 10,
+        jobKey: "swordman",
         cost: 10,
         exp: 10,
       })
@@ -533,25 +651,71 @@ describe("WorldBossBattleService", () => {
         userId: fixture.userId,
         roundId,
         attackType: "unknown",
-        damage: 1,
+        rawDamage: 1,
+        jobKey: "swordman",
         cost: 1,
         exp: 1,
       })
     ).rejects.toMatchObject({ code: "INVALID_ATTACK_TYPE" });
-    for (const field of ["damage", "cost", "exp"]) {
-      for (const value of [0, -1, 0.5, Number.NaN, Infinity, Number.MAX_SAFE_INTEGER + 1]) {
+    for (const field of ["rawDamage", "cost", "exp"]) {
+      for (const value of [0, -1, 0.5, Number.NaN, Infinity]) {
         await expect(
           service.attack({
             userId: fixture.userId,
             roundId,
             attackType: "standard",
-            damage: 1,
+            rawDamage: 1,
+            jobKey: "swordman",
             cost: 1,
             exp: 1,
             [field]: value,
           })
-        ).rejects.toMatchObject({ code: `INVALID_${field.toUpperCase()}` });
+        ).rejects.toMatchObject({
+          code: `INVALID_${field === "rawDamage" ? "RAW_DAMAGE" : field.toUpperCase()}`,
+        });
       }
+    }
+    // cost/exp stay JS-safe integers; rawDamage is BIGINT, so a value past
+    // MAX_SAFE_INTEGER must arrive as an exact decimal string, never as a float.
+    for (const field of ["cost", "exp"]) {
+      await expect(
+        service.attack({
+          userId: fixture.userId,
+          roundId,
+          attackType: "standard",
+          rawDamage: 1,
+          jobKey: "swordman",
+          cost: 1,
+          exp: 1,
+          [field]: Number.MAX_SAFE_INTEGER + 1,
+        })
+      ).rejects.toMatchObject({ code: `INVALID_${field.toUpperCase()}` });
+    }
+    for (const rawDamage of [Number.MAX_SAFE_INTEGER + 1, "1e3", "01x", "-5", "1.0", {}, null]) {
+      await expect(
+        service.attack({
+          userId: fixture.userId,
+          roundId,
+          attackType: "standard",
+          rawDamage,
+          jobKey: "swordman",
+          cost: 1,
+          exp: 1,
+        })
+      ).rejects.toMatchObject({ code: "INVALID_RAW_DAMAGE" });
+    }
+    for (const jobKey of [undefined, null, "", "ADVENTURER", "priest", 1, {}]) {
+      await expect(
+        service.attack({
+          userId: fixture.userId,
+          roundId,
+          attackType: "standard",
+          rawDamage: 1,
+          jobKey,
+          cost: 1,
+          exp: 1,
+        })
+      ).rejects.toMatchObject({ code: "INVALID_JOB_KEY" });
     }
     for (const value of [undefined, null, "", "0", 0, -1, 1.5, "abc", "1e3", {}]) {
       await expect(
@@ -559,7 +723,8 @@ describe("WorldBossBattleService", () => {
           userId: fixture.userId,
           roundId: value,
           attackType: "standard",
-          damage: 1,
+          rawDamage: 1,
+          jobKey: "swordman",
           cost: 1,
           exp: 1,
         })
@@ -576,8 +741,16 @@ describe("WorldBossBattleService", () => {
 
     for (const attackType of ["standard", "skill"]) {
       await expect(
-        service.attack({ userId: fixture.userId, roundId, attackType, damage: 1, cost: 1, exp: 1 })
-      ).resolves.toMatchObject({ damage: 1, cost: 1 });
+        service.attack({
+          userId: fixture.userId,
+          roundId,
+          attackType,
+          rawDamage: 1,
+          jobKey: "swordman",
+          cost: 1,
+          exp: 1,
+        })
+      ).resolves.toMatchObject({ rawDamage: "1", effectiveDamage: "1", cost: 1 });
     }
   });
 
@@ -652,7 +825,8 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(target.id),
       attackType: "standard",
-      damage: 1,
+      rawDamage: 1,
+      jobKey: "swordman",
       cost: 1,
       exp: 1,
     });
@@ -678,14 +852,14 @@ describe("WorldBossBattleService", () => {
         userId: fixture.userId,
         roundId: String(target.id),
         attackType: "standard",
-        damage: Number.MAX_SAFE_INTEGER,
+        rawDamage: Number.MAX_SAFE_INTEGER,
+        jobKey: "swordman",
         cost: 1,
         exp: 1,
       })
     ).resolves.toMatchObject({
       seasonTotalDamage: "9007199254740991",
       effectiveDamage: "9007199254740991",
-      wastedDamage: "0",
     });
 
     await expect(mysql("world_boss_round").where({ id: target.id }).first()).resolves.toMatchObject(
@@ -706,7 +880,8 @@ describe("WorldBossBattleService", () => {
         userId: fixture.userId,
         roundId: String(fixture.rounds[0].id),
         attackType: "standard",
-        damage: 100,
+        rawDamage: 100,
+        jobKey: "swordman",
         cost: 10,
         exp: 10,
       })
@@ -739,7 +914,8 @@ describe("WorldBossBattleService", () => {
         userId: fixture.userId,
         roundId: String(fixture.rounds[0].id),
         attackType: "standard",
-        damage: 1,
+        rawDamage: 1,
+        jobKey: "swordman",
         cost: 1,
         exp: 1,
       })
@@ -768,7 +944,8 @@ describe("WorldBossBattleService", () => {
         userId: fixture.userId,
         roundId: String(fixture.rounds[4].id),
         attackType: "skill",
-        damage: 10,
+        rawDamage: 10,
+        jobKey: "swordman",
         cost: 10,
         exp: 5,
       })
@@ -793,7 +970,8 @@ describe("WorldBossBattleService", () => {
       userId,
       roundId: String(fixture.rounds[0].id),
       attackType: "standard",
-      damage: 1,
+      rawDamage: 1,
+      jobKey: "swordman",
       cost: 1,
       exp: 1,
     });
@@ -801,7 +979,8 @@ describe("WorldBossBattleService", () => {
       userId,
       roundId: String(fixture.rounds[1].id),
       attackType: "skill",
-      damage: 1,
+      rawDamage: 1,
+      jobKey: "swordman",
       cost: 1,
       exp: 1,
     });
@@ -961,7 +1140,8 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(fixture.rounds[0].id),
       attackType: "standard",
-      damage: 10,
+      rawDamage: 10,
+      jobKey: "swordman",
       cost: 10,
       exp: 5,
     });
@@ -969,7 +1149,8 @@ describe("WorldBossBattleService", () => {
       userId: fixture.userId,
       roundId: String(fixture.rounds[1].id),
       attackType: "skill",
-      damage: 10,
+      rawDamage: 10,
+      jobKey: "swordman",
       cost: 10,
       exp: 5,
     });
@@ -1038,7 +1219,8 @@ describe("WorldBossBattleService", () => {
       userId: firstUserId,
       roundId: String(fixture.rounds[3].id),
       attackType: "standard",
-      damage: 10,
+      rawDamage: 10,
+      jobKey: "swordman",
       cost: 1,
       exp: 1,
     });
@@ -1046,7 +1228,8 @@ describe("WorldBossBattleService", () => {
       userId: firstUserId,
       roundId: String(fixture.rounds[4].id),
       attackType: "standard",
-      damage: 10,
+      rawDamage: 10,
+      jobKey: "swordman",
       cost: 1,
       exp: 1,
     });
@@ -1059,7 +1242,8 @@ describe("WorldBossBattleService", () => {
         userId: secondUserId,
         roundId: String(fixture.rounds[4].id),
         attackType: "skill",
-        damage: 10,
+        rawDamage: 10,
+        jobKey: "swordman",
         cost: 1,
         exp: 1,
       })
@@ -1121,7 +1305,8 @@ describe("WorldBossBattleService", () => {
         userId: fourthKiller,
         roundId: String(fourthRound.id),
         attackType: "standard",
-        damage: 5,
+        rawDamage: 5,
+        jobKey: "swordman",
         cost: 3,
         exp: 1,
       }),
@@ -1130,7 +1315,8 @@ describe("WorldBossBattleService", () => {
         roundId: String(fifthRound.id),
         attackType: "skill",
         // Overkill: the effective damage must be boss 5's 7 HP, not the requested 900.
-        damage: 900,
+        rawDamage: 900,
+        jobKey: "swordman",
         cost: 4,
         exp: 1,
       }),
@@ -1139,14 +1325,21 @@ describe("WorldBossBattleService", () => {
     expect(fourthResult).toMatchObject({
       cleared: true,
       attackedCycleNo: 1,
+      rawDamage: "5",
+      effectDamage: "0",
       effectiveDamage: "5",
-      wastedDamage: "0",
+      overkillDamage: "0",
+      scoreGained: { direct: "5", assist: "0", relay: "0" },
     });
     expect(fifthResult).toMatchObject({
       cleared: true,
       attackedCycleNo: 1,
+      rawDamage: "900",
+      effectDamage: "0",
       effectiveDamage: "7",
-      wastedDamage: "893",
+      overkillDamage: "893",
+      // Overkill still scores in full: the ledger and the HP pool are separate books.
+      scoreGained: { direct: "900", assist: "0", relay: "0" },
     });
 
     // Whichever transaction commits second sees all five dead — and only it advances.
@@ -1174,21 +1367,715 @@ describe("WorldBossBattleService", () => {
     expect(cycleNumbers).toHaveLength(ROSTER_SIZE * 2);
     expect(cycleNumbers.every(row => Number(row.count) === 1)).toBe(true);
 
-    // Exactly one contribution each, credited to the encounter that was actually hit.
-    const contributions = await mysql("world_boss_contribution")
+    // Exactly one contribution each, credited to the encounter that was actually hit,
+    // and exactly one direct score event each — a double-credited kill is the failure here.
+    const rows = await mysql("world_boss_contribution")
       .where({ season_id: fixture.seasonId })
       .orderBy("user_id");
-    expect(contributions).toHaveLength(2);
+    expect(rows).toHaveLength(2);
     expect(
-      contributions.map(row => ({
+      rows.map(row => ({
         user_id: row.user_id,
         round_id: Number(row.round_id),
+        raw_damage: String(row.raw_damage),
+        effect_damage: String(row.effect_damage),
         damage: Number(row.damage),
         cost: row.cost,
       }))
     ).toEqual([
-      { user_id: fourthKiller, round_id: Number(fourthRound.id), damage: 5, cost: 3 },
-      { user_id: fifthKiller, round_id: Number(fifthRound.id), damage: 7, cost: 4 },
+      {
+        user_id: fourthKiller,
+        round_id: Number(fourthRound.id),
+        raw_damage: "5",
+        effect_damage: "0",
+        damage: 5,
+        cost: 3,
+      },
+      {
+        user_id: fifthKiller,
+        round_id: Number(fifthRound.id),
+        raw_damage: "900",
+        effect_damage: "0",
+        damage: 7,
+        cost: 4,
+      },
     ]);
+    const events = await listScoreEvents(fixture.seasonId);
+    expect(
+      events
+        .map(row => [row.beneficiary_user_id, row.kind, String(row.points)])
+        .sort((left, right) => left[0].localeCompare(right[0]))
+    ).toEqual([
+      [fourthKiller, "direct", "5"],
+      [fifthKiller, "direct", "900"],
+    ]);
+    // A lethal hit leaves no effect, so nothing unconsumable was created either.
+    await expect(listEffects(fixture.seasonId)).resolves.toEqual([]);
+  });
+});
+
+describe("WorldBossBattleService — effect lifecycle and score events", () => {
+  test("an adventurer leaves a banner worth 25% of raw damage and scores only direct", async () => {
+    const fixture = await createBattleFixture({ label: "bnew", maxHp: 1000 });
+    const target = fixture.rounds[0];
+    const service = createBattleService({ clock: () => now });
+
+    const result = await attackWith(service, {
+      userId: fixture.userId,
+      roundId: target.id,
+      rawDamage: 101,
+      jobKey: "adventurer",
+      cost: 8,
+    });
+
+    // floor(101 * 25 / 100) = 25 — the fractional part is dropped, not rounded.
+    expect(result).toMatchObject({
+      rawDamage: "101",
+      effectDamage: "0",
+      effectiveDamage: "101",
+      overkillDamage: "0",
+      consumedEffect: null,
+      createdEffect: { type: "banner", value: "25", sourceUserId: fixture.userId },
+      scoreGained: { direct: "101", assist: "0", relay: "0" },
+    });
+    // The banner is pure score: the boss lost the raw damage only.
+    await expect(mysql("world_boss_round").where({ id: target.id }).first()).resolves.toMatchObject(
+      { current_hp: 899 }
+    );
+    const [contribution] = await listContributions(fixture.seasonId);
+    await expect(ledgerOf(contribution.id)).resolves.toEqual({
+      raw_damage: "101",
+      effect_damage: "0",
+      damage: "101",
+      job_key: "adventurer",
+      direct_points: "101",
+    });
+    const [effect] = await listEffects(fixture.seasonId);
+    expect(effect).toMatchObject({
+      effect_type: "banner",
+      value: 25,
+      source_user_id: fixture.userId,
+      source_contribution_id: contribution.id,
+      consumed_by_contribution_id: null,
+      round_id: target.id,
+    });
+    // Creating a banner pays nobody an assist or relay yet.
+    const events = await listScoreEvents(fixture.seasonId);
+    expect(events.map(row => row.kind)).toEqual(["direct"]);
+  });
+
+  test("a creator never consumes their own effect and skips it to the next eligible one", async () => {
+    const owner = ownedUserId("self_owner");
+    const other = ownedUserId("self_other");
+    const fixture = await createBattleFixture({
+      label: "self_skip",
+      userId: owner,
+      maxHp: 100000,
+    });
+    await createUser(other);
+    const target = fixture.rounds[0];
+    const service = createBattleService({ clock: () => now });
+
+    // Own banner first (lower id), then someone else's banner.
+    const ownEffect = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: owner,
+      type: "banner",
+      value: 40,
+    });
+    const otherEffect = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: other,
+      type: "banner",
+      value: 7,
+    });
+    expect(Number(ownEffect.id)).toBeLessThan(Number(otherEffect.id));
+
+    const result = await attackWith(service, {
+      userId: owner,
+      roundId: target.id,
+      rawDamage: 200,
+      jobKey: "adventurer",
+      cost: 8,
+    });
+
+    // The proof the exclusion is in SQL and not in JS: the oldest row is skipped rather
+    // than blocking, and the next eligible row is consumed in the same hit.
+    expect(result).toMatchObject({
+      effectDamage: "0",
+      consumedEffect: { id: String(otherEffect.id), type: "banner", value: "7" },
+      scoreGained: { direct: "200", assist: "7", relay: "7" },
+    });
+    const rows = await listEffects(fixture.seasonId);
+    const byId = new Map(rows.map(row => [String(row.id), row]));
+    expect(byId.get(String(ownEffect.id)).consumed_by_contribution_id).toBeNull();
+    expect(byId.get(String(otherEffect.id)).consumed_by_contribution_id).not.toBeNull();
+  });
+
+  test("a creator attacking again neither consumes nor stacks on their own banner", async () => {
+    const fixture = await createBattleFixture({ label: "self_only", maxHp: 100000 });
+    const target = fixture.rounds[0];
+    const service = createBattleService({ clock: () => now });
+
+    await attackWith(service, {
+      userId: fixture.userId,
+      roundId: target.id,
+      rawDamage: 100,
+      jobKey: "adventurer",
+      cost: 8,
+    });
+    const second = await attackWith(service, {
+      userId: fixture.userId,
+      roundId: target.id,
+      rawDamage: 100,
+      jobKey: "adventurer",
+      cost: 8,
+    });
+
+    expect(second).toMatchObject({ effectDamage: "0", consumedEffect: null });
+    const rows = await listEffects(fixture.seasonId);
+    expect(rows).toHaveLength(2);
+    expect(rows.every(row => row.consumed_by_contribution_id === null)).toBe(true);
+    // Two hits, two quota charges, no assist/relay ever paid to the same player.
+    await expect(service.getRemainingDailyCost(fixture.userId)).resolves.toMatchObject({
+      used: 16,
+    });
+    const events = await listScoreEvents(fixture.seasonId);
+    expect(events.map(row => row.kind)).toEqual(["direct", "direct"]);
+  });
+
+  test("a banner survives with no TTL and pays assist to the creator and relay to the taker", async () => {
+    const creator = ownedUserId("banner_creator");
+    const taker = ownedUserId("banner_taker");
+    const fixture = await createBattleFixture({
+      label: "banner_relay",
+      userId: creator,
+      maxHp: 100000,
+    });
+    await createUser(taker);
+    const target = fixture.rounds[0];
+    // Injectable clock: hours pass between the two hits, and nothing expires.
+    let currentTime = now;
+    const service = createBattleService({ clock: () => currentTime });
+
+    await attackWith(service, {
+      userId: creator,
+      roundId: target.id,
+      rawDamage: 400,
+      jobKey: "adventurer",
+      cost: 8,
+    });
+    const hpAfterCreate = Number(
+      (await mysql("world_boss_round").where({ id: target.id }).first()).current_hp
+    );
+    currentTime = new Date(now.getTime() + 6 * 60 * 60 * 1000);
+
+    const result = await attackWith(service, {
+      userId: taker,
+      roundId: target.id,
+      rawDamage: 300,
+      jobKey: "swordman",
+      cost: 10,
+    });
+
+    expect(result).toMatchObject({
+      rawDamage: "300",
+      // A banner adds score, never HP: the taker's own contribution stays at 300.
+      effectDamage: "0",
+      effectiveDamage: "300",
+      consumedEffect: { type: "banner", value: "100", sourceUserId: creator },
+      createdEffect: null,
+      scoreGained: { direct: "300", assist: "100", relay: "100" },
+      seasonTotalScore: "400",
+    });
+    await expect(mysql("world_boss_round").where({ id: target.id }).first()).resolves.toMatchObject(
+      { current_hp: hpAfterCreate - 300 }
+    );
+    const takerContribution = (await listContributions(fixture.seasonId)).find(
+      row => row.user_id === taker
+    );
+    await expect(ledgerOf(takerContribution.id)).resolves.toEqual({
+      raw_damage: "300",
+      effect_damage: "0",
+      damage: "300",
+      job_key: "swordman",
+      direct_points: "300",
+    });
+    const events = await listScoreEvents(fixture.seasonId);
+    expect(events.map(row => [row.beneficiary_user_id, row.kind, String(row.points)])).toEqual([
+      [creator, "direct", "400"],
+      [taker, "direct", "300"],
+      [creator, "assist", "100"],
+      [taker, "relay", "100"],
+    ]);
+    // One attack still costs exactly one quota charge, effect or not.
+    await expect(service.getRemainingDailyCost(taker)).resolves.toMatchObject({ used: 10 });
+  });
+
+  test("a mage leaves a seal worth 50% of raw damage and still scores only its own raw", async () => {
+    const fixture = await createBattleFixture({ label: "seal_create", maxHp: 100000 });
+    const target = fixture.rounds[0];
+    const service = createBattleService({ clock: () => now });
+
+    const result = await attackWith(service, {
+      userId: fixture.userId,
+      roundId: target.id,
+      rawDamage: 501,
+      jobKey: "mage",
+      cost: 7,
+    });
+
+    // floor(501 * 50 / 100) = 250.
+    expect(result).toMatchObject({
+      rawDamage: "501",
+      effectDamage: "0",
+      effectiveDamage: "501",
+      createdEffect: { type: "seal", value: "250", sourceUserId: fixture.userId },
+      scoreGained: { direct: "501", assist: "0", relay: "0" },
+    });
+    const [effect] = await listEffects(fixture.seasonId);
+    expect(effect).toMatchObject({ effect_type: "seal", value: 250 });
+    await expect(mysql("world_boss_round").where({ id: target.id }).first()).resolves.toMatchObject(
+      { current_hp: 100000 - 501 }
+    );
+  });
+
+  test("a seal detonates into HP, pays the creator an assist, and pays the taker no relay", async () => {
+    const creator = ownedUserId("seal_creator");
+    const taker = ownedUserId("seal_taker");
+    const fixture = await createBattleFixture({
+      label: "seal_relay",
+      userId: creator,
+      maxHp: 100000,
+    });
+    await createUser(taker);
+    const target = fixture.rounds[0];
+    const service = createBattleService({ clock: () => now });
+    const seal = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: creator,
+      type: "seal",
+      value: 250,
+    });
+
+    const result = await attackWith(service, {
+      userId: taker,
+      roundId: target.id,
+      rawDamage: 300,
+      jobKey: "swordman",
+      cost: 10,
+    });
+
+    expect(result).toMatchObject({
+      rawDamage: "300",
+      effectDamage: "250",
+      effectiveDamage: "550",
+      overkillDamage: "0",
+      cleared: false,
+      consumedEffect: { id: String(seal.id), type: "seal", value: "250" },
+      // The taker's own score is their raw damage only — the seal already paid them in HP.
+      scoreGained: { direct: "300", assist: "250", relay: "0" },
+    });
+    await expect(mysql("world_boss_round").where({ id: target.id }).first()).resolves.toMatchObject(
+      { current_hp: 100000 - 550 }
+    );
+    const takerContribution = (await listContributions(fixture.seasonId)).find(
+      row => row.user_id === taker
+    );
+    await expect(ledgerOf(takerContribution.id)).resolves.toEqual({
+      raw_damage: "300",
+      effect_damage: "250",
+      damage: "550",
+      job_key: "swordman",
+      direct_points: "300",
+    });
+    const events = await mysql("world_boss_score_event")
+      .where({ contribution_id: takerContribution.id })
+      .orderBy("id");
+    expect(events.map(row => [row.beneficiary_user_id, row.kind, String(row.points)])).toEqual([
+      [taker, "direct", "300"],
+      [creator, "assist", "250"],
+    ]);
+    await expect(service.getRemainingDailyCost(taker)).resolves.toMatchObject({ used: 10 });
+  });
+
+  test("a seal detonation that overkills still scores the full raw and assist", async () => {
+    const creator = ownedUserId("seal_ok_creator");
+    const taker = ownedUserId("seal_ok_taker");
+    const fixture = await createBattleFixture({
+      label: "seal_overkill",
+      maxHp: 100,
+      userId: creator,
+    });
+    await createUser(taker);
+    const target = fixture.rounds[0];
+    const service = createBattleService({ clock: () => now });
+    await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: creator,
+      type: "seal",
+      value: 50,
+    });
+
+    // HP 100, raw 80, seal 50 → requested 130, applied 100, overkill 30.
+    const result = await attackWith(service, {
+      userId: taker,
+      roundId: target.id,
+      rawDamage: 80,
+      jobKey: "mage",
+      cost: 7,
+    });
+
+    expect(result).toMatchObject({
+      rawDamage: "80",
+      effectDamage: "50",
+      effectiveDamage: "100",
+      overkillDamage: "30",
+      cleared: true,
+      // The cap belongs to the HP ledger only: direct is still the full 80.
+      scoreGained: { direct: "80", assist: "50", relay: "0" },
+      // The killing blow leaves no effect, even for a mage.
+      createdEffect: null,
+    });
+    const takerContribution = (await listContributions(fixture.seasonId)).find(
+      row => row.user_id === taker
+    );
+    await expect(ledgerOf(takerContribution.id)).resolves.toEqual({
+      raw_damage: "80",
+      effect_damage: "50",
+      damage: "100",
+      job_key: "mage",
+      direct_points: "80",
+    });
+    const rounds = await WorldBossRound.listCycle(fixture.seasonId, 1);
+    expect(Number(rounds[0].current_hp)).toBe(0);
+    expect(rounds[0].cleared_at).toBeInstanceOf(Date);
+    // Exactly one effect ever existed on this round, and it is now consumed.
+    const rows = await listEffects(fixture.seasonId);
+    expect(rows).toHaveLength(1);
+    expect(String(rows[0].consumed_by_contribution_id)).toBe(String(takerContribution.id));
+  });
+
+  test("an unconsumed effect on a cleared round is stranded, not carried into the next cycle", async () => {
+    const creator = ownedUserId("stranded_creator");
+    const killer = ownedUserId("stranded_killer");
+    const fixture = await createBattleFixture({
+      label: "stranded",
+      userId: creator,
+      maxHp: 10,
+      // Four already dead, so the fifth kill also opens cycle 2.
+      currentHps: [0, 0, 0, 0, 10],
+    });
+    await createUser(killer);
+    const target = fixture.rounds[4];
+    const service = createBattleService({ clock: () => now });
+    // Two effects, but one attack consumes at most one — the second is stranded by the kill.
+    await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: creator,
+      type: "banner",
+      value: 500,
+    });
+    const stranded = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: creator,
+      type: "seal",
+      value: 999,
+    });
+
+    const kill = await attackWith(service, {
+      userId: killer,
+      roundId: target.id,
+      rawDamage: 10,
+      jobKey: "swordman",
+      cost: 1,
+    });
+    expect(kill.cycleAdvanced).toBe(true);
+    expect(kill.consumedEffect).toMatchObject({ type: "banner", value: "500" });
+
+    // The cleared round rejects every further attack, so the stranded seal can never detonate.
+    await expect(
+      attackWith(service, {
+        userId: killer,
+        roundId: target.id,
+        rawDamage: 10,
+        jobKey: "swordman",
+        cost: 1,
+      })
+    ).rejects.toMatchObject({ code: "ROUND_STALE" });
+
+    // A cycle-2 attack looks up effects by round id, so it sees none of cycle 1's.
+    const cycleTwo = await WorldBossRound.listCycle(fixture.seasonId, 2);
+    const next = await attackWith(service, {
+      userId: killer,
+      roundId: cycleTwo[0].id,
+      rawDamage: 10,
+      jobKey: "swordman",
+      cost: 1,
+    });
+    expect(next).toMatchObject({ effectDamage: "0", consumedEffect: null });
+    await expect(
+      mysql("world_boss_round_effect").where({ id: stranded.id }).first()
+    ).resolves.toMatchObject({ consumed_by_contribution_id: null });
+  });
+
+  test("consumes eligible effects strictly oldest first", async () => {
+    const first = ownedUserId("fifo_first");
+    const second = ownedUserId("fifo_second");
+    const taker = ownedUserId("fifo_taker");
+    const fixture = await createBattleFixture({ label: "fifo", userId: first, maxHp: 100000 });
+    await createUser(second);
+    await createUser(taker);
+    const target = fixture.rounds[0];
+    const service = createBattleService({ clock: () => now });
+    const older = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: first,
+      type: "banner",
+      value: 11,
+    });
+    const newer = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: second,
+      type: "banner",
+      value: 22,
+    });
+
+    const firstTake = await attackWith(service, {
+      userId: taker,
+      roundId: target.id,
+      rawDamage: 50,
+      jobKey: "swordman",
+      cost: 1,
+    });
+    const secondTake = await attackWith(service, {
+      userId: taker,
+      roundId: target.id,
+      rawDamage: 50,
+      jobKey: "swordman",
+      cost: 1,
+    });
+
+    // Strict FIFO by id, and at most one effect per attack.
+    expect(firstTake.consumedEffect).toMatchObject({ id: String(older.id), value: "11" });
+    expect(secondTake.consumedEffect).toMatchObject({ id: String(newer.id), value: "22" });
+    expect(firstTake.scoreGained).toEqual({ direct: "50", assist: "11", relay: "11" });
+    expect(secondTake.scoreGained).toEqual({ direct: "50", assist: "22", relay: "22" });
+    await expect(
+      attackWith(service, {
+        userId: taker,
+        roundId: target.id,
+        rawDamage: 50,
+        jobKey: "swordman",
+        cost: 1,
+      })
+    ).resolves.toMatchObject({ consumedEffect: null, effectDamage: "0" });
+  });
+
+  test("a forced failure rolls back the consumption, the score events, and the new effect", async () => {
+    const creator = ownedUserId("rb_creator");
+    const taker = ownedUserId("rb_taker");
+    const fixture = await createBattleFixture({
+      label: "effect_rollback",
+      userId: creator,
+      maxHp: 1000,
+    });
+    await createUser(taker);
+    const target = fixture.rounds[0];
+    const seal = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: creator,
+      type: "seal",
+      value: 90,
+    });
+    const beforeRounds = await WorldBossRound.listCycle(fixture.seasonId, 1);
+    const beforeContributions = await listContributions(fixture.seasonId);
+    const beforeCost = await createBattleService({ clock: () => now }).getRemainingDailyCost(taker);
+    const forcedError = new Error("forced exp failure");
+    const service = createBattleService({
+      clock: () => now,
+      hooks: { beforeExpUpdate: jest.fn().mockRejectedValue(forcedError) },
+    });
+
+    await expect(
+      attackWith(service, {
+        userId: taker,
+        roundId: target.id,
+        // A mage so the rolled-back transaction also had a new effect to create.
+        rawDamage: 200,
+        jobKey: "mage",
+        cost: 7,
+        exp: 5,
+      })
+    ).rejects.toBe(forcedError);
+
+    await expect(WorldBossRound.listCycle(fixture.seasonId, 1)).resolves.toEqual(beforeRounds);
+    await expect(listContributions(fixture.seasonId)).resolves.toEqual(beforeContributions);
+    // The consumption is back to NULL and no second effect was left behind.
+    const rows = await listEffects(fixture.seasonId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: seal.id, consumed_by_contribution_id: null });
+    await expect(listScoreEvents(fixture.seasonId)).resolves.toEqual([]);
+    await expect(service.getRemainingDailyCost(taker)).resolves.toEqual(beforeCost);
+    await expect(
+      mysql("minigame_level").where({ user_id: fixture.userDbId }).first()
+    ).resolves.toMatchObject({ level: 1, exp: 0 });
+  });
+
+  test("a double consume of the same effect aborts the whole attack", async () => {
+    const creator = ownedUserId("dup_creator");
+    const taker = ownedUserId("dup_taker");
+    const fixture = await createBattleFixture({
+      label: "dup_consume",
+      userId: creator,
+      maxHp: 1000,
+    });
+    await createUser(taker);
+    const target = fixture.rounds[0];
+    const seal = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: target.id,
+      userId: creator,
+      type: "seal",
+      value: 60,
+    });
+    const beforeRounds = await WorldBossRound.listCycle(fixture.seasonId, 1);
+    const beforeContributions = await listContributions(fixture.seasonId);
+
+    // Simulate the row already being consumed between the FOR UPDATE read and the UPDATE.
+    // The conditional UPDATE must then affect 0 rows and take the transaction down with it.
+    const service = createBattleService({
+      clock: () => now,
+      hooks: {
+        afterSeasonLock: async ({ trx }) => {
+          await trx("world_boss_round_effect")
+            .where({ id: seal.id })
+            .update({ consumed_by_contribution_id: seal.sourceContributionId });
+        },
+      },
+    });
+    const consumeSpy = jest
+      .spyOn(WorldBossRoundEffect, "findConsumableForUpdate")
+      .mockResolvedValue({
+        id: seal.id,
+        effect_type: "seal",
+        value: "60",
+        source_user_id: creator,
+      });
+
+    try {
+      await expect(
+        attackWith(service, {
+          userId: taker,
+          roundId: target.id,
+          rawDamage: 100,
+          jobKey: "swordman",
+          cost: 10,
+        })
+      ).rejects.toMatchObject({ code: "EFFECT_ALREADY_CONSUMED" });
+    } finally {
+      consumeSpy.mockRestore();
+    }
+
+    await expect(WorldBossRound.listCycle(fixture.seasonId, 1)).resolves.toEqual(beforeRounds);
+    await expect(listContributions(fixture.seasonId)).resolves.toEqual(beforeContributions);
+    await expect(listScoreEvents(fixture.seasonId)).resolves.toEqual([]);
+    await expect(
+      mysql("world_boss_round_effect").where({ id: seal.id }).first()
+    ).resolves.toMatchObject({ consumed_by_contribution_id: null });
+    await expect(service.getRemainingDailyCost(taker)).resolves.toMatchObject({ used: 0 });
+  });
+
+  test("concurrent lethal hits advance the cycle once and consume each effect once", async () => {
+    const creator = ownedUserId("conc_creator");
+    const fourthKiller = ownedUserId("conc_a");
+    const fifthKiller = ownedUserId("conc_b");
+    const fixture = await createBattleFixture({
+      label: "conc_effect",
+      userId: creator,
+      maxHp: 10,
+      currentHps: [0, 0, 0, 5, 7],
+    });
+    await createUser(fourthKiller);
+    await createUser(fifthKiller);
+    const fourthRound = fixture.rounds[3];
+    const fifthRound = fixture.rounds[4];
+    const fourthSeal = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: fourthRound.id,
+      userId: creator,
+      type: "banner",
+      value: 3,
+    });
+    const fifthSeal = await seedEffect({
+      seasonId: fixture.seasonId,
+      roundId: fifthRound.id,
+      userId: creator,
+      type: "banner",
+      value: 4,
+    });
+
+    const bothStarted = barrier(2);
+    const service = createBattleService({
+      clock: () => now,
+      hooks: { onAttackStarted: bothStarted },
+    });
+
+    const [fourthResult, fifthResult] = await Promise.all([
+      attackWith(service, {
+        userId: fourthKiller,
+        roundId: fourthRound.id,
+        rawDamage: 5,
+        jobKey: "adventurer",
+        cost: 3,
+      }),
+      attackWith(service, {
+        userId: fifthKiller,
+        roundId: fifthRound.id,
+        rawDamage: 7,
+        jobKey: "mage",
+        cost: 4,
+      }),
+    ]);
+
+    expect(
+      [fourthResult, fifthResult].filter(result => result.cycleAdvanced === true)
+    ).toHaveLength(1);
+    expect(await WorldBossRound.currentCycleNo(fixture.seasonId)).toBe(2);
+    const cycleCounts = await mysql("world_boss_round as round")
+      .join("world_boss_season_boss as roster", "round.season_boss_id", "roster.id")
+      .where("roster.season_id", fixture.seasonId)
+      .select("round.season_boss_id", "round.cycle_no")
+      .count({ count: "round.id" })
+      .groupBy("round.season_boss_id", "round.cycle_no");
+    expect(cycleCounts).toHaveLength(ROSTER_SIZE * 2);
+    expect(cycleCounts.every(row => Number(row.count) === 1)).toBe(true);
+
+    // Each attacker wrote exactly one direct event; each banner was consumed exactly once.
+    const events = await listScoreEvents(fixture.seasonId);
+    const directs = events.filter(row => row.kind === "direct");
+    expect(directs.map(row => row.beneficiary_user_id).sort()).toEqual(
+      [fourthKiller, fifthKiller].sort()
+    );
+    const consumers = (await listEffects(fixture.seasonId)).map(row => [
+      String(row.id),
+      String(row.consumed_by_contribution_id),
+    ]);
+    expect(new Set(consumers.map(pair => pair[1])).size).toBe(consumers.length);
+    expect(consumers.map(pair => pair[0]).sort()).toEqual(
+      [String(fourthSeal.id), String(fifthSeal.id)].sort()
+    );
+    // Both bosses died, so neither killer left a new effect behind.
+    expect(fourthResult.createdEffect).toBeNull();
+    expect(fifthResult.createdEffect).toBeNull();
   });
 });

--- a/app/src/service/__tests__/WorldBossSeasonService.test.js
+++ b/app/src/service/__tests__/WorldBossSeasonService.test.js
@@ -13,6 +13,7 @@ const { inventory } = require("../../model/application/Inventory");
 const UserTitle = require("../../model/application/UserTitle");
 const WorldBossSeasonBoss = require("../../model/application/WorldBossSeasonBoss");
 const WorldBossRound = require("../../model/application/WorldBossRound");
+const WorldBossRoundEffect = require("../../model/application/WorldBossRoundEffect");
 const { createSeasonService } = require("../WorldBossSeasonService");
 
 const prefix = `${PREFIX}season_`;
@@ -116,20 +117,114 @@ async function createActiveFixture({ label, endTime = now } = {}) {
   return { seasonId, roster, rounds, roundId: rounds[0].id };
 }
 
+/**
+ * Seeds one v2 attack per damage value: a contribution plus its `direct` score event.
+ * Score and damage are equal here so a test that only cares about ranking can keep using
+ * a single number; tests that need them to diverge use `addScoreEvents` / `addLegacy`.
+ */
 async function addContributions(seasonId, roundId, rows) {
-  await mysql("world_boss_contribution").insert(
-    rows.flatMap(({ userId, damages }) =>
-      damages.map((damage, index) => ({
+  for (const { userId, damages } of rows) {
+    for (const [index, damage] of damages.entries()) {
+      const at = new Date(now.getTime() + index);
+      const [contributionId] = await mysql("world_boss_contribution").insert({
         season_id: seasonId,
         round_id: roundId,
         user_id: userId,
+        raw_damage: String(damage),
+        effect_damage: 0,
+        job_key: "swordman",
         damage,
         cost: 1,
-        created_at: new Date(now.getTime() + index),
-        updated_at: new Date(now.getTime() + index),
-      }))
-    )
+        created_at: at,
+        updated_at: at,
+      });
+      await mysql("world_boss_score_event").insert({
+        season_id: seasonId,
+        round_id: roundId,
+        contribution_id: contributionId,
+        effect_id: null,
+        beneficiary_user_id: userId,
+        kind: "direct",
+        points: String(damage),
+        created_at: at,
+        updated_at: at,
+      });
+    }
+  }
+}
+
+/**
+ * Seeds a v1 contribution and the legacy `direct` event the migration backfills for it:
+ * points equal contribution.damage and `raw_damage` stays NULL.
+ */
+async function addLegacyContribution(seasonId, roundId, userId, damage) {
+  const [contributionId] = await mysql("world_boss_contribution").insert({
+    season_id: seasonId,
+    round_id: roundId,
+    user_id: userId,
+    raw_damage: null,
+    effect_damage: 0,
+    job_key: null,
+    damage,
+    cost: 1,
+    created_at: now,
+    updated_at: now,
+  });
+  await mysql("world_boss_score_event").insert({
+    season_id: seasonId,
+    round_id: roundId,
+    contribution_id: contributionId,
+    effect_id: null,
+    beneficiary_user_id: userId,
+    kind: "direct",
+    points: String(damage),
+    created_at: now,
+    updated_at: now,
+  });
+  return contributionId;
+}
+
+/**
+ * Attaches extra score events (assist / relay) to an existing contribution, which is how a
+ * beneficiary can outscore the damage they personally dealt.
+ */
+async function addScoreEvents(seasonId, roundId, contributionId, effectId, events) {
+  await mysql("world_boss_score_event").insert(
+    events.map(({ userId, kind, points }) => ({
+      season_id: seasonId,
+      round_id: roundId,
+      contribution_id: contributionId,
+      effect_id: effectId,
+      beneficiary_user_id: userId,
+      kind,
+      points: String(points),
+      created_at: now,
+      updated_at: now,
+    }))
   );
+}
+
+async function addEffect(seasonId, roundId, sourceContributionId, sourceUserId, value) {
+  const [id] = await mysql("world_boss_round_effect").insert({
+    season_id: seasonId,
+    round_id: roundId,
+    source_contribution_id: sourceContributionId,
+    source_user_id: sourceUserId,
+    effect_type: "banner",
+    value: String(value),
+    consumed_by_contribution_id: null,
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+/**
+ * The driver returns a small BIGINT as a JS number and a large one as a string, so ledger
+ * assertions compare canonical decimal strings rather than whatever the wire produced.
+ */
+function ledgerFacts(row) {
+  return [row.user_id, row.ranking, String(row.total_score), String(row.total_damage)];
 }
 
 async function inventoryStoneTotal(userId) {
@@ -562,6 +657,67 @@ describe("WorldBossSeasonService CRUD and opening", () => {
     });
   });
 
+  test("enriches live rounds with grouped pending effects and clears stale counts", async () => {
+    const fixture = await createActiveFixture({ label: "pending_effects" });
+    const [sourceContributionId] = await mysql("world_boss_contribution").insert({
+      season_id: fixture.seasonId,
+      round_id: fixture.roundId,
+      user_id: owned("effect_source"),
+      raw_damage: "100",
+      effect_damage: 0,
+      job_key: "adventurer",
+      damage: 100,
+      cost: 1,
+      created_at: now,
+      updated_at: now,
+    });
+    const secondRound = fixture.rounds[1];
+    const [secondContributionId] = await mysql("world_boss_contribution").insert({
+      season_id: fixture.seasonId,
+      round_id: secondRound.id,
+      user_id: owned("effect_source_2"),
+      raw_damage: "100",
+      effect_damage: 0,
+      job_key: "mage",
+      damage: 100,
+      cost: 1,
+      created_at: now,
+      updated_at: now,
+    });
+    await WorldBossRoundEffect.insert(mysql, {
+      season_id: fixture.seasonId,
+      round_id: fixture.roundId,
+      source_contribution_id: sourceContributionId,
+      source_user_id: owned("effect_source"),
+      effect_type: "banner",
+      value: 25,
+    });
+    await WorldBossRoundEffect.insert(mysql, {
+      season_id: fixture.seasonId,
+      round_id: fixture.roundId,
+      source_contribution_id: secondContributionId,
+      source_user_id: owned("effect_source_2"),
+      effect_type: "seal",
+      value: 50,
+    });
+    await mysql("world_boss_round").where({ id: secondRound.id }).update({
+      current_hp: 0,
+      cleared_at: now,
+    });
+
+    const status = await createSeasonService({
+      activeSlot: ACTIVE_SLOT,
+      clock: () => now,
+    }).getBattleStatus();
+    expect(status.rounds[0].pending_effects).toEqual({ banner: 1, seal: 1 });
+    expect(status.rounds[1].pending_effects).toEqual({ banner: 0, seal: 0 });
+    expect(status.rounds.slice(2).map(round => round.pending_effects)).toEqual([
+      { banner: 0, seal: 0 },
+      { banner: 0, seal: 0 },
+      { banner: 0, seal: 0 },
+    ]);
+  });
+
   test("batch-enriches ranking names once without changing ranking rows", async () => {
     const fixture = await createActiveFixture({ label: "ranking_names" });
     const rows = [
@@ -582,8 +738,8 @@ describe("WorldBossSeasonService CRUD and opening", () => {
     mysql.on("query", onQuery);
     try {
       await expect(service.getRanking(fixture.seasonId, 2)).resolves.toEqual([
-        { user_id: owned("named"), total_damage: "500", ranking: 1, display_name: "玩家甲" },
-        { user_id: owned("missing"), total_damage: "400", ranking: 2, display_name: null },
+        { user_id: owned("named"), total_score: "500", ranking: 1, display_name: "玩家甲" },
+        { user_id: owned("missing"), total_score: "400", ranking: 2, display_name: null },
       ]);
     } finally {
       mysql.removeListener("query", onQuery);
@@ -641,7 +797,7 @@ describe("WorldBossSeasonService settlement", () => {
     });
   });
 
-  test("settles exact damage totals into distinct tiers and exact reward ledgers", async () => {
+  test("settles exact score totals into distinct tiers and exact reward ledgers", async () => {
     const fixture = await createActiveFixture({ label: "exact_damage" });
     const topUser = owned("exact_top");
     const secondUser = owned("exact_second");
@@ -652,8 +808,8 @@ describe("WorldBossSeasonService settlement", () => {
     const service = createSeasonService({ activeSlot: ACTIVE_SLOT, clock: () => now });
 
     await expect(service.getRanking(fixture.seasonId, 100)).resolves.toEqual([
-      { user_id: topUser, total_damage: "9007199254740993", ranking: 1, display_name: null },
-      { user_id: secondUser, total_damage: "9007199254740992", ranking: 2, display_name: null },
+      { user_id: topUser, total_score: "9007199254740993", ranking: 1, display_name: null },
+      { user_id: secondUser, total_score: "9007199254740992", ranking: 2, display_name: null },
     ]);
     await expect(service.settleSeason(fixture.seasonId)).resolves.toMatchObject({
       contributors: 2,
@@ -668,6 +824,7 @@ describe("WorldBossSeasonService settlement", () => {
       ledgers.map(row => ({
         userId: row.user_id,
         ranking: row.ranking,
+        totalScore: row.total_score,
         totalDamage: row.total_damage,
         stoneAmount: row.stone_amount,
         titleKey: row.title_key,
@@ -676,6 +833,7 @@ describe("WorldBossSeasonService settlement", () => {
       {
         userId: topUser,
         ranking: 1,
+        totalScore: "9007199254740993",
         totalDamage: "9007199254740993",
         stoneAmount: 100,
         titleKey: "worldboss_annihilator",
@@ -683,6 +841,7 @@ describe("WorldBossSeasonService settlement", () => {
       {
         userId: secondUser,
         ranking: 2,
+        totalScore: "9007199254740992",
         totalDamage: "9007199254740992",
         stoneAmount: 60,
         titleKey: "worldboss_vanguard",
@@ -690,8 +849,128 @@ describe("WorldBossSeasonService settlement", () => {
     ]);
     await expect(service.getLatestSettledResult(topUser)).resolves.toMatchObject({
       ranking: 1,
+      totalScore: "9007199254740993",
       totalDamage: "9007199254740993",
     });
+  });
+
+  test("ranks by score, not damage, and stores both in the ledger", async () => {
+    const fixture = await createActiveFixture({ label: "score_ranking" });
+    // The bruiser removes the most HP; the supporter deals less but banks assist + relay
+    // score, so the score leaderboard inverts the damage leaderboard.
+    const bruiser = owned("score_bruiser");
+    const supporter = owned("score_supporter");
+    await addContributions(fixture.seasonId, fixture.roundId, [
+      { userId: bruiser, damages: [500] },
+      { userId: supporter, damages: [300] },
+    ]);
+    const [supporterContribution] = await mysql("world_boss_contribution")
+      .where({ season_id: fixture.seasonId, user_id: supporter })
+      .select("id");
+    const effectId = await addEffect(
+      fixture.seasonId,
+      fixture.roundId,
+      supporterContribution.id,
+      supporter,
+      75
+    );
+    await addScoreEvents(
+      fixture.seasonId,
+      fixture.roundId,
+      supporterContribution.id,
+      effectId,
+      // 300 direct + 150 from assisting = 450, still below the bruiser.
+      [{ userId: supporter, kind: "assist", points: 150 }]
+    );
+    // A second assist on a different contribution pushes the supporter past 500.
+    const [bruiserContribution] = await mysql("world_boss_contribution")
+      .where({ season_id: fixture.seasonId, user_id: bruiser })
+      .select("id");
+    const secondEffect = await addEffect(
+      fixture.seasonId,
+      fixture.roundId,
+      bruiserContribution.id,
+      bruiser,
+      100
+    );
+    await addScoreEvents(fixture.seasonId, fixture.roundId, bruiserContribution.id, secondEffect, [
+      { userId: supporter, kind: "relay", points: 100 },
+    ]);
+    const service = createSeasonService({ activeSlot: ACTIVE_SLOT, clock: () => now });
+
+    await expect(service.getRanking(fixture.seasonId, 100)).resolves.toEqual([
+      { user_id: supporter, total_score: "550", ranking: 1, display_name: null },
+      { user_id: bruiser, total_score: "500", ranking: 2, display_name: null },
+    ]);
+    await expect(service.settleSeason(fixture.seasonId)).resolves.toMatchObject({
+      contributors: 2,
+      rewarded: 2,
+    });
+    const ledgers = await mysql("world_boss_season_reward")
+      .where({ season_id: fixture.seasonId })
+      .orderBy("ranking");
+    expect(ledgers.map(ledgerFacts)).toEqual([
+      [supporter, 1, "550", "300"],
+      [bruiser, 2, "500", "500"],
+    ]);
+  });
+
+  test("settles a mixed v1 legacy and v2 season on one leaderboard", async () => {
+    const fixture = await createActiveFixture({ label: "mixed_season" });
+    const legacyUser = owned("mixed_legacy");
+    const mixedUser = owned("mixed_both");
+    const v2User = owned("mixed_v2");
+    // v1-only player: raw_damage NULL, score comes purely from the legacy backfill.
+    await addLegacyContribution(fixture.seasonId, fixture.roundId, legacyUser, 300);
+    // Returning player: 300 legacy + 100 v2 direct + 50 assist + 50 relay = 500.
+    await addLegacyContribution(fixture.seasonId, fixture.roundId, mixedUser, 300);
+    await addContributions(fixture.seasonId, fixture.roundId, [
+      { userId: mixedUser, damages: [100] },
+      { userId: v2User, damages: [400] },
+    ]);
+    const [mixedV2] = await mysql("world_boss_contribution")
+      .where({ season_id: fixture.seasonId, user_id: mixedUser })
+      .whereNotNull("raw_damage")
+      .select("id");
+    const effectId = await addEffect(fixture.seasonId, fixture.roundId, mixedV2.id, mixedUser, 50);
+    await addScoreEvents(fixture.seasonId, fixture.roundId, mixedV2.id, effectId, [
+      { userId: mixedUser, kind: "assist", points: 50 },
+      { userId: mixedUser, kind: "relay", points: 50 },
+    ]);
+    const service = createSeasonService({ activeSlot: ACTIVE_SLOT, clock: () => now });
+
+    // Nobody who played v1 is zeroed out by the switch.
+    await expect(service.getRanking(fixture.seasonId, 100)).resolves.toEqual([
+      { user_id: mixedUser, total_score: "500", ranking: 1, display_name: null },
+      { user_id: v2User, total_score: "400", ranking: 2, display_name: null },
+      { user_id: legacyUser, total_score: "300", ranking: 3, display_name: null },
+    ]);
+    await expect(service.getUserSeasonStats(fixture.seasonId, mixedUser)).resolves.toEqual({
+      seasonId: String(fixture.seasonId),
+      totalScore: "500",
+      score: { direct: "400", assist: "50", relay: "50" },
+      // The v1 row contributes 300 to effective only; raw/effect/overkill stay v2-only.
+      damage: { raw: "100", effect: "0", effective: "400", overkill: "0" },
+    });
+    await expect(service.getUserSeasonStats(fixture.seasonId, legacyUser)).resolves.toEqual({
+      seasonId: String(fixture.seasonId),
+      totalScore: "300",
+      score: { direct: "300", assist: "0", relay: "0" },
+      damage: { raw: "0", effect: "0", effective: "300", overkill: "0" },
+    });
+
+    await expect(service.settleSeason(fixture.seasonId)).resolves.toMatchObject({
+      contributors: 3,
+      rewarded: 3,
+    });
+    const ledgers = await mysql("world_boss_season_reward")
+      .where({ season_id: fixture.seasonId })
+      .orderBy("ranking");
+    expect(ledgers.map(ledgerFacts)).toEqual([
+      [mixedUser, 1, "500", "400"],
+      [v2User, 2, "400", "400"],
+      [legacyUser, 3, "300", "300"],
+    ]);
   });
 
   test("preserves a BIGINT season id in settlement output", () => {
@@ -804,22 +1083,36 @@ describe("WorldBossSeasonService settlement", () => {
     const fixture = await createActiveFixture({ label: "mismatch" });
     const userId = owned("mismatch_user");
     await addContributions(fixture.seasonId, fixture.roundId, [{ userId, damages: [500] }]);
-    await mysql("world_boss_season_reward").insert({
+    const service = createSeasonService({ activeSlot: ACTIVE_SLOT, clock: () => now });
+    const correct = {
       season_id: fixture.seasonId,
       user_id: userId,
-      ranking: 51,
+      ranking: 1,
+      total_score: 500,
       total_damage: 500,
-      stone_amount: 0,
-      title_key: null,
+      stone_amount: 100,
+      title_key: "worldboss_annihilator",
       paid_at: null,
-    });
-    const service = createSeasonService({ activeSlot: ACTIVE_SLOT, clock: () => now });
+    };
 
-    await expect(service.settleSeason(fixture.seasonId)).rejects.toMatchObject({
-      code: "SETTLEMENT_INCOMPLETE",
-    });
-    expect(await inventoryStoneTotal(userId)).toBe(0);
-    await expect(seasonRow(fixture.seasonId)).resolves.toMatchObject({ status: "active" });
+    // Every fact the ledger records is proof-checked, including both aggregates
+    // independently: a ledger that matches on damage but not on score must still fail.
+    for (const wrong of [
+      { ranking: 51, stone_amount: 0, title_key: null },
+      { total_score: 499 },
+      { total_damage: 499 },
+      { total_score: null },
+      { stone_amount: 60 },
+      { title_key: "worldboss_vanguard" },
+    ]) {
+      await mysql("world_boss_season_reward").where({ season_id: fixture.seasonId }).del();
+      await mysql("world_boss_season_reward").insert({ ...correct, ...wrong });
+      await expect(service.settleSeason(fixture.seasonId)).rejects.toMatchObject({
+        code: "SETTLEMENT_INCOMPLETE",
+      });
+      expect(await inventoryStoneTotal(userId)).toBe(0);
+      await expect(seasonRow(fixture.seasonId)).resolves.toMatchObject({ status: "active" });
+    }
   });
 
   test("completes a pre-existing unpaid ledger exactly once before settling", async () => {
@@ -830,6 +1123,7 @@ describe("WorldBossSeasonService settlement", () => {
       season_id: fixture.seasonId,
       user_id: userId,
       ranking: 1,
+      total_score: 500,
       total_damage: 500,
       stone_amount: 100,
       title_key: "worldboss_annihilator",
@@ -892,6 +1186,7 @@ describe("WorldBossSeasonService settlement", () => {
       season_id: fixture.seasonId,
       user_id: owned("ghost_extra"),
       ranking: 99,
+      total_score: 1,
       total_damage: 1,
       stone_amount: 0,
       title_key: null,

--- a/app/src/templates/application/WorldBoss.js
+++ b/app/src/templates/application/WorldBoss.js
@@ -371,6 +371,18 @@ function clearedPanel(maxHp) {
   };
 }
 
+function pendingEffectsRow(pendingEffects) {
+  const labels = [
+    ["banner", "鼓舞"],
+    ["seal", "魔力刻印"],
+  ]
+    .filter(([type]) => Number(pendingEffects?.[type]) > 0)
+    .map(([type, label]) => `${label} ×${Number(pendingEffects[type])}`);
+  return labels.length
+    ? { type: "text", text: `待接力：${labels.join("、")}`, size: "xs", color: C.textMuted }
+    : null;
+}
+
 /** A `link` button has no border of its own, so an outline box supplies one. */
 function outlineButton(label, uri) {
   return {
@@ -431,6 +443,7 @@ function generateBattleStatusBubble({ round, boss, liffUri, attackEnabled = fals
   const label = `第 ${round.cycle_no} 輪 · ${boss.position} 號`;
   const hero = bossHero({ image: boss.image, cleared, label, name: boss.name });
   const boardUri = worldBossUri(liffUri);
+  const pendingEffects = !cleared ? pendingEffectsRow(round.pending_effects) : null;
 
   return {
     type: "bubble",
@@ -464,6 +477,7 @@ function generateBattleStatusBubble({ round, boss, liffUri, attackEnabled = fals
             ]
           : []),
         cleared ? clearedPanel(maxHp) : hpBlock({ currentHp, maxHp, percent: hpPercent }),
+        ...(pendingEffects ? [pendingEffects] : []),
       ],
     },
     footer: {

--- a/app/src/templates/application/__tests__/WorldBoss.test.js
+++ b/app/src/templates/application/__tests__/WorldBoss.test.js
@@ -166,6 +166,27 @@ describe("WorldBoss Flex production contract", () => {
     });
   });
 
+  it.each([
+    [{ banner: 1, seal: 2 }, "待接力：鼓舞 ×1、魔力刻印 ×2"],
+    [{ banner: 3, seal: 0 }, "待接力：鼓舞 ×3"],
+    [{ banner: 0, seal: 4 }, "待接力：魔力刻印 ×4"],
+  ])("renders pending effects as public shared state", (pending_effects, expected) => {
+    expect(text(bubbleFor({ pending_effects }))).toContain(expected);
+  });
+
+  it("omits pending effects when empty or cleared", () => {
+    expect(text(bubbleFor({ pending_effects: { banner: 0, seal: 0 } }))).not.toContain("待接力");
+    expect(
+      text(
+        bubbleFor({
+          current_hp: "0",
+          cleared_at: new Date(),
+          pending_effects: { banner: 9, seal: 9 },
+        })
+      )
+    ).not.toContain("待接力");
+  });
+
   it("weights the attack button above the skill button in the same row", () => {
     const footer = bubbleFor({}, { attackEnabled: true }).footer;
     const [row, board] = footer.contents;

--- a/frontend/src/pages/Worldboss/index.jsx
+++ b/frontend/src/pages/Worldboss/index.jsx
@@ -20,7 +20,15 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import BoltIcon from "@mui/icons-material/Bolt";
+import CampaignIcon from "@mui/icons-material/Campaign";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import HandshakeIcon from "@mui/icons-material/Handshake";
+import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import MilitaryTechIcon from "@mui/icons-material/MilitaryTech";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import ShieldIcon from "@mui/icons-material/Shield";
@@ -73,15 +81,82 @@ function attackErrorLabel(error) {
 }
 
 /**
+ * The two relay effects a hit can leave on a boss. Every label, colour and icon for them
+ * lives here so a card, a chip and the attack result can never drift apart.
+ */
+const EFFECT_META = {
+  banner: {
+    label: "鼓舞",
+    caption: "接的人和留的人都得分，不扣王的血",
+    Icon: CampaignIcon,
+    tone: theme => theme.palette.secondary.main,
+  },
+  seal: {
+    label: "魔力刻印",
+    caption: "被引爆時轉成傷害，分數歸留下的人",
+    Icon: AutoFixHighIcon,
+    tone: () => "#8B5CF6",
+  },
+};
+
+const UNKNOWN_EFFECT = {
+  label: "未知效果",
+  caption: "",
+  Icon: AutoFixHighIcon,
+  tone: theme => theme.palette.text.secondary,
+};
+
+function effectMeta(type) {
+  return EFFECT_META[type] ?? UNKNOWN_EFFECT;
+}
+
+/** The three books the score is kept in. Order is fixed: own damage first, then the two co-op rows. */
+const SCORE_KINDS = [
+  {
+    key: "direct",
+    label: "自身",
+    caption: "自己打出的傷害",
+    Icon: BoltIcon,
+    tone: theme => theme.palette.primary.main,
+  },
+  {
+    key: "assist",
+    label: "協助",
+    caption: "我留下的效果被別人接走",
+    Icon: HandshakeIcon,
+    tone: theme => theme.palette.secondary.main,
+  },
+  {
+    key: "relay",
+    label: "接力",
+    caption: "我接走別人留下的鼓舞",
+    Icon: ArrowForwardIcon,
+    tone: theme => theme.palette.success.main,
+  },
+];
+
+const DAMAGE_FIELDS = [
+  { key: "raw", label: "自身傷害" },
+  { key: "effect", label: "引爆刻印" },
+  { key: "effective", label: "實際扣血" },
+];
+
+/**
  * Folds an attack response back into the board without a full refetch. The server's
  * own `status` is authoritative; `me.current` is patched from the same response so the
  * personal numbers can't disagree with the board they were returned with.
+ *
+ * `scoreGained` carries the whole ledger the hit wrote, and `assist` in it is credited to
+ * the player whose effect was consumed — never to the attacker. Only `direct` and `relay`
+ * are folded into the caller's own breakdown; a new `assist` of mine can only arrive when
+ * somebody else takes my effect, which the next `/me` read picks up.
  */
 function mergeAfterAttack(previous, payload) {
   const { attack, status, latestReward } = payload;
   const nextStatus = status ?? previous.status;
   const seasonId =
     canonicalSeasonId(nextStatus?.season?.id) ?? canonicalSeasonId(previous.me?.current?.seasonId);
+  const current = previous.me?.current;
 
   return {
     ...previous,
@@ -90,12 +165,24 @@ function mergeAfterAttack(previous, payload) {
       ...previous.me,
       current:
         seasonId === null
-          ? (previous.me?.current ?? null)
+          ? (current ?? null)
           : {
-              ...previous.me?.current,
+              ...current,
               seasonId,
-              totalDamage: attack.seasonTotalDamage,
+              totalScore: attack.seasonTotalScore,
+              score: {
+                direct: addDecimal(current?.score?.direct, attack.scoreGained?.direct),
+                assist: current?.score?.assist ?? null,
+                relay: addDecimal(current?.score?.relay, attack.scoreGained?.relay),
+              },
+              damage: {
+                raw: addDecimal(current?.damage?.raw, attack.rawDamage),
+                effect: addDecimal(current?.damage?.effect, attack.effectDamage),
+                effective: attack.seasonTotalDamage,
+                overkill: addDecimal(current?.damage?.overkill, attack.overkillDamage),
+              },
               daily: attack.daily,
+              effects: withCreatedEffect(current?.effects, attack),
             },
       latestReward: latestReward ?? previous.me?.latestReward ?? null,
     },
@@ -103,23 +190,25 @@ function mergeAfterAttack(previous, payload) {
 }
 
 /**
- * Private, attacker-only summary of the hit that just landed. This page is the personal
- * surface, so quota and EXP belong here rather than in any group message.
+ * Puts the effect this hit just left at the top of "what I left behind", so the history
+ * agrees with the result card that just announced it. Shaped exactly like a `/me` row.
  */
-function attackSummary(attack) {
-  const parts = [
-    `有效傷害 ${formatInteger(attack.effectiveDamage)}`,
-    `消耗 ${formatInteger(attack.cost)}`,
-    `今日剩餘 ${formatInteger(attack.daily?.remaining)}`,
-    `賽季累積 ${formatInteger(attack.seasonTotalDamage)}`,
+function withCreatedEffect(effects, attack) {
+  const list = Array.isArray(effects) ? effects : [];
+  const created = attack.createdEffect;
+  if (!created) return list;
+  return [
+    {
+      effectId: created.id,
+      type: created.type,
+      value: created.value,
+      roundId: attack.roundId,
+      createdAt: new Date().toISOString(),
+      consumedAt: null,
+      consumedBy: null,
+    },
+    ...list.filter(effect => String(effect.effectId) !== String(created.id)),
   ];
-  if (attack.wastedDamage && String(attack.wastedDamage) !== "0") {
-    parts.push(`溢傷作廢 ${formatInteger(attack.wastedDamage)}`);
-  }
-  if (attack.levelResult?.levelUp) {
-    parts.push(`職業等級提升至 Lv.${formatInteger(attack.levelResult.newLevel)}`);
-  }
-  return parts.join(" · ");
 }
 
 function decimalToBigInt(value) {
@@ -127,6 +216,24 @@ function decimalToBigInt(value) {
   if (typeof value === "number" && Number.isSafeInteger(value)) return BigInt(value);
   if (typeof value === "string" && /^\d+$/.test(value)) return BigInt(value);
   return null;
+}
+
+/**
+ * BIGINT arithmetic for the optimistic merge. Every score/damage field arrives as a
+ * decimal string that can exceed Number.MAX_SAFE_INTEGER, so the sum stays in BigInt and
+ * comes back out as a string. An unparsable side gives up and returns null, which renders
+ * as "—" instead of a wrong number until the next fetch corrects it.
+ */
+function addDecimal(left, right) {
+  const a = decimalToBigInt(left ?? "0");
+  const b = decimalToBigInt(right ?? "0");
+  return a === null || b === null ? null : (a + b).toString();
+}
+
+/** True only for a decimal string/number that is strictly greater than zero. */
+function isPositive(value) {
+  const parsed = decimalToBigInt(value);
+  return parsed !== null && parsed > 0n;
 }
 
 function canonicalSeasonId(value) {
@@ -248,35 +355,362 @@ function LoadingBoard() {
   );
 }
 
+/**
+ * The season score, broken into where it came from. The hero number is the score, not the
+ * damage — the leaderboard ranks on score, and the whole point of the split is that damage
+ * alone no longer explains a rank.
+ */
+function ScoreBreakdown({ score }) {
+  return (
+    <Grid container spacing={1}>
+      {SCORE_KINDS.map(({ key, label, caption, Icon, tone }) => {
+        const value = score?.[key];
+        const earned = isPositive(value);
+        return (
+          <Grid key={key} size={{ xs: 4 }}>
+            <Box
+              sx={theme => ({
+                height: "100%",
+                px: 1.25,
+                py: 1.25,
+                borderRadius: 2,
+                border: "1px solid",
+                borderColor: earned ? alpha(tone(theme), 0.45) : "divider",
+                bgcolor: earned ? alpha(tone(theme), 0.1) : "transparent",
+                transition: "background-color .25s ease-out, border-color .25s ease-out",
+              })}
+            >
+              <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mb: 0.25 }}>
+                <Icon
+                  sx={theme => ({
+                    fontSize: 16,
+                    color: earned ? tone(theme) : "text.disabled",
+                  })}
+                />
+                <Typography
+                  variant="caption"
+                  sx={theme => ({
+                    fontWeight: 700,
+                    lineHeight: 1.2,
+                    color: earned ? tone(theme) : "text.secondary",
+                  })}
+                >
+                  {label}
+                </Typography>
+              </Stack>
+              <Typography
+                sx={theme => ({
+                  fontWeight: 800,
+                  lineHeight: 1.2,
+                  fontVariantNumeric: "tabular-nums",
+                  overflowWrap: "anywhere",
+                  fontSize: { xs: "1rem", sm: "1.125rem" },
+                  color: earned ? tone(theme) : "text.disabled",
+                })}
+              >
+                {formatInteger(value)}
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mt: 0.25, lineHeight: 1.3 }}
+              >
+                {caption}
+              </Typography>
+            </Box>
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+}
+
+/**
+ * Damage is now a supporting statistic. Overkill gets its own line because the rule change
+ * lives there: it used to be thrown away, and it is now scored in full.
+ */
+function DamageBreakdown({ damage }) {
+  const overkill = damage?.overkill;
+  const hasOverkill = isPositive(overkill);
+
+  return (
+    <Box>
+      <Typography
+        variant="overline"
+        color="text.secondary"
+        sx={{ display: "block", lineHeight: 1.6 }}
+      >
+        傷害統計
+      </Typography>
+      <Grid container spacing={1} sx={{ mt: 0.25 }}>
+        {DAMAGE_FIELDS.map(({ key, label }) => (
+          <Grid key={key} size={{ xs: 4 }}>
+            <Typography variant="caption" color="text.secondary" display="block">
+              {label}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: 700, fontVariantNumeric: "tabular-nums", overflowWrap: "anywhere" }}
+            >
+              {formatInteger(damage?.[key])}
+            </Typography>
+          </Grid>
+        ))}
+      </Grid>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        sx={theme => ({
+          mt: 1,
+          px: 1.25,
+          py: 0.75,
+          borderRadius: 2,
+          border: "1px dashed",
+          borderColor: hasOverkill ? alpha(theme.palette.success.main, 0.5) : "divider",
+          bgcolor: hasOverkill ? alpha(theme.palette.success.main, 0.08) : "transparent",
+        })}
+      >
+        <CheckCircleIcon
+          sx={{ fontSize: 18, color: hasOverkill ? "success.main" : "text.disabled" }}
+        />
+        <Box minWidth={0} flex={1}>
+          <Typography variant="caption" color="text.secondary" display="block">
+            溢傷（超過王剩餘 HP 的部分）
+          </Typography>
+          <Typography variant="caption" color="text.secondary" display="block">
+            不扣王的血，但全額計入分數
+          </Typography>
+        </Box>
+        <Typography
+          sx={{
+            fontWeight: 800,
+            fontVariantNumeric: "tabular-nums",
+            overflowWrap: "anywhere",
+            color: hasOverkill ? "success.main" : "text.disabled",
+          }}
+        >
+          {formatInteger(overkill)}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}
+
 function PersonalStats({ current, unavailable = false }) {
   const daily = current?.daily;
 
   return (
-    <Grid container spacing={2}>
-      <Grid size={{ xs: 6 }}>
-        <SummaryStat label="賽季累積傷害" value={formatInteger(current?.totalDamage)} />
-      </Grid>
-      <Grid size={{ xs: 6 }}>
-        <SummaryStat
-          label="今日剩餘額度"
-          value={daily ? formatInteger(daily.remaining) : "—"}
-          tone="primary.main"
-        />
-      </Grid>
-      <Grid size={{ xs: 12 }}>
-        <SummaryStat
-          label="今日已消耗 / 額度"
-          value={daily ? `${formatInteger(daily.used)} / ${formatInteger(daily.limit)}` : "—"}
-        />
-      </Grid>
-      {unavailable && (
-        <Grid size={{ xs: 12 }}>
-          <Typography variant="caption" color="warning.main">
-            個人資料與目前賽季不同步，請重新整理後再試。
+    <Stack spacing={2}>
+      <Stack
+        direction="row"
+        spacing={1.5}
+        alignItems="flex-end"
+        justifyContent="space-between"
+        flexWrap="wrap"
+        useFlexGap
+      >
+        <Box minWidth={0}>
+          <Typography variant="caption" color="text.secondary" display="block">
+            賽季總分（排行榜依據）
           </Typography>
-        </Grid>
+          <Typography
+            component="p"
+            sx={{
+              fontWeight: 900,
+              lineHeight: 1.1,
+              fontVariantNumeric: "tabular-nums",
+              overflowWrap: "anywhere",
+              fontSize: { xs: "2rem", sm: "2.5rem" },
+              background: theme =>
+                `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+            }}
+          >
+            {formatInteger(current?.totalScore)}
+          </Typography>
+        </Box>
+        <Box sx={{ textAlign: { xs: "left", sm: "right" } }}>
+          <Typography variant="caption" color="text.secondary" display="block">
+            今日剩餘 / 額度
+          </Typography>
+          <Typography
+            sx={{ fontWeight: 800, fontVariantNumeric: "tabular-nums" }}
+            color="primary.main"
+          >
+            {daily ? `${formatInteger(daily.remaining)} / ${formatInteger(daily.limit)}` : "—"}
+          </Typography>
+        </Box>
+      </Stack>
+
+      <ScoreBreakdown score={current?.score} />
+      <DamageBreakdown damage={current?.damage} />
+
+      {unavailable && (
+        <Typography variant="caption" color="warning.main">
+          個人資料與目前賽季不同步，請重新整理後再試。
+        </Typography>
       )}
-    </Grid>
+    </Stack>
+  );
+}
+
+/**
+ * "What I left behind, and who picked it up." A player can never consume their own effect,
+ * so this list is the only place the interaction with other players is visible — an unclaimed
+ * row is an open invitation, a claimed one is a name.
+ */
+function EffectHistory({ effects }) {
+  const rows = Array.isArray(effects) ? effects : [];
+  if (rows.length === 0) {
+    return (
+      <Box
+        sx={{
+          py: 3,
+          px: 2,
+          textAlign: "center",
+          borderRadius: 2,
+          border: "1px dashed",
+          borderColor: "divider",
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          這個賽季還沒有留下任何效果。
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          冒險者攻擊後會留下鼓舞，法師會留下魔力刻印，等其他玩家來接。
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={1}>
+      {rows.map(effect => {
+        const { label, Icon, tone } = effectMeta(effect.type);
+        const claimed = Boolean(effect.consumedAt);
+        const taker = effect.consumedBy?.displayName || effect.consumedBy?.userId || "某位玩家";
+
+        return (
+          <Box
+            key={effect.effectId}
+            sx={theme => ({
+              position: "relative",
+              px: 1.5,
+              py: 1.25,
+              borderRadius: 2,
+              overflow: "hidden",
+              border: "1px solid",
+              borderColor: claimed ? alpha(tone(theme), 0.4) : "divider",
+              bgcolor: claimed ? alpha(tone(theme), 0.08) : "transparent",
+              borderStyle: claimed ? "solid" : "dashed",
+              "&::before": {
+                content: '""',
+                position: "absolute",
+                insetBlock: 0,
+                insetInlineStart: 0,
+                width: 3,
+                bgcolor: claimed ? tone(theme) : alpha(theme.palette.text.disabled, 0.4),
+              },
+            })}
+          >
+            <Stack direction="row" spacing={1.25} alignItems="flex-start" sx={{ pl: 0.75 }}>
+              <Avatar
+                variant="rounded"
+                sx={theme => ({
+                  width: 32,
+                  height: 32,
+                  bgcolor: claimed ? alpha(tone(theme), 0.18) : "action.hover",
+                  color: claimed ? tone(theme) : "text.disabled",
+                })}
+              >
+                <Icon sx={{ fontSize: 18 }} />
+              </Avatar>
+              <Box minWidth={0} flex={1}>
+                <Stack
+                  direction="row"
+                  spacing={0.75}
+                  alignItems="baseline"
+                  flexWrap="wrap"
+                  useFlexGap
+                >
+                  <Typography
+                    variant="body2"
+                    sx={theme => ({
+                      fontWeight: 800,
+                      color: claimed ? tone(theme) : "text.primary",
+                    })}
+                  >
+                    {label}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: 700, fontVariantNumeric: "tabular-nums" }}
+                    color="text.secondary"
+                  >
+                    {formatInteger(effect.value)}
+                  </Typography>
+                </Stack>
+                {claimed ? (
+                  <Typography variant="caption" color="text.secondary" display="block">
+                    被 <b>{taker}</b> 接走 · {formatDate(effect.consumedAt)}
+                  </Typography>
+                ) : (
+                  <Typography variant="caption" color="text.secondary" display="block">
+                    還掛在王身上 · 留於 {formatDate(effect.createdAt)}
+                  </Typography>
+                )}
+              </Box>
+              <Chip
+                size="small"
+                icon={
+                  claimed ? (
+                    <HandshakeIcon sx={{ fontSize: 14 }} />
+                  ) : (
+                    <HourglassEmptyIcon sx={{ fontSize: 14 }} />
+                  )
+                }
+                label={claimed ? "已接走" : "等人接"}
+                variant={claimed ? "filled" : "outlined"}
+                sx={theme => ({
+                  flexShrink: 0,
+                  fontWeight: 700,
+                  height: 24,
+                  ...(claimed
+                    ? { bgcolor: alpha(tone(theme), 0.16), color: tone(theme) }
+                    : { color: "text.secondary" }),
+                })}
+              />
+            </Stack>
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}
+
+function EffectHistoryCard({ effects }) {
+  const rows = Array.isArray(effects) ? effects : [];
+  const claimed = rows.filter(effect => effect.consumedAt).length;
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
+        <Stack spacing={1.75}>
+          <Box>
+            <Typography variant="h6" component="h2" sx={{ fontWeight: 800 }}>
+              我留下的效果
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              自己不能接自己的效果，要等別人來接。
+              {rows.length > 0 && ` 已被接走 ${claimed} / ${rows.length}`}
+            </Typography>
+          </Box>
+          <EffectHistory effects={rows} />
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -296,21 +730,65 @@ function PersonalProgressCard({ current, unavailable }) {
 }
 
 /**
+ * Effects sitting on this boss right now, waiting for somebody other than the person who
+ * left them. Cleared bosses always report zeros server-side, and are skipped anyway.
+ */
+function PendingEffectsRow({ pending }) {
+  const waiting = ["banner", "seal"].filter(type => isPositive(pending?.[type]));
+  if (waiting.length === 0) return null;
+
+  return (
+    <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+      {waiting.map(type => {
+        const { label, Icon, tone } = effectMeta(type);
+        return (
+          <Chip
+            key={type}
+            size="small"
+            icon={<Icon sx={{ fontSize: 14 }} />}
+            label={`${label} ×${formatInteger(pending[type])}`}
+            aria-label={`待接力 ${label} ${formatInteger(pending[type])} 個`}
+            sx={theme => ({
+              height: 22,
+              fontWeight: 700,
+              fontSize: "0.7rem",
+              color: tone(theme),
+              bgcolor: alpha(tone(theme), 0.12),
+              border: "1px solid",
+              borderColor: alpha(tone(theme), 0.35),
+              "& .MuiChip-icon": { color: "inherit", ml: 0.5 },
+              "& .MuiChip-label": { px: 0.75 },
+            })}
+          />
+        );
+      })}
+    </Stack>
+  );
+}
+
+/**
  * One encounter in the current cycle. Each boss carries its own HP, so a cleared boss
  * has to read as finished at a glance while its neighbours are still live.
  */
 function BossRoundCard({ round, onAttack, busy, disabled }) {
   const hpPercent = safeHpPercent(round);
   const cleared = Boolean(round.cleared_at);
+  const pending = cleared ? null : round.pending_effects;
+  const hasPending = Boolean(pending && (isPositive(pending.banner) || isPositive(pending.seal)));
 
   return (
     <Card
       variant="outlined"
-      sx={{
+      sx={theme => ({
         height: "100%",
-        borderColor: cleared ? "success.light" : "divider",
+        borderColor: cleared
+          ? "success.light"
+          : hasPending
+            ? alpha(theme.palette.secondary.main, 0.55)
+            : "divider",
         bgcolor: cleared ? "action.hover" : "background.paper",
-      }}
+        ...(hasPending && { boxShadow: `0 0 0 1px ${alpha(theme.palette.secondary.main, 0.2)}` }),
+      })}
     >
       <CardContent sx={{ p: 1.75, "&:last-child": { pb: 1.75 } }}>
         <Stack spacing={1.25}>
@@ -387,25 +865,36 @@ function BossRoundCard({ round, onAttack, busy, disabled }) {
             </Typography>
           ) : (
             <Stack spacing={0.75}>
+              {hasPending && (
+                <Box>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    display="block"
+                    sx={{ mb: 0.5 }}
+                  >
+                    待接力
+                  </Typography>
+                  <PendingEffectsRow pending={pending} />
+                </Box>
+              )}
               <Button
-                size="small"
                 variant="contained"
                 fullWidth
                 disabled={disabled}
                 onClick={() => onAttack(round, "standard")}
                 startIcon={busy ? <CircularProgress size={14} color="inherit" /> : null}
-                sx={{ fontWeight: 700 }}
+                sx={{ fontWeight: 700, minHeight: 40 }}
               >
                 普通攻擊
               </Button>
               <Button
-                size="small"
                 variant="outlined"
                 color="secondary"
                 fullWidth
                 disabled={disabled}
                 onClick={() => onAttack(round, "skill")}
-                sx={{ fontWeight: 700 }}
+                sx={{ fontWeight: 700, minHeight: 40 }}
               >
                 技能攻擊
               </Button>
@@ -484,20 +973,50 @@ function BattleCard({ status, current, currentUnavailable, onAttack, attackingRo
   );
 }
 
+function AttackStat({ label, value, tone }) {
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography variant="caption" color="text.secondary" display="block" sx={{ lineHeight: 1.3 }}>
+        {label}
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: 800,
+          fontVariantNumeric: "tabular-nums",
+          overflowWrap: "anywhere",
+          ...(tone ? { color: tone } : {}),
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
 /**
  * Attacker-only result of the most recent hit. Sits above the board so the numbers
  * land where the user was already looking after tapping.
+ *
+ * `scoreGained.assist` is deliberately labelled as going to somebody else: the ledger this
+ * hit wrote credits it to the owner of the consumed effect, never to the attacker.
  */
 function AttackResultCard({ attack, onDismiss }) {
   const cleared = Boolean(attack.cleared);
   const full = Boolean(attack.cycleAdvanced);
+  const consumed = attack.consumedEffect;
+  const created = attack.createdEffect;
+  const consumedMeta = consumed ? effectMeta(consumed.type) : null;
+  const createdMeta = created ? effectMeta(created.type) : null;
+  const overkill = attack.overkillDamage;
 
   return (
     <Alert
-      severity={full ? "success" : cleared ? "success" : "info"}
+      severity={full || cleared ? "success" : "info"}
       variant="outlined"
       onClose={onDismiss}
       aria-live="polite"
+      sx={{ "& .MuiAlert-message": { width: "100%", minWidth: 0 } }}
     >
       <Typography sx={{ fontWeight: 800 }}>
         {full
@@ -506,9 +1025,115 @@ function AttackResultCard({ attack, onDismiss }) {
             ? `已擊破 ${attack.boss?.name || "世界王"}`
             : "攻擊成功"}
       </Typography>
-      <Typography variant="body2" sx={{ mt: 0.5, overflowWrap: "anywhere" }}>
-        {attackSummary(attack)}
-      </Typography>
+
+      <Stack spacing={1.25} sx={{ mt: 1 }}>
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          flexWrap="wrap"
+          useFlexGap
+          sx={{ color: "text.primary" }}
+        >
+          <AttackStat label="自身傷害" value={formatInteger(attack.rawDamage)} />
+          {isPositive(attack.effectDamage) && (
+            <>
+              <Typography color="text.disabled">+</Typography>
+              <AttackStat label="引爆刻印" value={formatInteger(attack.effectDamage)} />
+            </>
+          )}
+          <ArrowForwardIcon sx={{ fontSize: 16, color: "text.disabled" }} />
+          <AttackStat label="實際扣血" value={formatInteger(attack.effectiveDamage)} />
+          {isPositive(overkill) && (
+            <Chip
+              size="small"
+              label={`溢傷 ${formatInteger(overkill)} 全額計分`}
+              color="success"
+              variant="outlined"
+              sx={{ height: 22, fontWeight: 700, fontSize: "0.7rem" }}
+            />
+          )}
+        </Stack>
+
+        <Stack direction="row" spacing={1.5} flexWrap="wrap" useFlexGap>
+          <AttackStat
+            label="這刀的分數"
+            value={formatInteger(attack.scoreGained?.direct)}
+            tone="primary.main"
+          />
+          {isPositive(attack.scoreGained?.relay) && (
+            <AttackStat
+              label="接力加分"
+              value={formatInteger(attack.scoreGained?.relay)}
+              tone="success.main"
+            />
+          )}
+          {isPositive(attack.scoreGained?.assist) && (
+            <AttackStat
+              label={`回饋給${consumed?.sourceDisplayName || "留效果的人"}`}
+              value={formatInteger(attack.scoreGained?.assist)}
+              tone="secondary.main"
+            />
+          )}
+        </Stack>
+
+        {(consumed || created) && (
+          <Stack spacing={0.75}>
+            {consumed && (
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                sx={theme => ({
+                  px: 1.25,
+                  py: 0.75,
+                  borderRadius: 2,
+                  bgcolor: alpha(consumedMeta.tone(theme), 0.12),
+                })}
+              >
+                <consumedMeta.Icon
+                  sx={theme => ({ fontSize: 18, color: consumedMeta.tone(theme) })}
+                />
+                <Typography variant="body2" sx={{ overflowWrap: "anywhere" }}>
+                  你接走了 <b>{consumed.sourceDisplayName || "某位玩家"}</b> 的{consumedMeta.label}
+                  （{formatInteger(consumed.value)}）
+                </Typography>
+              </Stack>
+            )}
+            {created && (
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                sx={theme => ({
+                  px: 1.25,
+                  py: 0.75,
+                  borderRadius: 2,
+                  border: "1px dashed",
+                  borderColor: alpha(createdMeta.tone(theme), 0.5),
+                })}
+              >
+                <createdMeta.Icon
+                  sx={theme => ({ fontSize: 18, color: createdMeta.tone(theme) })}
+                />
+                <Typography variant="body2" sx={{ overflowWrap: "anywhere" }}>
+                  你在這隻王身上留下了{createdMeta.label}（{formatInteger(created.value)}），等其他
+                  玩家來接
+                </Typography>
+              </Stack>
+            )}
+          </Stack>
+        )}
+
+        <Typography variant="caption" color="text.secondary" sx={{ overflowWrap: "anywhere" }}>
+          消耗 {formatInteger(attack.cost)} · 今日剩餘 {formatInteger(attack.daily?.remaining)} ·
+          賽季總分 {formatInteger(attack.seasonTotalScore)}
+          {attack.levelResult?.levelUp
+            ? ` · 職業等級提升至 Lv.${formatInteger(attack.levelResult.newLevel)}`
+            : ""}
+        </Typography>
+      </Stack>
+
       {attack.announcementQueued && (
         <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
           擊破公告會在群組的下一則訊息時送出。
@@ -588,7 +1213,19 @@ function LatestRewardCard({ reward }) {
 
           <Divider />
 
-          <SummaryStat label="賽季總傷害" value={formatInteger(reward.totalDamage)} />
+          <Stack spacing={1}>
+            <SummaryStat
+              label="賽季總分"
+              value={reward.totalScore == null ? "舊制未計分" : formatInteger(reward.totalScore)}
+              tone={reward.totalScore == null ? "text.secondary" : "text.primary"}
+            />
+            {reward.totalScore == null && (
+              <Typography variant="caption" color="text.secondary">
+                這個賽季在改制前結算，當時只記錄傷害。
+              </Typography>
+            )}
+            <SummaryStat label="賽季總傷害" value={formatInteger(reward.totalDamage)} />
+          </Stack>
           <Box sx={{ bgcolor: "action.hover", borderRadius: 1.5, p: 1.25 }}>
             <Typography variant="caption" color="text.secondary" display="block">
               結算編號
@@ -677,10 +1314,10 @@ function Leaderboard({ rows, unavailable }) {
         >
           <Box>
             <Typography variant="h6" component="h2" sx={{ fontWeight: 800 }}>
-              賽季傷害排行榜
+              賽季分數排行榜
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              顯示前 50 名貢獻者
+              顯示前 50 名 · 分數含溢傷與協作加分
             </Typography>
           </Box>
           <EmojiEventsIcon color="warning" aria-hidden="true" />
@@ -692,7 +1329,7 @@ function Leaderboard({ rows, unavailable }) {
           </Alert>
         )}
         {hasRows ? (
-          <List disablePadding aria-label="世界王傷害排行榜">
+          <List disablePadding aria-label="世界王分數排行榜">
             {rows.map((row, index) => {
               const ranking = row.ranking;
               return (
@@ -718,7 +1355,7 @@ function Leaderboard({ rows, unavailable }) {
                   </ListItemAvatar>
                   <ListItemText
                     primary={row.display_name || row.user_id || "未知玩家"}
-                    secondary="累積傷害"
+                    secondary="賽季總分"
                     primaryTypographyProps={{
                       noWrap: true,
                       sx: { maxWidth: { xs: "calc(100vw - 190px)", sm: "min(50vw, 360px)" } },
@@ -736,7 +1373,7 @@ function Leaderboard({ rows, unavailable }) {
                       textAlign: "right",
                     }}
                   >
-                    {formatInteger(row.total_damage)}
+                    {formatInteger(row.total_score)}
                   </Typography>
                 </ListItem>
               );
@@ -990,7 +1627,12 @@ export default function Worldboss() {
               <NoActiveSeason />
             )}
           </Grid>
-          <Grid size={{ xs: 12, md: hasBattle ? 12 : 5 }}>
+          {shouldRenderCurrent && (
+            <Grid size={{ xs: 12, md: 7 }}>
+              <EffectHistoryCard effects={current?.effects} />
+            </Grid>
+          )}
+          <Grid size={{ xs: 12, md: shouldRenderCurrent || !hasBattle ? 5 : 12 }}>
             {data.me === undefined ? (
               <UnavailableRewardCard />
             ) : latestReward != null ? (


### PR DESCRIPTION
## 背景

真正要解決的不是「四個職業傷害倍率不一樣」，而是 **`world_boss_contribution.damage` 同時當 HP 帳本與排行榜依據**。卡血不打、輔助職業不可行、職業只能比拼傷害，三個症狀同一個病根。

線上賽季 1 的證據：
- 85 個已破 round 中，11 個在最後一刀前卡超過 30 分鐘，7 個卡超過 3 小時，最久 414 分鐘。收尾刀平均傷害 23,199 vs 全體平均 28,813，補刀者平均少拿約 20%
- 同輪相鄰攻擊 402 次是同一人接自己、247 次才換人（62% 自我接續），平均間隔 18 分鐘 → 任何需要同時在線的配合設計都會沒人碰得到，分工必須是非同步接力
- 職業每 cost 期望傷害（30 萬次模擬，level 100）：劍士 2420 / 法師 2057 / 盜賊 1427 / 冒險者 1100。盜賊是最大族群（17 人）卻效率最低 41%

## 主要改動

### 拆開帳本
| 帳本 | 位置 | 語意 |
|---|---|---|
| HP | `world_boss_round.current_hp` | 王實際剩餘血量 |
| 扣血 | `world_boss_contribution.damage` | 這刀實際扣掉的 HP（語意不變）|
| 分數 | `world_boss_score_event.points`（新表）| 排行榜唯一來源 |

溢傷完整計入分數，但 HP 只扣有效值 → 補最後一刀不再虧。

### 非同步接力
新表 `world_boss_round_effect`，冒險者留鼓舞 banner（score-only，不扣血），法師留魔力刻印 seal（引爆時轉成實際傷害，分數歸法師）。

- 建立者**不能消耗自己的效果**（過濾寫在 SQL WHERE，不在 application code）
- FIFO、條件式 UPDATE 且 affected rows 必須為 1
- 效果生命週期綁 round，被消耗或 round 被 clear 即失效，**不需要 cron / TTL / status 欄位**
- 致命一擊仍可消耗效果但不建立新效果（否則玩家會為了拿 assist 而避免補刀）

### 職業數值
adventurer cost 8 rate 1.2、swordman rate 1.8、mage rate 0.7、thief rate 2.1。`getStandardDamage()` 未動（劍士轉職任務也在用）。移除 swordman 從未被呼叫的 `criticalConfig` 死碼。

調整後 score/cost（effect 100% 被消耗時）：法師 2162 / 冒險者 2062 / 盜賊 1994 / 劍士 1980，全距 8.9%。

### 相容性
既有 659 筆 contribution 已 backfill 成 legacy `direct` score event（idempotent，可重跑），**賽季 1 排名不會歸零**。`raw_damage IS NULL` 即為 v1 舊資料的天然辨識子，未新增版本欄位。

## Test plan

- [x] `app` 全量：144 suites / 1819 tests passed
- [x] `app` lint 0 errors
- [x] `frontend` lint 0 errors（42 warnings 皆為既有）、`yarn build` 通過
- [x] migration round-trip：up → rollback → up
- [x] 12 個核心 transaction 情境（含建立者不吃自己的效果、Seal 溢傷、cleared round 殘留效果、FIFO、rollback 一致性、duplicate consume 被擋、五王全滅只推進一次 cycle）
- [x] 修正 handler 測試的假綠 mock（原本 mock 餵 `total_damage`，service 已改產 `total_score`，兩邊一致地錯）
- [x] BIGINT 全程 string / BigInt，無 `Number()` 轉換
- [x] 群組訊息規範：效果建立與消耗不發送任何群組訊息，個人資料不出現在群組 Flex

## 部署注意

**需要在 production 執行 `yarn migrate`**（新增 2 表 + 4 欄位 + legacy backfill）。migration 是 additive 的，舊 code 不會讀新表，可先於 image 替換執行。

由於 migration 與 image 替換非原子操作，中間空窗若有攻擊寫入，其 contribution 不會有對應 score event。migration 檔內的 `BACKFILL_LEGACY_DIRECT_SQL` 是 idempotent 的，**部署確認後再手動重跑一次**即可補齊（以目前每天約 180 刀的量，5 分鐘空窗約 0–1 筆）。

規則切換時間點以 image 替換時間為準。

無新增環境變數、無新增套件、未改 `config/default.json`（daily_cost_limit / cooldown / hp_tiers 全部維持，避免與職業改動變因混雜）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)