### PR TITLE
fix(frontend): 修正轉蛋商店卡片圖片被裁成橫條

### DIFF
--- a/frontend/src/components/CharacterCard.jsx
+++ b/frontend/src/components/CharacterCard.jsx
@@ -45,7 +45,14 @@ export default function CharacterCard({
   return (
     <Card>
       <CardActionArea>
-        <CardMedia sx={{ height: 200 }} image={image} />
+        {/* 商品圖都是 16:9，固定高度會在寬卡片上把圖裁成橫條 */}
+        <CardMedia
+          component="img"
+          image={image}
+          alt={name}
+          loading="lazy"
+          sx={{ aspectRatio: "16 / 9", objectFit: "cover" }}
+        />
         <CardContent>
           <Typography gutterBottom variant="h5" component="h2">
             {name}


### PR DESCRIPTION
## 問題

`/gacha/exchange`（女神石兌換商店）在桌面版的商品圖被裁成扁橫條。

`components/CharacterCard.jsx:48`：

```jsx
<CardMedia sx={{ height: 200 }} image={image} />
```

`image` prop（而非 `component="img"`）渲染出的是背景圖 div，`background-size: cover`。高度硬寫 200px、寬度吃滿卡片，所以卡片一變寬、實際比例就跟著失真，`cover` 便把圖裁掉上下。

`Gacha/Exchange.jsx` 的 Grid 是 `md: 4`，且 `MainLayout` 沒有 `Container` 約束寬度，桌面版單張卡片可到 600px 以上 → 600×200 約 3:1，把 16:9 的原圖裁掉近一半高度。手機 LIFF 寬約 400px 時接近 2:1，落差還不明顯，所以只有桌面版看得出來。

商品圖本身沒問題 — 線上 63 筆全是 16:9（62 筆 `1408x792`、1 筆 `1036x583`），純粹是呈現端的比例問題。

## 改動

改用 `component="img"` + `aspectRatio: "16 / 9"`，讓高度隨寬度走，不再有固定高度。與 `GroupCard.jsx:42` 既有做法一致（該處 `MEDIA_ASPECT_RATIO` 也是為同一類問題而加），並補上 `alt` 與 `loading="lazy"`。

## 驗證

- `yarn build` 通過
- ESLint 0 errors / 0 warnings
- Prettier `--check` 通過