### PR TITLE
fix(worldboss): 修正效果接力紀錄的三個可見性問題

### DIFF
--- a/app/src/handler/WorldBoss/__tests__/handlers.test.js
+++ b/app/src/handler/WorldBoss/__tests__/handlers.test.js
@@ -19,14 +19,17 @@ jest.mock("../../../service/WorldBossBattleService", () => ({
   getRemainingDailyCost: jest.fn(),
 }));
 jest.mock("../../../service/WorldBossAttackService", () => ({ attack: jest.fn() }));
+jest.mock("../../../service/MinigameService", () => ({ findByUserId: jest.fn() }));
 jest.mock("../../../model/application/WorldBossRoundEffect", () => ({
   listSeasonHistoryBySource: jest.fn(),
+  listSeasonHistoryByConsumer: jest.fn(),
 }));
 jest.mock("../../../model/application/UserModel", () => ({ getDisplayNames: jest.fn() }));
 const CatalogService = require("../../../service/WorldBossCatalogService");
 const SeasonService = require("../../../service/WorldBossSeasonService");
 const BattleService = require("../../../service/WorldBossBattleService");
 const AttackService = require("../../../service/WorldBossAttackService");
+const MinigameService = require("../../../service/MinigameService");
 const WorldBossRoundEffect = require("../../../model/application/WorldBossRoundEffect");
 const UserModel = require("../../../model/application/UserModel");
 const express = require("express");
@@ -183,6 +186,8 @@ beforeEach(() => {
   BattleService.getRemainingDailyCost.mockResolvedValue({ limit: 100, used: 20, remaining: 80 });
   SeasonService.getUserSeasonStats.mockResolvedValue(seasonStats);
   WorldBossRoundEffect.listSeasonHistoryBySource.mockResolvedValue(effectHistoryRows);
+  WorldBossRoundEffect.listSeasonHistoryByConsumer.mockResolvedValue([]);
+  MinigameService.findByUserId.mockResolvedValue({ job_key: "adventurer" });
   UserModel.getDisplayNames.mockImplementation(
     async ids =>
       new Map(
@@ -615,26 +620,32 @@ describe("World Boss public handlers", () => {
       score: { direct: "500", assist: "150", relay: "50" },
       damage: { raw: "500", effect: "100", effective: "550", overkill: "50" },
       daily: { limit: 100, used: 20, remaining: 80 },
-      effects: [
-        {
-          effectId: "31",
-          type: "seal",
-          value: "100",
-          roundId: "21",
-          createdAt: "2026-07-20T02:00:00.000Z",
-          consumedAt: "2026-07-20T02:05:00.000Z",
-          consumedBy: { userId: "Utaker", displayName: "接棒者" },
-        },
-        {
-          effectId: "30",
-          type: "banner",
-          value: "25",
-          roundId: "20",
-          createdAt: "2026-07-20T01:30:00.000Z",
-          consumedAt: null,
-          consumedBy: null,
-        },
-      ],
+      jobKey: "adventurer",
+      effects: {
+        left: [
+          {
+            effectId: "31",
+            type: "seal",
+            value: "100",
+            roundId: "21",
+            createdAt: "2026-07-20T02:00:00.000Z",
+            consumedAt: "2026-07-20T02:05:00.000Z",
+            consumedBy: { userId: "Utaker", displayName: "接棒者" },
+            expired: false,
+          },
+          {
+            effectId: "30",
+            type: "banner",
+            value: "25",
+            roundId: "20",
+            createdAt: "2026-07-20T01:30:00.000Z",
+            consumedAt: null,
+            consumedBy: null,
+            expired: false,
+          },
+        ],
+        taken: [],
+      },
     });
     expect(res.json.mock.calls[0][0].latestReward).toMatchObject({
       totalScore: "1200",
@@ -712,10 +723,10 @@ describe("World Boss public handlers", () => {
     expect(UserModel.getDisplayNames).toHaveBeenCalledTimes(1);
     expect(UserModel.getDisplayNames).toHaveBeenCalledWith(new Array(25).fill("Utaker"));
     const { effects } = res.json.mock.calls[0][0].current;
-    expect(effects).toHaveLength(50);
-    expect(effects.map(row => row.effectId)).toEqual(rows.map(row => String(row.id)));
-    expect(effects[0].effectId).toBe("500");
-    expect(effects.at(-1).effectId).toBe("451");
+    expect(effects.left).toHaveLength(50);
+    expect(effects.left.map(row => row.effectId)).toEqual(rows.map(row => String(row.id)));
+    expect(effects.left[0].effectId).toBe("500");
+    expect(effects.left.at(-1).effectId).toBe("451");
   });
 
   it("returns an empty effect history without any name lookup", async () => {
@@ -724,7 +735,7 @@ describe("World Boss public handlers", () => {
 
     await publicHandler.me(request({ userId: "Ume" }), res);
 
-    expect(res.json.mock.calls[0][0].current.effects).toEqual([]);
+    expect(res.json.mock.calls[0][0].current.effects).toEqual({ left: [], taken: [] });
     expect(UserModel.getDisplayNames).toHaveBeenCalledWith([]);
     expect(UserModel.getDisplayNames).toHaveBeenCalledTimes(1);
   });
@@ -745,10 +756,60 @@ describe("World Boss public handlers", () => {
 
     await publicHandler.me(request({ userId: "Ume" }), res);
 
-    expect(res.json.mock.calls[0][0].current.effects[0].consumedBy).toEqual({
+    expect(res.json.mock.calls[0][0].current.effects.left[0].consumedBy).toEqual({
       userId: "Unameless",
       displayName: null,
     });
+  });
+
+  it("returns effects taken by the caller with the source name", async () => {
+    WorldBossRoundEffect.listSeasonHistoryByConsumer.mockResolvedValue([
+      {
+        id: "127",
+        round_id: "103",
+        effect_type: "seal",
+        value: "11692",
+        source_user_id: "Usource",
+        taken_at: new Date("2026-09-01T02:09:42.000Z"),
+      },
+    ]);
+    const res = response();
+
+    await publicHandler.me(request({ userId: "Utaker" }), res);
+
+    expect(res.json.mock.calls[0][0].current.effects.taken).toEqual([
+      {
+        effectId: "127",
+        type: "seal",
+        value: "11692",
+        roundId: "103",
+        takenAt: "2026-09-01T02:09:42.000Z",
+        source: { userId: "Usource", displayName: "留效果的人" },
+      },
+    ]);
+    expect(UserModel.getDisplayNames).toHaveBeenCalledWith(["Utaker", "Usource"]);
+  });
+
+  it("returns a job fallback and taken effects for a job without left effects", async () => {
+    MinigameService.findByUserId.mockResolvedValue(null);
+    WorldBossRoundEffect.listSeasonHistoryBySource.mockResolvedValue([]);
+    WorldBossRoundEffect.listSeasonHistoryByConsumer.mockResolvedValue([
+      {
+        id: "127",
+        round_id: "103",
+        effect_type: "seal",
+        value: "11692",
+        source_user_id: "Usource",
+        taken_at: new Date("2026-09-01T02:09:42.000Z"),
+      },
+    ]);
+    const res = response();
+
+    await publicHandler.me(request({ userId: "Uswordman" }), res);
+
+    expect(res.json.mock.calls[0][0].current.jobKey).toBe("adventurer");
+    expect(res.json.mock.calls[0][0].current.effects.left).toEqual([]);
+    expect(res.json.mock.calls[0][0].current.effects.taken).toHaveLength(1);
   });
 
   it("preserves an exact active season ID through leaderboard and me", async () => {

--- a/app/src/handler/WorldBoss/public.js
+++ b/app/src/handler/WorldBoss/public.js
@@ -3,6 +3,7 @@ const BattleService = require("../../service/WorldBossBattleService");
 const AttackService = require("../../service/WorldBossAttackService");
 const WorldBossRoundEffect = require("../../model/application/WorldBossRoundEffect");
 const UserModel = require("../../model/application/UserModel");
+const MinigameService = require("../../service/MinigameService");
 const { canonicalPositiveInteger, canonicalUnsignedInteger } = require("../../util/decimalInteger");
 const { toApiDto, respondError, fail, parseLeaderboardLimit } = require(".");
 
@@ -52,19 +53,27 @@ function leaderboardRow(row) {
 }
 
 /**
- * "Who took the effects I left." Two queries regardless of row count: one windowed read
- * of the effect ledger, then one batched name lookup for the consumers that exist.
+ * Read both sides of the effect ledger, then resolve all involved users in one batch.
  */
 async function effectHistory(seasonId, userId) {
-  const rows = await WorldBossRoundEffect.listSeasonHistoryBySource({
-    seasonId,
-    userId,
-    limit: EFFECT_HISTORY_LIMIT,
-  });
-  const nameByUserId = await UserModel.getDisplayNames(
-    rows.map(row => row.consumed_by_user_id).filter(Boolean)
-  );
-  return rows.map(row => ({
+  const [leftRows, takenRows] = await Promise.all([
+    WorldBossRoundEffect.listSeasonHistoryBySource({
+      seasonId,
+      userId,
+      limit: EFFECT_HISTORY_LIMIT,
+    }),
+    WorldBossRoundEffect.listSeasonHistoryByConsumer({
+      seasonId,
+      userId,
+      limit: EFFECT_HISTORY_LIMIT,
+    }),
+  ]);
+  const userIds = [
+    ...leftRows.map(row => row.consumed_by_user_id),
+    ...takenRows.map(row => row.source_user_id),
+  ].filter(Boolean);
+  const nameByUserId = await UserModel.getDisplayNames(userIds);
+  const left = leftRows.map(row => ({
     effectId: canonicalPositiveInteger(row.id),
     type: row.effect_type,
     value: canonicalPositiveInteger(row.value),
@@ -77,7 +86,20 @@ async function effectHistory(seasonId, userId) {
           displayName: nameByUserId.get(row.consumed_by_user_id) ?? null,
         }
       : null,
+    expired: !row.consumed_at && Boolean(row.cleared_at),
   }));
+  const taken = takenRows.map(row => ({
+    effectId: canonicalPositiveInteger(row.id),
+    type: row.effect_type,
+    value: canonicalPositiveInteger(row.value),
+    roundId: canonicalPositiveInteger(row.round_id),
+    takenAt: row.taken_at ?? null,
+    source: {
+      userId: row.source_user_id,
+      displayName: nameByUserId.get(row.source_user_id) ?? null,
+    },
+  }));
+  return { left, taken };
 }
 
 /**
@@ -127,10 +149,11 @@ exports.me = async function (req, res) {
     const seasonId = activeSeasonId(status);
     let current = null;
     if (seasonId) {
-      const [stats, daily, effects] = await Promise.all([
+      const [stats, daily, effects, progress] = await Promise.all([
         SeasonService.getUserSeasonStats(seasonId, userId),
         BattleService.getRemainingDailyCost(userId),
         effectHistory(seasonId, userId),
+        MinigameService.findByUserId(userId),
       ]);
       current = {
         seasonId: stats.seasonId,
@@ -138,6 +161,7 @@ exports.me = async function (req, res) {
         score: stats.score,
         damage: stats.damage,
         daily,
+        jobKey: progress ? progress.job_key : "adventurer",
         effects,
       };
     }

--- a/app/src/model/application/WorldBossRoundEffect.js
+++ b/app/src/model/application/WorldBossRoundEffect.js
@@ -91,12 +91,13 @@ exports.listUnconsumedByRound = async function (roundId, trx) {
  *
  * 來源端不 join contribution —— source_user_id 已經反正規化在本表上，join 回去只會拿到
  * 同一個值。過濾條件 (season_id, source_user_id) 正好走 idx_wbre_season_source_user。
- * 顯示名稱刻意不在這裡 join：呼叫端只需要對「被接走的那幾筆」做一次批次查詢，join 進來
+ * 顯示名稱刻意不在這裡 join：呼叫端只需要對效果涉及的玩家做一次批次查詢，join 進來
  * 反而會讓每列都帶一份 user 資料。
  */
 exports.listSeasonHistoryBySource = async function ({ seasonId, userId, limit }, trx) {
   const db = trx || mysql;
   return db(`${TABLE} as effect`)
+    .leftJoin("world_boss_round as round", "effect.round_id", "round.id")
     .leftJoin(
       "world_boss_contribution as consumer",
       "effect.consumed_by_contribution_id",
@@ -111,8 +112,31 @@ exports.listSeasonHistoryBySource = async function ({ seasonId, userId, limit },
       "effect.effect_type as effect_type",
       "effect.value as value",
       "effect.created_at as created_at",
+      "round.cleared_at as cleared_at",
       "consumer.user_id as consumed_by_user_id",
       "consumer.created_at as consumed_at"
+    );
+};
+
+/** Effects consumed by this player, with the source user kept on the denormalized effect row. */
+exports.listSeasonHistoryByConsumer = async function ({ seasonId, userId, limit }, trx) {
+  const db = trx || mysql;
+  return db(`${TABLE} as effect`)
+    .join(
+      "world_boss_contribution as consumer",
+      "effect.consumed_by_contribution_id",
+      "consumer.id"
+    )
+    .where({ "effect.season_id": seasonId, "consumer.user_id": userId })
+    .orderBy("effect.id", "desc")
+    .limit(limit)
+    .select(
+      "effect.id as id",
+      "effect.round_id as round_id",
+      "effect.effect_type as effect_type",
+      "effect.value as value",
+      "effect.source_user_id as source_user_id",
+      "consumer.created_at as taken_at"
     );
 };
 

--- a/frontend/src/pages/Worldboss/index.jsx
+++ b/frontend/src/pages/Worldboss/index.jsx
@@ -18,6 +18,8 @@ import {
   ListItemText,
   Skeleton,
   Stack,
+  Tab,
+  Tabs,
   Typography,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
@@ -28,6 +30,7 @@ import CampaignIcon from "@mui/icons-material/Campaign";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import HandshakeIcon from "@mui/icons-material/Handshake";
+import HistoryToggleOffIcon from "@mui/icons-material/HistoryToggleOff";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import MilitaryTechIcon from "@mui/icons-material/MilitaryTech";
 import RefreshIcon from "@mui/icons-material/Refresh";
@@ -182,7 +185,7 @@ function mergeAfterAttack(previous, payload) {
                 overkill: addDecimal(current?.damage?.overkill, attack.overkillDamage),
               },
               daily: attack.daily,
-              effects: withCreatedEffect(current?.effects, attack),
+              effects: foldAttackEffects(current?.effects, attack),
             },
       latestReward: latestReward ?? previous.me?.latestReward ?? null,
     },
@@ -190,25 +193,71 @@ function mergeAfterAttack(previous, payload) {
 }
 
 /**
- * Puts the effect this hit just left at the top of "what I left behind", so the history
- * agrees with the result card that just announced it. Shaped exactly like a `/me` row.
+ * `/me` used to return `effects` as a plain array of what the player left behind. It is now
+ * `{ left, taken }`. Both shapes — and a missing one — have to render, because a cached page
+ * can outlive a deploy and a blank board is worse than a partial one.
  */
-function withCreatedEffect(effects, attack) {
-  const list = Array.isArray(effects) ? effects : [];
+function normalizeEffects(effects) {
+  if (Array.isArray(effects)) return { left: effects, taken: [] };
+  return {
+    left: Array.isArray(effects?.left) ? effects.left : [],
+    taken: Array.isArray(effects?.taken) ? effects.taken : [],
+  };
+}
+
+/**
+ * Folds both halves of a hit into the history without a refetch: the effect it left goes to
+ * the top of `left`, the effect it took goes to the top of `taken`. One attack can do both.
+ *
+ * A hit that clears the boss also ends every effect of mine still waiting on that round —
+ * the server will say so on the next read, and until then the row would keep claiming it is
+ * still up for grabs.
+ */
+function foldAttackEffects(effects, attack) {
+  const { left, taken } = normalizeEffects(effects);
   const created = attack.createdEffect;
-  if (!created) return list;
-  return [
-    {
-      effectId: created.id,
-      type: created.type,
-      value: created.value,
-      roundId: attack.roundId,
-      createdAt: new Date().toISOString(),
-      consumedAt: null,
-      consumedBy: null,
-    },
-    ...list.filter(effect => String(effect.effectId) !== String(created.id)),
-  ];
+  const consumed = attack.consumedEffect;
+  const sameRound = effect => String(effect.roundId) === String(attack.roundId);
+
+  const expiredLeft = attack.cleared
+    ? left.map(effect =>
+        !effect.consumedAt && sameRound(effect) ? { ...effect, expired: true } : effect
+      )
+    : left;
+
+  return {
+    left: created
+      ? [
+          {
+            effectId: created.id,
+            type: created.type,
+            value: created.value,
+            roundId: attack.roundId,
+            createdAt: new Date().toISOString(),
+            consumedAt: null,
+            consumedBy: null,
+            expired: false,
+          },
+          ...expiredLeft.filter(effect => String(effect.effectId) !== String(created.id)),
+        ]
+      : expiredLeft,
+    taken: consumed
+      ? [
+          {
+            effectId: consumed.id,
+            type: consumed.type,
+            value: consumed.value,
+            roundId: attack.roundId,
+            takenAt: new Date().toISOString(),
+            source: {
+              userId: consumed.sourceUserId ?? null,
+              displayName: consumed.sourceDisplayName ?? null,
+            },
+          },
+          ...taken.filter(effect => String(effect.effectId) !== String(consumed.id)),
+        ]
+      : taken,
+  };
 }
 
 function decimalToBigInt(value) {
@@ -557,121 +606,220 @@ function PersonalStats({ current, unavailable = false }) {
 }
 
 /**
- * "What I left behind, and who picked it up." A player can never consume their own effect,
- * so this list is the only place the interaction with other players is visible — an unclaimed
- * row is an open invitation, a claimed one is a name.
+ * A left-behind effect is in exactly one of three states, and they are not equally good news.
+ * `expired` is the one the board used to hide: the round died before anybody relayed it, so
+ * the row is finished — it just never paid out.
  */
-function EffectHistory({ effects }) {
-  const rows = Array.isArray(effects) ? effects : [];
-  if (rows.length === 0) {
-    return (
-      <Box
-        sx={{
-          py: 3,
-          px: 2,
-          textAlign: "center",
-          borderRadius: 2,
-          border: "1px dashed",
-          borderColor: "divider",
-        }}
-      >
-        <Typography variant="body2" color="text.secondary">
-          這個賽季還沒有留下任何效果。
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          冒險者攻擊後會留下鼓舞，法師會留下魔力刻印，等其他玩家來接。
-        </Typography>
-      </Box>
-    );
-  }
+const EFFECT_STATUS = {
+  claimed: { label: "已接走", Icon: HandshakeIcon },
+  waiting: { label: "等人接", Icon: HourglassEmptyIcon },
+  expired: { label: "已失效", Icon: HistoryToggleOffIcon },
+};
+
+function effectStatus(effect) {
+  if (effect.consumedAt) return "claimed";
+  return effect.expired ? "expired" : "waiting";
+}
+
+/** Job names, and whether the job leaves anything behind at all. */
+const JOB_META = {
+  adventurer: { name: "冒險者", leaves: "鼓舞" },
+  mage: { name: "法師", leaves: "魔力刻印" },
+  swordman: { name: "劍士", leaves: null },
+  thief: { name: "盜賊", leaves: null },
+};
+
+/**
+ * A swordman or thief never leaves an effect — not "not yet", ever. Telling them the season
+ * simply hasn't started for them reads as a bug, so the empty state names the rule and points
+ * at the list they do have rows in.
+ */
+function LeftEmptyState({ jobKey, onSeeTaken }) {
+  const job = JOB_META[jobKey];
+  const structural = Boolean(job && job.leaves === null);
+
+  return (
+    <Box
+      sx={{
+        py: 3,
+        px: 2,
+        textAlign: "center",
+        borderRadius: 2,
+        border: "1px dashed",
+        borderColor: "divider",
+      }}
+    >
+      <Typography variant="body2" color="text.secondary">
+        {structural ? `${job.name}攻擊後不會留下效果。` : "這個賽季還沒有留下任何效果。"}
+      </Typography>
+      <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+        {structural
+          ? "你的分數來自自身傷害，以及接走別人留下的效果。"
+          : job
+            ? `${job.name}攻擊後會留下${job.leaves}，等其他玩家來接。`
+            : "冒險者攻擊後會留下鼓舞，法師會留下魔力刻印，等其他玩家來接。"}
+      </Typography>
+      {structural && (
+        <Button
+          size="small"
+          variant="text"
+          endIcon={<ArrowForwardIcon />}
+          onClick={onSeeTaken}
+          sx={{ mt: 1, fontWeight: 700 }}
+        >
+          看我接走的效果
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+function TakenEmptyState() {
+  return (
+    <Box
+      sx={{
+        py: 3,
+        px: 2,
+        textAlign: "center",
+        borderRadius: 2,
+        border: "1px dashed",
+        borderColor: "divider",
+      }}
+    >
+      <Typography variant="body2" color="text.secondary">
+        還沒接走任何人的效果。
+      </Typography>
+      <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+        王身上有「待接力」標記時，攻擊那隻王就會接走一個，但接不到自己留下的。
+      </Typography>
+    </Box>
+  );
+}
+
+/** Shared chrome for both lists: colour rail, icon tile, title row, one caption line, chip. */
+function EffectRow({ type, muted, rail, tint, hatched, title, caption, chip }) {
+  const { label, Icon, tone } = effectMeta(type);
+
+  return (
+    <Box
+      sx={theme => ({
+        position: "relative",
+        px: 1.5,
+        py: 1.25,
+        borderRadius: 2,
+        overflow: "hidden",
+        border: "1px solid",
+        borderStyle: rail === "dashed" ? "dashed" : "solid",
+        borderColor: rail === "solid" ? alpha(tone(theme), 0.4) : "divider",
+        bgcolor: tint ? alpha(tone(theme), 0.08) : "transparent",
+        ...(hatched && {
+          backgroundImage: `repeating-linear-gradient(135deg, ${alpha(
+            theme.palette.text.disabled,
+            0.07
+          )} 0 5px, transparent 5px 11px)`,
+        }),
+        "&::before": {
+          content: '""',
+          position: "absolute",
+          insetBlock: 0,
+          insetInlineStart: 0,
+          width: 3,
+          bgcolor: muted ? alpha(theme.palette.text.disabled, 0.4) : tone(theme),
+        },
+      })}
+    >
+      <Stack direction="row" spacing={1.25} alignItems="flex-start" sx={{ pl: 0.75 }}>
+        <Avatar
+          variant="rounded"
+          sx={theme => ({
+            width: 32,
+            height: 32,
+            bgcolor: muted ? "action.hover" : alpha(tone(theme), 0.18),
+            color: muted ? "text.disabled" : tone(theme),
+            ...(muted && { filter: "grayscale(1)" }),
+          })}
+        >
+          <Icon sx={{ fontSize: 18 }} />
+        </Avatar>
+        <Box minWidth={0} flex={1}>
+          <Stack direction="row" spacing={0.75} alignItems="baseline" flexWrap="wrap" useFlexGap>
+            <Typography
+              variant="body2"
+              sx={theme => ({
+                fontWeight: 800,
+                color: muted ? "text.disabled" : tone(theme),
+                ...(muted && { textDecoration: "line-through" }),
+              })}
+            >
+              {label}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: 700, fontVariantNumeric: "tabular-nums" }}
+              color={muted ? "text.disabled" : "text.secondary"}
+            >
+              {formatInteger(title)}
+            </Typography>
+          </Stack>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            display="block"
+            sx={{ overflowWrap: "anywhere" }}
+          >
+            {caption}
+          </Typography>
+        </Box>
+        {chip}
+      </Stack>
+    </Box>
+  );
+}
+
+/**
+ * "What I left behind, and what became of it." A player can never consume their own effect,
+ * so an unclaimed row is an open invitation, a claimed one is a name — and an expired one is
+ * a round that ended first. The expired styling is deliberately grey and struck through
+ * rather than red: nothing was done wrong, the window just closed.
+ */
+function LeftEffectList({ effects, jobKey, onSeeTaken }) {
+  if (effects.length === 0) return <LeftEmptyState jobKey={jobKey} onSeeTaken={onSeeTaken} />;
 
   return (
     <Stack spacing={1}>
-      {rows.map(effect => {
-        const { label, Icon, tone } = effectMeta(effect.type);
-        const claimed = Boolean(effect.consumedAt);
+      {effects.map(effect => {
+        const status = effectStatus(effect);
+        const { label: statusLabel, Icon: StatusIcon } = EFFECT_STATUS[status];
+        const { tone } = effectMeta(effect.type);
+        const claimed = status === "claimed";
+        const expired = status === "expired";
         const taker = effect.consumedBy?.displayName || effect.consumedBy?.userId || "某位玩家";
 
         return (
-          <Box
+          <EffectRow
             key={effect.effectId}
-            sx={theme => ({
-              position: "relative",
-              px: 1.5,
-              py: 1.25,
-              borderRadius: 2,
-              overflow: "hidden",
-              border: "1px solid",
-              borderColor: claimed ? alpha(tone(theme), 0.4) : "divider",
-              bgcolor: claimed ? alpha(tone(theme), 0.08) : "transparent",
-              borderStyle: claimed ? "solid" : "dashed",
-              "&::before": {
-                content: '""',
-                position: "absolute",
-                insetBlock: 0,
-                insetInlineStart: 0,
-                width: 3,
-                bgcolor: claimed ? tone(theme) : alpha(theme.palette.text.disabled, 0.4),
-              },
-            })}
-          >
-            <Stack direction="row" spacing={1.25} alignItems="flex-start" sx={{ pl: 0.75 }}>
-              <Avatar
-                variant="rounded"
-                sx={theme => ({
-                  width: 32,
-                  height: 32,
-                  bgcolor: claimed ? alpha(tone(theme), 0.18) : "action.hover",
-                  color: claimed ? tone(theme) : "text.disabled",
-                })}
-              >
-                <Icon sx={{ fontSize: 18 }} />
-              </Avatar>
-              <Box minWidth={0} flex={1}>
-                <Stack
-                  direction="row"
-                  spacing={0.75}
-                  alignItems="baseline"
-                  flexWrap="wrap"
-                  useFlexGap
-                >
-                  <Typography
-                    variant="body2"
-                    sx={theme => ({
-                      fontWeight: 800,
-                      color: claimed ? tone(theme) : "text.primary",
-                    })}
-                  >
-                    {label}
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    sx={{ fontWeight: 700, fontVariantNumeric: "tabular-nums" }}
-                    color="text.secondary"
-                  >
-                    {formatInteger(effect.value)}
-                  </Typography>
-                </Stack>
-                {claimed ? (
-                  <Typography variant="caption" color="text.secondary" display="block">
-                    被 <b>{taker}</b> 接走 · {formatDate(effect.consumedAt)}
-                  </Typography>
-                ) : (
-                  <Typography variant="caption" color="text.secondary" display="block">
-                    還掛在王身上 · 留於 {formatDate(effect.createdAt)}
-                  </Typography>
-                )}
-              </Box>
+            type={effect.type}
+            muted={expired}
+            rail={claimed ? "solid" : expired ? "muted" : "dashed"}
+            tint={claimed}
+            hatched={expired}
+            title={effect.value}
+            caption={
+              claimed ? (
+                <>
+                  被 <b>{taker}</b> 接走 · {formatDate(effect.consumedAt)}
+                </>
+              ) : expired ? (
+                <>這隻王在有人接走前就被打倒了 · 留於 {formatDate(effect.createdAt)}</>
+              ) : (
+                <>還掛在王身上 · 留於 {formatDate(effect.createdAt)}</>
+              )
+            }
+            chip={
               <Chip
                 size="small"
-                icon={
-                  claimed ? (
-                    <HandshakeIcon sx={{ fontSize: 14 }} />
-                  ) : (
-                    <HourglassEmptyIcon sx={{ fontSize: 14 }} />
-                  )
-                }
-                label={claimed ? "已接走" : "等人接"}
+                icon={<StatusIcon sx={{ fontSize: 14 }} />}
+                label={statusLabel}
                 variant={claimed ? "filled" : "outlined"}
                 sx={theme => ({
                   flexShrink: 0,
@@ -679,38 +827,157 @@ function EffectHistory({ effects }) {
                   height: 24,
                   ...(claimed
                     ? { bgcolor: alpha(tone(theme), 0.16), color: tone(theme) }
-                    : { color: "text.secondary" }),
+                    : expired
+                      ? { color: "text.disabled", borderStyle: "dashed" }
+                      : { color: "text.secondary" }),
                 })}
               />
-            </Stack>
-          </Box>
+            }
+          />
         );
       })}
     </Stack>
   );
 }
 
-function EffectHistoryCard({ effects }) {
-  const rows = Array.isArray(effects) ? effects : [];
-  const claimed = rows.filter(effect => effect.consumedAt).length;
+/**
+ * "What I picked up off a boss." Every row here is settled by definition — it was consumed
+ * the moment it was taken — so the chip carries what the pickup actually did instead of
+ * repeating the tab name: a banner scores for both sides, a seal turns into damage and its
+ * score goes back to the mage who left it.
+ */
+function TakenEffectList({ effects }) {
+  if (effects.length === 0) return <TakenEmptyState />;
 
   return (
-    <Card variant="outlined">
+    <Stack spacing={1}>
+      {effects.map(effect => {
+        const { tone } = effectMeta(effect.type);
+        const banner = effect.type === "banner";
+
+        return (
+          <EffectRow
+            key={effect.effectId}
+            type={effect.type}
+            rail="solid"
+            tint
+            title={effect.value}
+            caption={
+              <>
+                接自 <b>{effect.source?.displayName || effect.source?.userId || "某位玩家"}</b> ·{" "}
+                {formatDate(effect.takenAt)}
+              </>
+            }
+            chip={
+              <Chip
+                size="small"
+                icon={
+                  banner ? (
+                    <ArrowForwardIcon sx={{ fontSize: 14 }} />
+                  ) : (
+                    <BoltIcon sx={{ fontSize: 14 }} />
+                  )
+                }
+                label={banner ? "接力加分" : "轉成傷害"}
+                sx={theme => ({
+                  flexShrink: 0,
+                  fontWeight: 700,
+                  height: 24,
+                  bgcolor: alpha(banner ? theme.palette.success.main : tone(theme), 0.16),
+                  color: banner ? theme.palette.success.main : tone(theme),
+                })}
+              />
+            }
+          />
+        );
+      })}
+    </Stack>
+  );
+}
+
+/**
+ * Both halves of the relay in one card, on tabs rather than stacked: on a phone two full
+ * lists back to back means the second one is never seen, and two separate cards double the
+ * scroll. The tab a player lands on depends on their job — a swordman has nothing in "我留下的"
+ * and never will, so opening there would be an empty screen every single time.
+ */
+function EffectHistoryCard({ effects, jobKey }) {
+  const { left, taken } = normalizeEffects(effects);
+  const leavesNothing = JOB_META[jobKey]?.leaves === null;
+  // ponytail: jobKey is present whenever this card mounts (it ships in the same `current`
+  // object the parent gates on), so the initial tab never needs to re-derive.
+  const [tab, setTab] = useState(leavesNothing ? "taken" : "left");
+
+  const claimed = left.filter(effect => effectStatus(effect) === "claimed").length;
+  const expired = left.filter(effect => effectStatus(effect) === "expired").length;
+  const waiting = left.length - claimed - expired;
+
+  return (
+    <Card variant="outlined" sx={{ height: "100%" }}>
       <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
         <Stack spacing={1.75}>
           <Box>
             <Typography variant="h6" component="h2" sx={{ fontWeight: 800 }}>
-              我留下的效果
+              效果接力紀錄
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              自己不能接自己的效果，要等別人來接。
-              {rows.length > 0 && ` 已被接走 ${claimed} / ${rows.length}`}
+              效果只在留下它的那隻王身上，王被打倒就跟著結束。
             </Typography>
           </Box>
-          <EffectHistory effects={rows} />
+
+          <Tabs
+            value={tab}
+            onChange={(_event, next) => setTab(next)}
+            variant="fullWidth"
+            aria-label="效果接力紀錄"
+            sx={{ minHeight: 40, "& .MuiTab-root": { minHeight: 40, fontWeight: 700 } }}
+          >
+            <Tab value="left" id="effect-tab-left" label={`我留下的 ${left.length}`} />
+            <Tab value="taken" id="effect-tab-taken" label={`我接走的 ${taken.length}`} />
+          </Tabs>
+
+          <Box role="tabpanel" aria-labelledby={`effect-tab-${tab}`}>
+            {tab === "left" ? (
+              <Stack spacing={1.25}>
+                {left.length > 0 && (
+                  <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+                    <StatusTally label="已接走" count={claimed} tone="secondary.main" />
+                    <StatusTally label="等人接" count={waiting} tone="text.secondary" />
+                    <StatusTally label="已失效" count={expired} tone="text.disabled" />
+                  </Stack>
+                )}
+                <LeftEffectList effects={left} jobKey={jobKey} onSeeTaken={() => setTab("taken")} />
+                {expired > 0 && (
+                  <Typography variant="caption" color="text.secondary">
+                    王被打倒後，還沒被接走的效果就不會再有人接，這部分不計分。血量還多的王留下的效果，比較有機會被接走。
+                  </Typography>
+                )}
+              </Stack>
+            ) : (
+              <Stack spacing={1.25}>
+                <TakenEffectList effects={taken} />
+                {taken.length > 0 && (
+                  <Typography variant="caption" color="text.secondary">
+                    接走鼓舞時你和對方都得分；接走魔力刻印會轉成傷害，那份分數歸留下的人。
+                  </Typography>
+                )}
+              </Stack>
+            )}
+          </Box>
         </Stack>
       </CardContent>
     </Card>
+  );
+}
+
+function StatusTally({ label, count, tone }) {
+  return (
+    <Typography
+      variant="caption"
+      sx={{ fontWeight: 700, color: tone, fontVariantNumeric: "tabular-nums" }}
+    >
+      {label} {count}
+    </Typography>
   );
 }
 
@@ -1629,7 +1896,7 @@ export default function Worldboss() {
           </Grid>
           {shouldRenderCurrent && (
             <Grid size={{ xs: 12, md: 7 }}>
-              <EffectHistoryCard effects={current?.effects} />
+              <EffectHistoryCard effects={current?.effects} jobKey={current?.jobKey} />
             </Grid>
           )}
           <Grid size={{ xs: 12, md: shouldRenderCurrent || !hasBattle ? 5 : 12 }}>


### PR DESCRIPTION
## 背景

職業分工機制（#810）上線後跑了一天資料，先做了線上異常觀測。

**資料層完全乾淨** — 12 項一致性檢查全部 0 違規：job_key 合法性、effect 值與 raw_damage 比例、direct/assist/relay 分數對帳、relay 來源必為 banner、每日 cost 上限、damage 守恆。攻擊時記錄的職業與 DB 目前職業 100% 吻合。計算邏輯也對得上設計（等級正規化後 swordman 實測 1.800 / mage 0.935 / thief 3.662，與設計倍率＋爆擊期望值相符）。

問題全部出在**顯示端**。

## 三個修正

### 1. 已失效的效果被誤標成「還掛在王身上」

效果綁在該場 round 上，王被打倒後未被接走的效果就永遠不會有人接。前端只看 `consumedAt` 判斷兩態，這種列會一直顯示「還掛在王身上」。

線上已累積 **42 筆、共 444,974 分**，佔法師產出的 36%，且分布極不均：

| 法師 | 產生 seal | 實拿 assist | 蒸發 |
|---|---:|---:|---:|
| Ua3e75052 | 264,016 | 70,057 | 193,959 |
| U19e99666 | 226,244 | 86,037 | 140,207 |
| Ubefdb261 | 168,543 | 61,167 | 107,376 |
| 另 4 人 | — | 多為全額 | 0–3,432 |

API 新增 `expired`（未消耗且 round 已 cleared），前端補上第三態。

### 2. 空狀態文案對劍士/盜賊說謊

`EFFECT_BY_JOB` 只有 `adventurer→banner`、`mage→seal`，劍士/盜賊**結構上永遠不會留下效果**。但空狀態寫「這個賽季**還沒有**留下任何效果」並解釋別人的機制，等於當著他們的面講不實的話。線上有 13 名玩家（3 劍士 + 10 盜賊）看到這句。

API 新增 `jobKey`，空狀態改為依職業分歧。

### 3. 「我接走的」完全不持久化

`/me` 只查 `source_user_id`，接走別人效果的紀錄重整頁面就消失（`POST /attack` 的戰報卡有顯示，但那是一次性的）。線上 13 名玩家的 36 次消耗全部看不到。

`effects` 改為 `{ left, taken }` 雙向結構。

## API 變更

`GET /api/world-boss/me` 的 `current`：

```jsonc
{
  "jobKey": "swordman",        // 新增
  "effects": {                  // 破壞性變更：原為 array
    "left":  [{ ..., "expired": false }],   // expired 新增
    "taken": [{ effectId, type, value, roundId, takenAt, source }]  // 整段新增
  }
}
```

前端 `normalizeEffects` 對舊 array 形狀做防禦，快取頁面撐過部署不會白屏。

## 實作取捨

- `listSeasonHistoryByConsumer` 與既有 `listSeasonHistoryBySource` 對稱；`source_user_id` 已反正規化在 effect 表上，不需 join 回來源 contribution
- 兩側顯示名稱合併為單次 `getDisplayNames` 批次查詢，不各查一次
- 前端用分頁籤而非兩張卡：手機上兩個列表堆疊會讓第二個永遠在第一屏外。**預設分頁依職業決定** — 不留效果的職業直接開在「我接走的」，否則每次開頁都吃一次結構性空狀態
- 失效狀態刻意不用紅色/警告 icon（玩家沒做錯事，只是王先死了），改用灰階＋斜線紋理＋刪除線

## Test plan

- [x] `cd app && yarn test` — 144 suites / 1821 tests 全過
- [x] `cd app && yarn test -- src/handler/WorldBoss` — 107 tests 全過（含新增的 taken / expired / jobKey / 劍士盜賊情境）
- [x] `cd frontend && yarn build` — 通過
- [x] `cd frontend && yarn lint` — 0 errors（42 warnings 與改動前同數，全為既有 `react-hooks/set-state-in-effect`）
- [x] 線上資料對帳：`expired` 判定命中 42 筆 / 444,974 分，與獨立 SQL 查詢完全一致
- [x] 線上資料對帳：`taken` 對 `Uc28b2e00...`（劍士）回傳 12 筆共 129,066，與該玩家 API 現有的 `damage.effect` 吻合
- [x] pending-live 為 0（所有未消耗效果所屬的王都已被打倒），確認 `expired` 不會誤傷進行中的效果

## 不在此 PR 範圍

法師 seal 的**平衡問題**（36% 蒸發率、且等級正規化後單位 cost 效率墊底 0.1294）本 PR 只做「讓玩家看得到」，不動機制。補償或機制調整需要另外討論。

🤖 Generated with [Claude Code](https://claude.com/claude-code)