### PR TITLE
fix(frontend): 群組頁改用 session 登入判定

### DIFF
--- a/frontend/src/pages/Group/Battle.jsx
+++ b/frontend/src/pages/Group/Battle.jsx
@@ -18,6 +18,7 @@ import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import PeopleIcon from "@mui/icons-material/People";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import AlertLogin from "../../components/AlertLogin";
+import useLiff from "../../context/useLiff";
 import * as GroupAPI from "../../services/group";
 
 /* ---------- helpers ---------- */
@@ -252,7 +253,7 @@ function BattleSkeleton() {
 /* ---------- GroupBattle (main export) ---------- */
 export default function GroupBattle() {
   const { groupId } = useParams();
-  const isLoggedIn = window.liff?.isLoggedIn?.() ?? false;
+  const { loggedIn: isLoggedIn } = useLiff();
   const [month, setMonth] = useState(new Date().getMonth() + 1);
   const [signDatas, setSignDatas] = useState([]);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/pages/Group/Config.jsx
+++ b/frontend/src/pages/Group/Config.jsx
@@ -26,6 +26,7 @@ import SectionCard from "../../components/SectionCard";
 import FeatureToggleItem from "../../components/GroupConfig/FeatureToggleItem";
 import SenderInput from "../../components/GroupConfig/SenderInput";
 import * as GroupAPI from "../../services/group";
+import useLiff from "../../context/useLiff";
 
 /* ---------- GuildHeadInfo ---------- */
 function GuildHeadInfo({ groupName, pictureUrl, count }) {
@@ -214,7 +215,7 @@ function FeatureCards({ datas, config, handle, isLoggedIn }) {
 /* ---------- GroupConfig (main export) ---------- */
 export default function GroupConfig() {
   const { groupId } = useParams();
-  const isLoggedIn = window.liff?.isLoggedIn?.() ?? false;
+  const { loggedIn: isLoggedIn } = useLiff();
   const [loading, setLoading] = useState(false);
   const [info, setInfo] = useState({
     groupId: "",

--- a/frontend/src/pages/Group/Record.jsx
+++ b/frontend/src/pages/Group/Record.jsx
@@ -21,6 +21,7 @@ import ReplayIcon from "@mui/icons-material/Replay";
 import PeopleIcon from "@mui/icons-material/People";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import AlertLogin from "../../components/AlertLogin";
+import useLiff from "../../context/useLiff";
 
 /* ---------- helpers ---------- */
 const sum = (arr, key) => arr.reduce((acc, cur) => acc + (cur[key] || 0), 0);
@@ -233,8 +234,7 @@ function TopContributors({ rank }) {
 }
 
 /* ---------- MyStats ---------- */
-function MyStats({ rank, maxTotal }) {
-  const userId = window.liff?.getContext?.()?.userId;
+function MyStats({ rank, maxTotal, userId }) {
   const me = rank.find(m => m.userId === userId);
   if (!me) return null;
 
@@ -440,7 +440,7 @@ function RecordSkeleton() {
 /* ---------- GroupRecord (main export) ---------- */
 export default function GroupRecord() {
   const { groupId } = useParams();
-  const isLoggedIn = window.liff?.isLoggedIn?.() ?? false;
+  const { loggedIn: isLoggedIn, profile } = useLiff();
 
   const [{ data: rankData, loading: rankLoading }, fetchRank] = useAxios(
     { url: `/api/groups/${groupId}/speak-rank` },
@@ -484,7 +484,7 @@ export default function GroupRecord() {
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
       <GroupBanner group={groupData} rank={rank} />
       <TopContributors rank={rank} />
-      <MyStats rank={rank} maxTotal={maxTotal} />
+      <MyStats rank={rank} maxTotal={maxTotal} userId={profile?.userId} />
       <MemberList rank={rank} maxTotal={maxTotal} />
     </Box>
   );


### PR DESCRIPTION
## 問題

`Group/Config.jsx`、`Group/Battle.jsx`、`Group/Record.jsx` 三頁還在用 `window.liff?.isLoggedIn?.()` 判斷登入狀態。

但登入憑證早就改成後端的 HttpOnly `redive_session` cookie，`LiffProvider.jsx:27-29` 已經明講：

> `loggedIn` now means "the backend holds a session for us", not "the LIFF SDK has a token". The only credential in the browser is the HttpOnly redive_session cookie, which JS cannot read — so /api/me is the probe.

桌面瀏覽器沒有 LIFF context，`window.liff.isLoggedIn()` 恆為 false，所以即使 cookie session 完全有效：

- 群組設定：常駐「登入後即可進行操作！」，所有開關與輸入框被 disable
- 三刀簽到表 / 群組數據：直接被 `AlertLogin` 擋掉整頁

另外 `Record.jsx` 的 `MyStats` 用 `window.liff?.getContext?.()?.userId` 找「我」的排名，同一個病灶 — 桌面版永遠找不到自己。

## 改動

- 三頁的 `isLoggedIn` 改讀 `useLiff()` 的 `loggedIn`
- `MyStats` 改成由父層以 prop 傳入 `userId`，值來自 `useLiff()` 的 `profile?.userId`

`window.liff` 在 `frontend/src/` 下已完全清零。

## 驗證

- `yarn build` 通過
- ESLint 0 errors（5 個既有 `react-hooks` warning，非本次範圍）
- Prettier `--check` 全過